### PR TITLE
🔒 fix: Enable Content Security Policy

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -18,9 +18,7 @@ export function createApp() {
   const app = express();
 
   // Middleware
-  app.use(helmet({
-    contentSecurityPolicy: false, // Allow inline scripts for SSE
-  }));
+  app.use(helmet());
   app.use(cors());
   app.use(morgan('combined'));
   app.use(express.json());


### PR DESCRIPTION
### 🎯 What:
The Content Security Policy (CSP) was previously disabled in the Express application. This fix enables CSP by using the default Helmet configuration.

### ⚠️ Risk:
Disabling CSP makes the application vulnerable to Cross-Site Scripting (XSS), data injection, and other attacks. An attacker could potentially inject malicious scripts into the frontend that could steal user data or perform unauthorized actions.

### 🛡️ Solution:
Enabled CSP by removing the `contentSecurityPolicy: false` option from the `helmet` middleware in `server/src/app.ts`. This restores the default secure CSP provided by Helmet, which restricts resource loading and execution to trusted sources (primarily `'self'`).

The original comment suggesting that CSP was disabled to "Allow inline scripts for SSE" was analyzed. Server-Sent Events do not require inline scripts to function, and any processing of SSE data can and should be done within the application's existing secure script modules. Enabling CSP is a critical step in hardening the application's security posture.

---
*PR created automatically by Jules for task [4923137098677887078](https://jules.google.com/task/4923137098677887078) started by @PhBassin*