### PR TITLE
🧪 Add tests for film page parser

### DIFF
--- a/server/src/services/scraper/film-parser.test.ts
+++ b/server/src/services/scraper/film-parser.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { parseFilmPage } from './film-parser.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('parseFilmPage', () => {
+  let validHtml: string;
+
+  beforeAll(() => {
+    // Correct relative path to the fixture from this test file
+    const fixturePath = join(__dirname, '../../../tests/fixtures/film-page.html');
+    validHtml = readFileSync(fixturePath, 'utf-8');
+  });
+
+  it('should parse duration from valid HTML (hours and minutes)', () => {
+    const result = parseFilmPage(validHtml);
+    expect(result.duration_minutes).toBe(135); // 2h 15min = 120 + 15
+  });
+
+  it('should parse trailer URL from valid HTML', () => {
+    const result = parseFilmPage(validHtml);
+    // The parser prepends the base URL
+    expect(result.trailer_url).toBe('https://www.example-cinema-site.com/video/player_gen_cmedia=19598288&cfilm=296180.html');
+  });
+
+  it('should parse duration with only hours', () => {
+    const html = '<div class="meta-body-info">Duration: 2h</div>';
+    const result = parseFilmPage(html);
+    expect(result.duration_minutes).toBe(120);
+  });
+
+  it('should handle missing duration', () => {
+    const html = '<div class="meta-body-info">No duration info</div>';
+    const result = parseFilmPage(html);
+    expect(result.duration_minutes).toBeUndefined();
+  });
+
+  it('should handle missing trailer', () => {
+    const html = '<div>No trailer here</div>';
+    const result = parseFilmPage(html);
+    expect(result.trailer_url).toBeUndefined();
+  });
+
+  it('should handle empty HTML', () => {
+    const result = parseFilmPage('');
+    expect(result.duration_minutes).toBeUndefined();
+    expect(result.trailer_url).toBeUndefined();
+  });
+});

--- a/server/tests/fixtures/film-page.html
+++ b/server/tests/fixtures/film-page.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <div class="meta-body-info">
+    <span class="spacer"></span>
+    2h 15min
+    <span class="spacer"></span>
+  </div>
+  <a class="thumbnail-link" href="/video/player_gen_cmedia=19598288&cfilm=296180.html">
+    <img src="https://example.com/image.jpg" />
+  </a>
+</body>
+</html>


### PR DESCRIPTION
🎯 **What:** Added unit tests for `parseFilmPage` in `server/src/services/scraper/film-parser.ts`.
📊 **Coverage:**
- Duration extraction (hours + minutes)
- Duration extraction (hours only)
- Trailer URL extraction
- Edge cases: missing duration, missing trailer, empty HTML
✨ **Result:** Improved test coverage and reliability for the scraper service.

---
*PR created automatically by Jules for task [17604293926839736940](https://jules.google.com/task/17604293926839736940) started by @PhBassin*