### PR TITLE
🧹 Refactor: Remove duplicate date logic in theater parser

### DIFF
--- a/server/src/services/scraper/theater-parser.ts
+++ b/server/src/services/scraper/theater-parser.ts
@@ -1,6 +1,7 @@
 import * as cheerio from 'cheerio';
 import type { TheaterPageData, Cinema, FilmShowtimeData, Film, Showtime } from '../../types/scraper';
 import { logger } from '../../utils/logger.js';
+import { getWeekStartForDate } from '../../utils/date.js';
 
 // Parse the cinema page from the source website
 export function parseTheaterPage(html: string, cinemaId: string): TheaterPageData {
@@ -275,7 +276,7 @@ function parseShowtimes(
         version,
         format,
         experiences,
-        week_start: getWeekStart(showtimeDate),
+        week_start: getWeekStartForDate(showtimeDate),
       });
     });
   });
@@ -314,19 +315,3 @@ function parseDateFromText(day: string, monthName: string, year: string): string
   return `${year}-${month}-${dayPadded}`;
 }
 
-// Utilitaire: obtenir le mercredi de la semaine d'une date
-function getWeekStart(dateStr: string): string {
-  const date = new Date(dateStr);
-  const dayOfWeek = date.getDay(); // 0 = dimanche, 3 = mercredi
-  
-  // Calculer le décalage vers le mercredi précédent
-  let offset = dayOfWeek - 3; // mercredi = 3
-  if (offset < 0) {
-    offset += 7; // Si on est lundi/mardi, aller au mercredi précédent
-  }
-  
-  const wednesday = new Date(date);
-  wednesday.setDate(date.getDate() - offset);
-  
-  return wednesday.toISOString().split('T')[0];
-}


### PR DESCRIPTION
This PR refactors `server/src/services/scraper/theater-parser.ts` to remove a duplicate date calculation function (`getWeekStart`) and replace it with the existing utility function `getWeekStartForDate` from `server/src/utils/date.ts`.

### Changes
- Imported `getWeekStartForDate` from `../../utils/date.js` in `server/src/services/scraper/theater-parser.ts`.
- Replaced usage of local `getWeekStart` with `getWeekStartForDate`.
- Removed local `getWeekStart` function definition.

### Why
- Reduces code duplication.
- Centralizes date logic in `server/src/utils/date.ts`.
- `getWeekStartForDate` uses safer local date parsing to avoid potential timezone issues.

### Verification
- Ran existing tests for `theater-parser.ts` (`npm test server/src/services/scraper/theater-parser.test.ts`), all passed.
- Ran all scraper tests (`npm test server/src/services/scraper/`), all passed.

---
*PR created automatically by Jules for task [3820010118082034918](https://jules.google.com/task/3820010118082034918) started by @PhBassin*