### PR TITLE
fix(client): remove black background on cinema badge in FilmCard

### DIFF
--- a/client/src/components/FilmCard.tsx
+++ b/client/src/components/FilmCard.tsx
@@ -114,7 +114,7 @@ export default function FilmCard({ film, isNew = false }: FilmCardProps) {
               }`}
             >
               <span>{showSchedule ? '▼ Cacher les horaires' : '▶ Voir les horaires'}</span>
-              <span className="text-xs bg-black bg-opacity-10 px-1.5 py-0.5 rounded">{film.cinemas.length} cinémas</span>
+              <span className="text-xs bg-white/20 px-1.5 py-0.5 rounded">{film.cinemas.length} cinémas</span>
             </button>
             <Link 
               to={`/film/${film.id}`} 


### PR DESCRIPTION
## Summary

- The `▶ Voir les horaires` button badge showing cinema count had `bg-black bg-opacity-10` which rendered as a dark/black background
- Replaced with `bg-white/20` which works cleanly on both the default gray and active yellow button states

## Root cause

`bg-black bg-opacity-10` creates a semi-transparent black overlay that is visible regardless of the parent button's background color.

Closes #71