### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in cinema scraper

### DIFF
--- a/server/src/services/scraper/utils.test.ts
+++ b/server/src/services/scraper/utils.test.ts
@@ -93,7 +93,17 @@ describe('extractCinemaIdFromUrl', () => {
   });
 
   it('returns null for invalid URLs', () => {
-    expect(extractCinemaIdFromUrl('https://www.google.com')).toBeNull();
+    // Malicious domain with valid ID pattern
+    expect(extractCinemaIdFromUrl('https://malicious.com/attack?param-salle=C1234')).toBeNull();
+    // Localhost attempt
+    expect(extractCinemaIdFromUrl('http://localhost:8080/my-exploit?_csalle=C9999')).toBeNull();
+    // Subdomain bypass attempt (e.g., evil.com ending with allocine.fr)
+    expect(extractCinemaIdFromUrl('https://www.allocine.fr.evil.com/seance/salle_gen_csalle=C0013.html')).toBeNull();
+    // Relative URL (invalid URL format)
+    expect(extractCinemaIdFromUrl('/seance/salle_gen_csalle=C0013.html')).toBeNull();
+    // Valid domain but invalid path/pattern
     expect(extractCinemaIdFromUrl('https://www.allocine.fr/film/fichefilm_gen_cfilm=12345.html')).toBeNull();
+    // Completely unrelated URL
+    expect(extractCinemaIdFromUrl('https://www.google.com')).toBeNull();
   });
 });

--- a/server/src/services/scraper/utils.ts
+++ b/server/src/services/scraper/utils.ts
@@ -36,8 +36,20 @@ export function isStaleResponse(
 
 /**
  * Extracts the Allocine cinema ID (e.g., C0013) from a URL.
+ * Strictly validates that the URL originates from www.allocine.fr to prevent SSRF.
  */
 export function extractCinemaIdFromUrl(url: string): string | null {
+  try {
+    const parsedUrl = new URL(url);
+    // Strict domain validation
+    if (parsedUrl.hostname !== 'www.allocine.fr') {
+      return null;
+    }
+  } catch {
+    // Invalid URL format
+    return null;
+  }
+
   const match = url.match(/(?:-salle=|_csalle=)([A-Z0-9]+)/);
   return match ? match[1] : null;
 }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Server-Side Request Forgery (SSRF) in `addCinemaAndScrape` and `extractCinemaIdFromUrl`. The application accepted arbitrary URLs for scraping, allowing attackers to make the server send requests to internal or external resources.
🎯 Impact: Attackers could scan internal networks, access metadata services (e.g., AWS/GCP metadata), or perform other SSRF-based attacks.
🔧 Fix: Updated `extractCinemaIdFromUrl` in `server/src/services/scraper/utils.ts` to strictly validate that the URL hostname is `www.allocine.fr`.
✅ Verification: Added comprehensive test cases in `server/src/services/scraper/utils.test.ts` covering malicious domains, localhost, relative URLs, and other bypass attempts. Verified that valid Allociné URLs still work.

---
*PR created automatically by Jules for task [16444786575352697170](https://jules.google.com/task/16444786575352697170) started by @PhBassin*