### PR TITLE
🛡️ Sentinel: Fix SSRF vulnerability in cinema scraper

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1316,7 +1316,6 @@
       "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.18",
         "fflate": "^0.8.2",
@@ -2797,7 +2796,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -2895,7 +2893,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3573,7 +3570,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -3679,7 +3675,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3755,7 +3750,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",

--- a/server/src/routes/cinemas.test.ts
+++ b/server/src/routes/cinemas.test.ts
@@ -43,21 +43,21 @@ describe('Routes - Cinemas', () => {
   describe('POST /', () => {
     it('should create a new cinema and return 201', async () => {
       mockReq = {
-        body: { id: 'C0099', name: 'New Cinema', url: 'https://www.example-cinema-site.com/seance/salle_gen_csalle=C0099.html' }
+        body: { id: 'C0099', name: 'New Cinema', url: 'https://www.allocine.fr/seance/salle_gen_csalle=C0099.html' }
       };
-      const created = { id: 'C0099', name: 'New Cinema', url: 'https://www.example-cinema-site.com/seance/salle_gen_csalle=C0099.html' };
+      const created = { id: 'C0099', name: 'New Cinema', url: 'https://www.allocine.fr/seance/salle_gen_csalle=C0099.html' };
       (cinemaConfig.addCinemaWithSync as any).mockResolvedValue(created);
 
       const handler = router.stack.find(s => s.route?.path === '/' && s.route?.methods.post)?.route.stack[0].handle;
       await handler(mockReq, mockRes, mockNext);
 
-      expect(cinemaConfig.addCinemaWithSync).toHaveBeenCalledWith(expect.anything(), { id: 'C0099', name: 'New Cinema', url: 'https://www.example-cinema-site.com/seance/salle_gen_csalle=C0099.html' });
+      expect(cinemaConfig.addCinemaWithSync).toHaveBeenCalledWith(expect.anything(), { id: 'C0099', name: 'New Cinema', url: 'https://www.allocine.fr/seance/salle_gen_csalle=C0099.html' });
       expect(mockRes.status).toHaveBeenCalledWith(201);
       expect(mockRes.json).toHaveBeenCalledWith(expect.objectContaining({ success: true, data: created }));
     });
 
     it('should return 400 when id is missing', async () => {
-      mockReq = { body: { name: 'Missing ID', url: 'https://example.com' } };
+      mockReq = { body: { name: 'Missing ID', url: 'https://www.allocine.fr/seance/salle_gen_csalle=C0099.html' } };
 
       const handler = router.stack.find(s => s.route?.path === '/' && s.route?.methods.post)?.route.stack[0].handle;
       await handler(mockReq, mockRes, mockNext);
@@ -67,7 +67,7 @@ describe('Routes - Cinemas', () => {
     });
 
     it('should return 400 when name is missing', async () => {
-      mockReq = { body: { id: 'C0099', url: 'https://example.com' } };
+      mockReq = { body: { id: 'C0099', url: 'https://www.allocine.fr/seance/salle_gen_csalle=C0099.html' } };
 
       const handler = router.stack.find(s => s.route?.path === '/' && s.route?.methods.post)?.route.stack[0].handle;
       await handler(mockReq, mockRes, mockNext);
@@ -84,8 +84,18 @@ describe('Routes - Cinemas', () => {
       expect(mockRes.status).toHaveBeenCalledWith(400);
     });
 
+    it('should return 400 when url is invalid', async () => {
+      mockReq = { body: { id: 'C0099', name: 'New Cinema', url: 'https://example.com' } };
+
+      const handler = router.stack.find(s => s.route?.path === '/' && s.route?.methods.post)?.route.stack[0].handle;
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(mockRes.json).toHaveBeenCalledWith(expect.objectContaining({ success: false, error: expect.stringContaining('Invalid Allocine URL') }));
+    });
+
     it('should return 409 on duplicate cinema id', async () => {
-      mockReq = { body: { id: 'W7504', name: 'Duplicate', url: 'https://example.com' } };
+      mockReq = { body: { id: 'W7504', name: 'Duplicate', url: 'https://www.allocine.fr/seance/salle_affich-salle=W7504.html' } };
       (cinemaConfig.addCinemaWithSync as any).mockRejectedValue(new Error('duplicate key value violates unique constraint'));
 
       const handler = router.stack.find(s => s.route?.path === '/' && s.route?.methods.post)?.route.stack[0].handle;
@@ -96,7 +106,7 @@ describe('Routes - Cinemas', () => {
     });
 
     it('should call next(error) on unexpected error', async () => {
-      mockReq = { body: { id: 'C0099', name: 'New Cinema', url: 'https://example.com' } };
+      mockReq = { body: { id: 'C0099', name: 'New Cinema', url: 'https://www.allocine.fr/seance/salle_gen_csalle=C0099.html' } };
       const error = new Error('Unexpected DB error');
       (cinemaConfig.addCinemaWithSync as any).mockRejectedValue(error);
 
@@ -109,14 +119,14 @@ describe('Routes - Cinemas', () => {
 
   describe('PUT /:id', () => {
     it('should update a cinema and return the updated record', async () => {
-      mockReq = { params: { id: 'W7504' }, body: { name: 'Updated Name', url: 'https://new-url.com' } };
-      const updated = { id: 'W7504', name: 'Updated Name', url: 'https://new-url.com' };
+      mockReq = { params: { id: 'W7504' }, body: { name: 'Updated Name', url: 'https://www.allocine.fr/new-url.html' } };
+      const updated = { id: 'W7504', name: 'Updated Name', url: 'https://www.allocine.fr/new-url.html' };
       (cinemaConfig.updateCinemaWithSync as any).mockResolvedValue(updated);
 
       const handler = router.stack.find(s => s.route?.path === '/:id' && s.route?.methods.put)?.route.stack[0].handle;
       await handler(mockReq, mockRes, mockNext);
 
-      expect(cinemaConfig.updateCinemaWithSync).toHaveBeenCalledWith(expect.anything(), 'W7504', { name: 'Updated Name', url: 'https://new-url.com' });
+      expect(cinemaConfig.updateCinemaWithSync).toHaveBeenCalledWith(expect.anything(), 'W7504', { name: 'Updated Name', url: 'https://www.allocine.fr/new-url.html' });
       expect(mockRes.json).toHaveBeenCalledWith(expect.objectContaining({ success: true, data: updated }));
     });
 
@@ -127,6 +137,16 @@ describe('Routes - Cinemas', () => {
       await handler(mockReq, mockRes, mockNext);
 
       expect(mockRes.status).toHaveBeenCalledWith(400);
+    });
+
+    it('should return 400 when url is invalid', async () => {
+      mockReq = { params: { id: 'W7504' }, body: { url: 'https://example.com' } };
+
+      const handler = router.stack.find(s => s.route?.path === '/:id' && s.route?.methods.put)?.route.stack[0].handle;
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(mockRes.json).toHaveBeenCalledWith(expect.objectContaining({ success: false, error: expect.stringContaining('Invalid Allocine URL') }));
     });
 
     it('should return 404 when cinema not found', async () => {

--- a/server/src/routes/cinemas.ts
+++ b/server/src/routes/cinemas.ts
@@ -3,6 +3,7 @@ import { db } from '../db/client.js';
 import { getCinemas, getShowtimesByCinemaAndWeek } from '../db/queries.js';
 import { getWeekStart } from '../utils/date.js';
 import { addCinemaAndScrape } from '../services/scraper/index.js';
+import { isValidAllocineUrl } from '../services/scraper/utils.js';
 import {
   addCinemaWithSync,
   updateCinemaWithSync,
@@ -36,6 +37,14 @@ router.post('/', async (req, res, next) => {
 
     // Smart add via URL only
     if (url && !id && !name) {
+      if (!isValidAllocineUrl(url)) {
+        const response: ApiResponse = {
+          success: false,
+          error: 'Invalid Allocine URL. Must be https://www.allocine.fr/...',
+        };
+        return res.status(400).json(response);
+      }
+
       const cinema = await addCinemaAndScrape(url);
       const response: ApiResponse = {
         success: true,
@@ -48,6 +57,14 @@ router.post('/', async (req, res, next) => {
       const response: ApiResponse = {
         success: false,
         error: 'Missing required fields: id, name, url',
+      };
+      return res.status(400).json(response);
+    }
+
+    if (!isValidAllocineUrl(url)) {
+      const response: ApiResponse = {
+        success: false,
+        error: 'Invalid Allocine URL. Must be https://www.allocine.fr/...',
       };
       return res.status(400).json(response);
     }
@@ -82,6 +99,14 @@ router.put('/:id', async (req, res, next) => {
       const response: ApiResponse = {
         success: false,
         error: 'At least one field must be provided: name, url',
+      };
+      return res.status(400).json(response);
+    }
+
+    if (url && !isValidAllocineUrl(url)) {
+      const response: ApiResponse = {
+        success: false,
+        error: 'Invalid Allocine URL. Must be https://www.allocine.fr/...',
       };
       return res.status(400).json(response);
     }

--- a/server/src/services/scraper/index.ts
+++ b/server/src/services/scraper/index.ts
@@ -12,7 +12,7 @@ import { parseTheaterPage } from './theater-parser.js';
 import { parseShowtimesJson } from './theater-json-parser.js';
 import { parseFilmPage } from './film-parser.js';
 import { getScrapeDates, getWeekStartForDate, type ScrapeMode } from '../../utils/date.js';
-import { extractCinemaIdFromUrl, cleanCinemaUrl } from './utils.js';
+import { extractCinemaIdFromUrl, cleanCinemaUrl, isValidAllocineUrl } from './utils.js';
 import type { ProgressTracker, ScrapeSummary } from '../progress-tracker.js';
 import type { CinemaConfig, WeeklyProgram, Cinema } from '../../types/scraper.js';
 import { logger } from '../../utils/logger.js';
@@ -154,7 +154,12 @@ export async function addCinemaAndScrape(
   url: string,
   progress?: ProgressTracker
 ): Promise<Cinema> {
-  // 1. Extract ID and clean URL
+  // 1. Validate URL first!
+  if (!isValidAllocineUrl(url)) {
+    throw new Error('Invalid Allocine URL. Must be https://www.allocine.fr/...');
+  }
+
+  // 2. Extract ID and clean URL
   const cinemaId = extractCinemaIdFromUrl(url);
   if (!cinemaId) {
     throw new Error(
@@ -164,7 +169,7 @@ export async function addCinemaAndScrape(
 
   const cleanedUrl = cleanCinemaUrl(url);
 
-  // 2. Prepare temp config
+  // 3. Prepare temp config
   const tempConfig: CinemaConfig = {
     id: cinemaId,
     url: cleanedUrl,

--- a/server/src/services/scraper/utils.test.ts
+++ b/server/src/services/scraper/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isStaleResponse, extractCinemaIdFromUrl } from './utils.js';
+import { isStaleResponse, extractCinemaIdFromUrl, isValidAllocineUrl } from './utils.js';
 import type { Showtime } from '../../types/scraper.js';
 
 // Helper to build a minimal Showtime object for testing
@@ -95,5 +95,28 @@ describe('extractCinemaIdFromUrl', () => {
   it('returns null for invalid URLs', () => {
     expect(extractCinemaIdFromUrl('https://www.google.com')).toBeNull();
     expect(extractCinemaIdFromUrl('https://www.allocine.fr/film/fichefilm_gen_cfilm=12345.html')).toBeNull();
+  });
+});
+
+describe('isValidAllocineUrl', () => {
+  it('returns true for valid Allociné URLs', () => {
+    expect(isValidAllocineUrl('https://www.allocine.fr/seance/salle_affich-salle=C0013.html')).toBe(true);
+    expect(isValidAllocineUrl('https://www.allocine.fr/seance/salle_gen_csalle=C0013.html')).toBe(true);
+    expect(isValidAllocineUrl('https://www.allocine.fr/some/other/page.html')).toBe(true);
+  });
+
+  it('returns false for non-https URLs', () => {
+    expect(isValidAllocineUrl('http://www.allocine.fr/seance/salle_affich-salle=C0013.html')).toBe(false);
+  });
+
+  it('returns false for different domains', () => {
+    expect(isValidAllocineUrl('https://www.google.com')).toBe(false);
+    expect(isValidAllocineUrl('https://evil.allocine.fr.com')).toBe(false);
+    expect(isValidAllocineUrl('https://allocine.fr')).toBe(false); // subdomain mismatch
+  });
+
+  it('returns false for malformed URLs', () => {
+    expect(isValidAllocineUrl('not a url')).toBe(false);
+    expect(isValidAllocineUrl('')).toBe(false);
   });
 });

--- a/server/src/services/scraper/utils.ts
+++ b/server/src/services/scraper/utils.ts
@@ -50,3 +50,15 @@ export function cleanCinemaUrl(url: string): string {
   // Remove everything from the first ? or # onwards
   return url.split(/[?#]/)[0];
 }
+
+/**
+ * Validates that the URL is a valid Allociné URL (https://www.allocine.fr/...)
+ */
+export function isValidAllocineUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'https:' && parsed.hostname === 'www.allocine.fr';
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Server-Side Request Forgery (SSRF) risk

🚨 Severity: CRITICAL
💡 Vulnerability: The cinema scraper and API endpoints accepted arbitrary URLs, allowing potential SSRF attacks where the server could be made to request internal resources or malicious sites.
🎯 Impact: An attacker could potentially scan internal ports, access cloud metadata services (if hosted on cloud), or read local files if the URL handling library (Playwright/fetch) supports it and wasn't strictly sandboxed.
🔧 Fix: Implemented strict validation to ensure all cinema URLs must start with `https://www.allocine.fr/`. This validation is applied at both the API entry point (returning 400 Bad Request) and the service layer (throwing an error).
✅ Verification: Added unit tests for `isValidAllocineUrl` covering various attack vectors (different domains, non-https, malformed URLs). Verified that the API rejects invalid URLs.

---
*PR created automatically by Jules for task [9607009283638595171](https://jules.google.com/task/9607009283638595171) started by @PhBassin*