### PR TITLE
feat(client): add Allociné links to showtime badges

### DIFF
--- a/client/src/components/CinemaShowtimes.tsx
+++ b/client/src/components/CinemaShowtimes.tsx
@@ -99,7 +99,7 @@ export default function CinemaShowtimes({ cinemas, initialDate }: CinemaShowtime
               </div>
               
               <div className="pt-3 border-t border-gray-50">
-                <ShowtimeList showtimes={dailyShowtimes} />
+                <ShowtimeList showtimes={dailyShowtimes} cinemaId={cinema.id} />
               </div>
             </div>
           );

--- a/client/src/components/ShowtimeList.tsx
+++ b/client/src/components/ShowtimeList.tsx
@@ -1,10 +1,12 @@
 import type { Showtime } from '../types';
+import { getAllocineCinemaUrl } from '../utils/allocine';
 
 interface ShowtimeListProps {
   showtimes: Showtime[];
+  cinemaId: string;
 }
 
-export default function ShowtimeList({ showtimes }: ShowtimeListProps) {
+export default function ShowtimeList({ showtimes, cinemaId }: ShowtimeListProps) {
   // Group showtimes by version (VF/VO)
   const showtimesByVersion = showtimes.reduce((acc, showtime) => {
     const version = showtime.version || 'VF';
@@ -28,12 +30,15 @@ export default function ShowtimeList({ showtimes }: ShowtimeListProps) {
           <p className="text-sm font-semibold text-gray-700 mb-2">{version}</p>
           <div className="flex flex-wrap gap-2">
             {versionShowtimes.map((showtime, index) => (
-              <span
+              <a
                 key={`${showtime.time}-${index}`}
+                href={getAllocineCinemaUrl(cinemaId)}
+                target="_blank"
+                rel="noopener noreferrer"
                 className="px-3 py-1 bg-gray-100 text-gray-800 rounded hover:bg-primary hover:text-black transition cursor-pointer text-sm font-medium"
               >
                 {showtime.time}
-              </span>
+              </a>
             ))}
           </div>
         </div>

--- a/client/src/pages/CinemaPage.tsx
+++ b/client/src/pages/CinemaPage.tsx
@@ -243,7 +243,7 @@ export default function CinemaPage() {
                     </div>
 
                     <div className="pt-2 border-t border-gray-100">
-                      <ShowtimeList showtimes={showtimes} />
+                      <ShowtimeList showtimes={showtimes} cinemaId={id!} />
                     </div>
                   </div>
                 </div>

--- a/client/src/utils/allocine.test.ts
+++ b/client/src/utils/allocine.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { getAllocineCinemaUrl } from './allocine';
+
+describe('Allocine Utils', () => {
+  describe('getAllocineCinemaUrl', () => {
+    it('should return correct URL for a cinema ID', () => {
+      const cinemaId = 'W7504';
+      const expected = 'https://www.allocine.fr/seance/salle_gen_csalle=W7504.html';
+      expect(getAllocineCinemaUrl(cinemaId)).toBe(expected);
+    });
+
+    it('should return empty string if cinema ID is empty', () => {
+      expect(getAllocineCinemaUrl('')).toBe('');
+    });
+
+    it('should handle different cinema ID formats', () => {
+      const cinemaId = 'C0072';
+      const expected = 'https://www.allocine.fr/seance/salle_gen_csalle=C0072.html';
+      expect(getAllocineCinemaUrl(cinemaId)).toBe(expected);
+    });
+  });
+});

--- a/client/src/utils/allocine.ts
+++ b/client/src/utils/allocine.ts
@@ -1,0 +1,10 @@
+/**
+ * Generates the Allociné URL for a specific cinema's showtimes page.
+ * 
+ * @param cinemaId The Allociné cinema ID (e.g., 'W7504')
+ * @returns The full URL to the cinema's showtimes on Allociné
+ */
+export function getAllocineCinemaUrl(cinemaId: string): string {
+  if (!cinemaId) return '';
+  return `https://www.allocine.fr/seance/salle_gen_csalle=${cinemaId}.html`;
+}


### PR DESCRIPTION
## Summary
- Added a new utility to generate Allociné cinema URLs.
- Updated `ShowtimeList` component to make showtime badges clickable.
- Passed the necessary `cinemaId` from `CinemaShowtimes` and `CinemaPage` components.
- Added unit tests for the URL utility.

Closes #61