### PR TITLE
⚡ perf(db): add composite index for weekly showtimes query

### DIFF
--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -66,6 +66,7 @@ export async function initializeDatabase() {
     `CREATE INDEX IF NOT EXISTS idx_showtimes_cinema_date ON showtimes(cinema_id, date)`,
     `CREATE INDEX IF NOT EXISTS idx_showtimes_film_date ON showtimes(film_id, date)`,
     `CREATE INDEX IF NOT EXISTS idx_showtimes_week ON showtimes(week_start)`,
+    `CREATE INDEX IF NOT EXISTS idx_showtimes_cinema_week ON showtimes(cinema_id, week_start)`,
 
     // Table: weekly_programs
     `CREATE TABLE IF NOT EXISTS weekly_programs (


### PR DESCRIPTION
💡 **What:** Added a composite index `idx_showtimes_cinema_week` on `showtimes(cinema_id, week_start)`.
🎯 **Why:** This optimizes the `getShowtimesByCinemaAndWeek` query used for displaying weekly schedules, which currently filters by both columns.
📊 **Measured Improvement:** Direct performance measurement was not possible due to environment limitations (lack of internet for dependency installation and Docker image pulling, and absence of pre-installed database tools). However, theoretically, a composite index on the filtered columns allows for a more efficient index seek instead of relying on separate single-column indexes or a bitmap heap scan, which significantly improves query performance as the data volume grows.

---
*PR created automatically by Jules for task [13740354588196708259](https://jules.google.com/task/13740354588196708259) started by @PhBassin*