### PR TITLE
fix(ci): enable Docker push for internal PRs and normalize registry case

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -34,7 +34,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository)
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -60,7 +60,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -68,7 +68,7 @@ jobs:
           platforms: linux/amd64
 
       - name: Generate artifact attestation
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository)
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -77,9 +77,12 @@ jobs:
 
       - name: Output image details
         run: |
+          # Normalize registry path to lowercase (GHCR requirement)
+          IMAGE_PATH=$(echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" | tr '[:upper:]' '[:lower:]')
+          
           echo "### Docker Image Built Successfully! 🚀" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Image:** \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`${IMAGE_PATH}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Tags:**" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
@@ -94,10 +97,10 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
             echo "# Pull the image" >> $GITHUB_STEP_SUMMARY
-            echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
+            echo "docker pull ${IMAGE_PATH}:pr-${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "# Run it locally" >> $GITHUB_STEP_SUMMARY
-            echo "docker run -p 3000:3000 ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
+            echo "docker run -p 3000:3000 ${IMAGE_PATH}:pr-${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "💡 **Tip:** See [CONTRIBUTING.md](https://github.com/${{ github.repository }}/blob/develop/CONTRIBUTING.md#testing-your-changes-with-docker) for more testing options." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

This PR fixes two issues with the Docker workflow:

1. **Enables PR image pushing** - Internal PRs now push images to GHCR (fork PRs are blocked for security)
2. **Fixes case sensitivity** - Normalizes registry path to lowercase as required by GHCR

## Changes

### 1. Allow Internal PR Pushes
Modified three conditional checks to allow internal PRs:
- **Login step** (line 37): Added internal PR condition
- **Push step** (line 63): Added internal PR condition  
- **Attestation step** (line 71): Added internal PR condition

**Condition logic:**
```yaml
github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository)
```

**Security:** Fork PRs are blocked (only same-repo PRs push images)

### 2. Fix Registry Case Sensitivity
- Added `IMAGE_PATH` variable that normalizes to lowercase
- Updated all displayed commands to use `${IMAGE_PATH}`
- Fixes: `PhBassin` → `phbassin` (GHCR requirement)

## Testing

This PR itself will test the changes:
- ✅ Workflow should build the image
- ✅ Workflow should push to GHCR with tag `pr-147` (or current PR number)
- ✅ Commands displayed should use lowercase `phbassin`
- ✅ Image should be pullable: `docker pull ghcr.io/phbassin/allo-scrapper:pr-147`

## Impact

- **Users can now test PRs** before merging (as documented in #145)
- **Commands are correct** and won't confuse users with case mismatches
- **Security maintained** - fork PRs cannot push to registry
- **Registry will grow** - more images will accumulate (cleanup script available)

## References

Closes #146  
Related to #145 (documentation that assumes PR images exist)

## Checklist

- [x] Follows Conventional Commits format
- [x] References issue in commit message
- [x] Changes are minimal and focused
- [x] Security consideration (fork PR blocking) implemented
- [x] Will verify workflow output after PR opened