### PR TITLE
fix: correct date calculation in from_today_limited mode

### DIFF
--- a/server/src/utils/date.test.ts
+++ b/server/src/utils/date.test.ts
@@ -32,7 +32,31 @@ describe('getScrapeDates', () => {
   });
 
   describe('from_today_limited mode', () => {
-    it('should return 7 days when today is Wednesday', () => {
+    it('should return 7 days when today is Sunday (targeting next Tuesday, capped)', () => {
+      vi.setSystemTime(new Date('2026-02-15T10:00:00')); // Sunday
+      const dates = getScrapeDates('from_today_limited');
+      expect(dates).toHaveLength(7);
+      expect(dates[0]).toBe('2026-02-15');
+      expect(dates[6]).toBe('2026-02-21');
+    });
+
+    it('should return 7 days when today is Monday (targeting next Tuesday, capped)', () => {
+      vi.setSystemTime(new Date('2026-02-16T10:00:00')); // Monday
+      const dates = getScrapeDates('from_today_limited');
+      expect(dates).toHaveLength(7);
+      expect(dates[0]).toBe('2026-02-16');
+      expect(dates[6]).toBe('2026-02-22');
+    });
+
+    it('should return 7 days when today is Tuesday (targeting next Tuesday, capped)', () => {
+      vi.setSystemTime(new Date('2026-02-17T10:00:00')); // Tuesday
+      const dates = getScrapeDates('from_today_limited');
+      expect(dates).toHaveLength(7);
+      expect(dates[0]).toBe('2026-02-17');
+      expect(dates[6]).toBe('2026-02-23');
+    });
+
+    it('should return 7 days when today is Wednesday (targeting this week Tuesday)', () => {
       vi.setSystemTime(new Date('2026-02-18T10:00:00')); // Wednesday
       const dates = getScrapeDates('from_today_limited');
       expect(dates).toHaveLength(7);
@@ -46,13 +70,6 @@ describe('getScrapeDates', () => {
       expect(dates).toHaveLength(4);
       expect(dates[0]).toBe('2026-02-21');
       expect(dates[3]).toBe('2026-02-24'); // Tuesday
-    });
-
-    it('should return 1 day when today is Tuesday', () => {
-      vi.setSystemTime(new Date('2026-02-24T10:00:00')); // Tuesday
-      const dates = getScrapeDates('from_today_limited');
-      expect(dates).toHaveLength(1);
-      expect(dates[0]).toBe('2026-02-24');
     });
 
     it('should respect numDays if it is smaller than days until Tuesday', () => {

--- a/server/src/utils/date.ts
+++ b/server/src/utils/date.ts
@@ -73,11 +73,13 @@ export function getScrapeDates(
     // Wednesday (3) -> 6 days (next Tue)
     // Saturday (6) -> 3 days (next Tue)
     
-    // Logic: distance to 2 (Tuesday), if negative add 7
-    let daysUntilTuesday = 2 - dayOfWeek;
-    if (daysUntilTuesday < 0) {
-      daysUntilTuesday += 7;
-    }
+    // Logic: 9 - dayOfWeek finds the Tuesday that ends the cinema week
+    // If Wed(3): 9-3=6 days difference -> 7 days total
+    // If Sat(6): 9-6=3 days difference -> 4 days total
+    // If Sun(0): 9-0=9 days difference -> 10 days total (capped to 7)
+    // If Mon(1): 9-1=8 days difference -> 9 days total (capped to 7)
+    // If Tue(2): 9-2=7 days difference -> 8 days total (capped to 7)
+    const daysUntilTuesday = 9 - dayOfWeek;
     
     const actualDays = Math.min(numDays, daysUntilTuesday + 1);
     return getWeekDates(getTodayDate(), actualDays);


### PR DESCRIPTION
## Summary
Fixed the date range calculation for the  scrape mode.

### Changes
- Changed the logic to ensure that triggers on Monday or Tuesday scrape a full 7-day range instead of stopping at the immediate next day.
- The scraper now targets the Tuesday that concludes the relevant cinema week, with a minimum target of 7 days away if today is early in the week.
- Results are capped at 7 days.

### Verification
- Added/Updated tests for:
  - **Sunday**: 7 days (Targets Tue week+1)
  - **Monday**: 7 days (Targets Tue week+1)
  - **Tuesday**: 7 days (Targets Tue week+1)
  - **Wednesday**: 7 days (Targets Tue current)
  - **Saturday**: 4 days (Targets Tue current)

Closes #51