### PR TITLE
chore(ci): temporarily disable automated Docker cleanup workflows

### DIFF
--- a/.github/workflows/cleanup-docker-images.yml
+++ b/.github/workflows/cleanup-docker-images.yml
@@ -1,9 +1,13 @@
 name: Cleanup Docker Images
 
+# ⚠️ TEMPORARILY DISABLED
+# Automatic Docker image cleanup is disabled for manual control.
+# This workflow can still be triggered manually via workflow_dispatch.
+# To re-enable: uncomment the push trigger and/or schedule block below.
 on:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
   workflow_dispatch:
     inputs:
       dry-run:

--- a/.github/workflows/cleanup-ghcr-untagged.yml
+++ b/.github/workflows/cleanup-ghcr-untagged.yml
@@ -1,8 +1,12 @@
 name: Nettoyage Images Untagged GHCR
 
+# ⚠️ TEMPORARILY DISABLED
+# Automatic Docker image cleanup is disabled for manual control.
+# This workflow can still be triggered manually via workflow_dispatch.
+# To re-enable: uncomment the schedule block below.
 on:
-  schedule:
-    - cron: '0 2 */5 * *' # 
+  # schedule:
+  #   - cron: '0 2 */5 * *' # Runs every 5 days at 2 AM UTC
   workflow_dispatch:     # Permet de le lancer manuellement pour tester
 
 env:

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -90,34 +90,37 @@ jobs:
           echo "- \`:latest\` — tracks \`develop\` branch (continuous development)" >> $GITHUB_STEP_SUMMARY
           echo "- \`:stable\` — tracks \`main\` branch and version tags (production)" >> $GITHUB_STEP_SUMMARY
 
-  cleanup-after-production-build:
-    runs-on: ubuntu-latest
-    needs: build-and-push
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
-    permissions:
-      packages: write
-    
-    steps:
-      - name: Delete old untagged images (DRY-RUN)
-        uses: actions/delete-package-versions@v5
-        with:
-          package-name: 'allo-scrapper'
-          package-type: 'container'
-          min-versions-to-keep: 10
-          delete-only-untagged-versions: 'true'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          dry-run: true
-
-      - name: Cleanup summary
-        run: |
-          echo "### 🧹 Post-Build Cleanup Complete!" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Mode:** 🔍 DRY-RUN (no images deleted - for safety)" >> $GITHUB_STEP_SUMMARY
-          echo "**Trigger:** Production build (main branch or tag v*)" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "ℹ️ To enable actual deletion, modify this workflow and remove 'dry-run: true'" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Policy:**" >> $GITHUB_STEP_SUMMARY
-          echo "- Keep: 10 versions maximum" >> $GITHUB_STEP_SUMMARY
-          echo "- Delete: Only untagged versions" >> $GITHUB_STEP_SUMMARY
-          echo "- Protected: All tagged versions (v*, stable, latest)" >> $GITHUB_STEP_SUMMARY
+  # ⚠️ TEMPORARILY DISABLED
+  # Post-build Docker image cleanup is disabled for manual control.
+  # To re-enable: uncomment the entire cleanup-after-production-build job below.
+  # cleanup-after-production-build:
+  #   runs-on: ubuntu-latest
+  #   needs: build-and-push
+  #   if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+  #   permissions:
+  #     packages: write
+  #   
+  #   steps:
+  #     - name: Delete old untagged images (DRY-RUN)
+  #       uses: actions/delete-package-versions@v5
+  #       with:
+  #         package-name: 'allo-scrapper'
+  #         package-type: 'container'
+  #         min-versions-to-keep: 10
+  #         delete-only-untagged-versions: 'true'
+  #         token: ${{ secrets.GITHUB_TOKEN }}
+  #         dry-run: true
+  #
+  #     - name: Cleanup summary
+  #       run: |
+  #         echo "### 🧹 Post-Build Cleanup Complete!" >> $GITHUB_STEP_SUMMARY
+  #         echo "" >> $GITHUB_STEP_SUMMARY
+  #         echo "**Mode:** 🔍 DRY-RUN (no images deleted - for safety)" >> $GITHUB_STEP_SUMMARY
+  #         echo "**Trigger:** Production build (main branch or tag v*)" >> $GITHUB_STEP_SUMMARY
+  #         echo "" >> $GITHUB_STEP_SUMMARY
+  #         echo "ℹ️ To enable actual deletion, modify this workflow and remove 'dry-run: true'" >> $GITHUB_STEP_SUMMARY
+  #         echo "" >> $GITHUB_STEP_SUMMARY
+  #         echo "**Policy:**" >> $GITHUB_STEP_SUMMARY
+  #         echo "- Keep: 10 versions maximum" >> $GITHUB_STEP_SUMMARY
+  #         echo "- Delete: Only untagged versions" >> $GITHUB_STEP_SUMMARY
+  #         echo "- Protected: All tagged versions (v*, stable, latest)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,8 +1,12 @@
 name: GHCR Cleanup
 
+# ⚠️ TEMPORARILY DISABLED
+# Automatic Docker image cleanup is disabled for manual control.
+# This workflow can still be triggered manually via workflow_dispatch.
+# To re-enable: uncomment the schedule block below.
 on:
-  schedule:
-    - cron: '30 2 * * *'
+  # schedule:
+  #   - cron: '30 2 * * *' # Runs daily at 2:30 AM UTC
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary

Temporarily disables all automated Docker image cleanup workflows to maintain manual control over image retention.

## Changes Made

### 🔴 Disabled Automated Cron Schedules

1. **`.github/workflows/cleanup-ghcr-untagged.yml`**
   - ❌ Disabled cron: every 5 days at 2 AM
   - ✅ Manual trigger still available

2. **`.github/workflows/ghcr-cleanup.yml`**
   - ❌ Disabled cron: daily at 2:30 AM
   - ✅ Manual trigger still available

3. **`.github/workflows/cleanup-docker-images.yml`**
   - ❌ Disabled push trigger on `main` branch
   - ✅ Manual trigger still available

4. **`.github/workflows/docker-build-push.yml`**
   - ❌ Disabled `cleanup-after-production-build` job
   - ✅ Main build workflow still works normally

## Implementation Details

- **Approach**: Commented out triggers (not deleted)
- **Clear comments**: Added "⚠️ TEMPORARILY DISABLED" headers
- **YAML valid**: All workflows pass syntax validation
- **Easy re-enabling**: Simple uncomment to restore functionality

## What Remains Active

| Component | Status |
|-----------|--------|
| Automated cron jobs | ❌ Disabled |
| Manual workflow triggers | ✅ Active (via GitHub UI) |
| NPM `docker:clean` script | ✅ Active (local cleanup) |
| E2E test cleanup | ✅ Active |
| Dockerfile build optimizations | ✅ Active |

## Manual Cleanup Options

Users can still manually trigger cleanup workflows:
1. Go to **Actions** tab
2. Select the workflow
3. Click **Run workflow**
4. Choose dry-run mode if testing

## Re-enabling Process

When ready to re-enable automatic cleanup:
1. Uncomment the `schedule:` blocks in all workflows
2. Uncomment the `push:` trigger in cleanup-docker-images.yml
3. Uncomment the `cleanup-after-production-build` job in docker-build-push.yml
4. Remove "TEMPORARILY DISABLED" comments
5. Commit and push

## Testing

- ✅ YAML syntax validated with `yaml-lint`
- ✅ No automated triggers will fire
- ✅ Manual triggers remain functional
- ✅ Build pipeline unaffected

Closes #142