### PR TITLE
ci(docker): add nightly GHCR cleanup for untagged and non-protected images

### DIFF
--- a/.github/workflows/cleanup-ghcr-untagged.yml
+++ b/.github/workflows/cleanup-ghcr-untagged.yml
@@ -1,0 +1,101 @@
+name: Nettoyage Images Untagged GHCR
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # S'exécute toutes les nuits à 2h du matin
+  workflow_dispatch:     # Permet de le lancer manuellement pour tester
+
+env:
+  PACKAGE_NAME: allo-scrapper
+  # Tags qui ne seront JAMAIS supprimés
+  PROTECTED_TAGS: 'main,develop,stable,snapshot'
+
+jobs:
+  clean-ghcr:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write  # Obligatoire pour pouvoir supprimer des versions
+
+    steps:
+      - name: Supprimer les images sans tag protégé
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const packageName = process.env.PACKAGE_NAME;
+            const protectedTags = process.env.PROTECTED_TAGS.split(',').map(t => t.trim());
+            const owner = context.repo.owner;
+
+            console.log(`🔍 Package: ${packageName}`);
+            console.log(`🛡️  Tags protégés: ${protectedTags.join(', ')}`);
+
+            let page = 1;
+            let scanned = 0;
+            let deleted = 0;
+            let kept = 0;
+            const errors = [];
+
+            while (true) {
+              const { data: versions } = await github.rest.packages.getAllPackageVersionsForPackageOwnedByUser({
+                package_type: 'container',
+                package_name: packageName,
+                username: owner,
+                per_page: 100,
+                page,
+              });
+
+              if (versions.length === 0) break;
+
+              for (const version of versions) {
+                scanned++;
+                const tags = version.metadata?.container?.tags ?? [];
+                const hasProtectedTag = tags.some(tag => protectedTags.includes(tag));
+
+                if (hasProtectedTag) {
+                  console.log(`✅ Conservation  [${version.id}] tags: ${tags.join(', ')}`);
+                  kept++;
+                  continue;
+                }
+
+                // Suppression : image sans tag protégé
+                // (non taggée, ou taggée avec sha256:..., hash commit, etc.)
+                const label = tags.length ? tags.join(', ') : '(sans tag)';
+                console.log(`🗑️  Suppression   [${version.id}] tags: ${label}`);
+
+                try {
+                  await github.rest.packages.deletePackageVersionForUser({
+                    package_type: 'container',
+                    package_name: packageName,
+                    username: owner,
+                    package_version_id: version.id,
+                  });
+                  deleted++;
+                } catch (e) {
+                  const msg = `Échec suppression version ${version.id} (${label}): ${e.message}`;
+                  console.error(`❌ ${msg}`);
+                  errors.push(msg);
+                }
+              }
+
+              page++;
+            }
+
+            // Résumé dans le job summary
+            await core.summary
+              .addHeading('Nettoyage GHCR — Résumé')
+              .addTable([
+                [{data: 'Métrique', header: true}, {data: 'Valeur', header: true}],
+                ['Versions scannées', String(scanned)],
+                ['Conservées (tag protégé)', String(kept)],
+                ['Supprimées', String(deleted)],
+                ['Erreurs', String(errors.length)],
+              ])
+              .addHeading('Politique de rétention', 3)
+              .addRaw(`Tags protégés : \`${protectedTags.join('`, `')}\``)
+              .addBreak()
+              .addRaw('Toute image sans l\'un de ces tags est supprimée (non taggée, sha256, hash commit…)')
+              .write();
+
+            if (errors.length > 0) {
+              core.setFailed(`${errors.length} erreur(s) lors du nettoyage.`);
+            }


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/cleanup-ghcr-untagged.yml` — runs nightly at 02:00 UTC and on `workflow_dispatch`
- Deletes all container image versions **not** carrying a protected tag (`main`, `develop`, `stable`, `snapshot`)
- This covers both truly untagged images **and** images tagged with ephemeral identifiers (e.g. `sha256:2706245...`, commit hashes)
- Handles pagination (100 versions per page) to support large registries
- Writes a structured job summary table with counts (scanned / kept / deleted / errors)
- Fails the job if any deletion error occurs, without interrupting the rest of the cleanup

## Behaviour

| Image tag(s) | Action |
|---|---|
| `main` | Conservée |
| `develop` | Conservée |
| `stable` | Conservée |
| `snapshot` | Conservée |
| `sha256:270624...` | Supprimée |
| `pr-42`, `build-123` | Supprimée |
| *(aucun tag)* | Supprimée |

## Notes

- Protected tags are configurable via the `PROTECTED_TAGS` env variable in the workflow
- Uses `github.rest.packages` (REST API) for compatibility with user-owned packages (`PhBassin`)

closes #92