### PR TITLE
feat: add from_today_limited scrape mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,7 +41,10 @@ SCRAPE_DELAY_MS=1000
 # Min: 1, Max: 14
 SCRAPE_DAYS=7
 
-# Scrape mode: 'weekly' (from Wednesday) or 'from_today' (from current date)
+# Scrape mode: 
+# - 'weekly': Start from current/previous Wednesday (7 days by default)
+# - 'from_today': Start from current date
+# - 'from_today_limited': Start from today until Tuesday (max 7 days)
 # Default: weekly
 # Note: Automatic cron jobs always use 'weekly' mode with 7 days
 SCRAPE_MODE=weekly

--- a/README.md
+++ b/README.md
@@ -766,7 +766,7 @@ cp .env.example .env
 | `SCRAPE_CRON_SCHEDULE` | Cron expression for scheduled scraping | `0 6 * * 1` | `0 3 * * *` |
 | `SCRAPE_DELAY_MS` | Delay between cinema scrapes (ms) | `2000` | `3000` |
 | `SCRAPE_DAYS` | Number of days to scrape (1-14) | `7` | `14` |
-| `SCRAPE_MODE` | Start date: `weekly` (Wed) or `from_today` | `weekly` | `from_today` |
+| `SCRAPE_MODE` | Start date: `weekly` (Wed), `from_today`, or `from_today_limited` | `weekly` | `from_today_limited` |
 | `NODE_ENV` | Environment mode | `development` | `production` |
 | `LOG_LEVEL` | Logging level | `info` | `debug` |
 

--- a/server/src/utils/date.test.ts
+++ b/server/src/utils/date.test.ts
@@ -2,6 +2,14 @@ import { describe, it, expect, vi } from 'vitest';
 import { getWeekDates, getCurrentWeekStart, getTodayDate, getScrapeDates } from './date.js';
 
 describe('getScrapeDates', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('should return 7 dates starting from Wednesday in weekly mode', () => {
     const dates = getScrapeDates('weekly', 7);
     expect(dates).toHaveLength(7);
@@ -21,6 +29,43 @@ describe('getScrapeDates', () => {
     expect(dates).toHaveLength(7);
     const firstDate = new Date(dates[0] + 'T00:00:00');
     expect(firstDate.getDay()).toBe(3); // Wednesday
+  });
+
+  describe('from_today_limited mode', () => {
+    it('should return 7 days when today is Wednesday', () => {
+      vi.setSystemTime(new Date('2026-02-18T10:00:00')); // Wednesday
+      const dates = getScrapeDates('from_today_limited');
+      expect(dates).toHaveLength(7);
+      expect(dates[0]).toBe('2026-02-18');
+      expect(dates[6]).toBe('2026-02-24'); // Tuesday
+    });
+
+    it('should return 4 days when today is Saturday', () => {
+      vi.setSystemTime(new Date('2026-02-21T10:00:00')); // Saturday
+      const dates = getScrapeDates('from_today_limited');
+      expect(dates).toHaveLength(4);
+      expect(dates[0]).toBe('2026-02-21');
+      expect(dates[3]).toBe('2026-02-24'); // Tuesday
+    });
+
+    it('should return 1 day when today is Tuesday', () => {
+      vi.setSystemTime(new Date('2026-02-24T10:00:00')); // Tuesday
+      const dates = getScrapeDates('from_today_limited');
+      expect(dates).toHaveLength(1);
+      expect(dates[0]).toBe('2026-02-24');
+    });
+
+    it('should respect numDays if it is smaller than days until Tuesday', () => {
+      vi.setSystemTime(new Date('2026-02-18T10:00:00')); // Wednesday
+      const dates = getScrapeDates('from_today_limited', 3);
+      expect(dates).toHaveLength(3);
+      expect(dates[0]).toBe('2026-02-18');
+      expect(dates[2]).toBe('2026-02-20');
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
Implemented a new  called .

### Behavior
This mode starts scraping from the current date and ends on the next Tuesday (which marks the end of the cinema week), with a maximum range of 7 days.

- **Wednesday**: 7 days (Wed to Tue)
- **Saturday**: 4 days (Sat to Tue)
- **Tuesday**: 1 day (Tue only)

### Changes
- Updated  in  with the new logic.
- Added 4 new test cases in  using fake timers to verify correct day calculation.
- Updated  and .

Closes #49