### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS risk in reports pagination

### DIFF
--- a/server/src/routes/reports.test.ts
+++ b/server/src/routes/reports.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import router from './reports.js';
+import * as queries from '../db/queries.js';
+
+// Mock dependencies
+vi.mock('../db/client.js', () => ({
+  db: {
+    query: vi.fn()
+  }
+}));
+
+vi.mock('../db/queries.js', () => ({
+  getScrapeReports: vi.fn(),
+  getScrapeReport: vi.fn(),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+  }
+}));
+
+describe('Routes - Reports', () => {
+  let mockRes: any;
+  let mockReq: any;
+  let mockNext: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRes = {
+      json: vi.fn().mockReturnThis(),
+      status: vi.fn().mockReturnThis(),
+    };
+    mockNext = vi.fn();
+  });
+
+  describe('GET /', () => {
+    it('should clamp pageSize to 100 even if requested higher', async () => {
+      mockReq = {
+        query: {
+          page: '1',
+          pageSize: '1000' // Requesting excessive page size
+        }
+      };
+
+      (queries.getScrapeReports as any).mockResolvedValue({ reports: [], total: 0 });
+
+      // Find the handler for GET /
+      const handler = router.stack.find(s => s.route?.path === '/' && s.route?.methods.get)?.route.stack[0].handle;
+
+      expect(handler).toBeDefined();
+      await handler(mockReq, mockRes, mockNext);
+
+      // Verify that getScrapeReports was called with clamped limit
+      expect(queries.getScrapeReports).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+        limit: 100 // Should be clamped to 100
+      }));
+    });
+
+    it('should use default pageSize of 20 if not provided', async () => {
+      mockReq = {
+        query: {}
+      };
+
+      (queries.getScrapeReports as any).mockResolvedValue({ reports: [], total: 0 });
+
+      const handler = router.stack.find(s => s.route?.path === '/' && s.route?.methods.get)?.route.stack[0].handle;
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(queries.getScrapeReports).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+        limit: 20
+      }));
+    });
+
+    it('should handle negative page numbers gracefully (default to 1)', async () => {
+      mockReq = {
+        query: {
+          page: '-5'
+        }
+      };
+
+      (queries.getScrapeReports as any).mockResolvedValue({ reports: [], total: 0 });
+
+      const handler = router.stack.find(s => s.route?.path === '/' && s.route?.methods.get)?.route.stack[0].handle;
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(queries.getScrapeReports).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+        offset: 0 // (1 - 1) * 20 = 0
+      }));
+    });
+  });
+});

--- a/server/src/routes/reports.ts
+++ b/server/src/routes/reports.ts
@@ -11,8 +11,14 @@ const router = express.Router();
 router.get('/', async (req, res) => {
   try {
     const query = req.query as GetReportsQuery;
-    const page = parseInt(query.page || '1');
-    const pageSize = parseInt(query.pageSize || '20');
+    let page = parseInt(query.page || '1');
+    let pageSize = parseInt(query.pageSize || '20');
+
+    // Security: Validate and clamp pagination parameters to prevent DoS
+    if (isNaN(page) || page < 1) page = 1;
+    if (isNaN(pageSize) || pageSize < 1) pageSize = 20;
+    if (pageSize > 100) pageSize = 100;
+
     const status = query.status;
     const triggerType = query.triggerType;
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing input validation on `pageSize` allowed unbounded queries in `GET /api/reports`.
🎯 Impact: Potential Denial of Service (DoS) via database resource exhaustion if a malicious user requested an extremely large page size.
🔧 Fix: Implemented strict validation for `page` and `pageSize` parameters. `pageSize` is now clamped to a maximum of 100, and `page` defaults to 1 if invalid.
✅ Verification: Added `server/src/routes/reports.test.ts` to verify that large page sizes are clamped and invalid inputs are handled gracefully. All tests passed.

---
*PR created automatically by Jules for task [14966813142546219711](https://jules.google.com/task/14966813142546219711) started by @PhBassin*