### PR TITLE
feat(scraper): add configurable delays to prevent 429 rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,8 +55,14 @@ IMAGE_TAG=latest
 # Default: Every Wednesday at 8:00 AM
 SCRAPE_CRON_SCHEDULE=0 8 * * 3
 
-# Delay in milliseconds between HTTP requests to avoid rate limiting
-SCRAPE_DELAY_MS=1000
+# Delay in milliseconds between each cinema scrape to avoid rate limiting
+# Recommended: 3000ms (3 seconds) to avoid 429 errors when scraping multiple cinemas
+SCRAPE_THEATER_DELAY_MS=3000
+
+# Delay in milliseconds between movie detail page fetches
+# This delay is applied when fetching film metadata (duration, etc.)
+# Recommended: 500ms
+SCRAPE_MOVIE_DELAY_MS=500
 
 # Number of days to scrape starting from start date
 # Default: 7 (full week)

--- a/scraper/src/db/queries.ts
+++ b/scraper/src/db/queries.ts
@@ -93,6 +93,14 @@ export async function getCinemas(db: DB): Promise<Cinema[]> {
 }
 
 
+// Get cinemas configured for scraping (those with a URL)
+export async function getCinemaConfigs(db: DB): Promise<Array<{ id: string; name: string; url: string }>> {
+  const result = await db.query<{ id: string; name: string; url: string }>(
+    'SELECT id, name, url FROM cinemas WHERE url IS NOT NULL ORDER BY name'
+  );
+  return result.rows;
+}
+
 // Récupérer un film par son ID
 export async function getFilm(db: DB, filmId: number): Promise<Film | undefined> {
   const result = await db.query<FilmRow>(

--- a/scraper/src/scraper/index.ts
+++ b/scraper/src/scraper/index.ts
@@ -48,6 +48,7 @@ async function scrapeTheater(
   db: DB,
   cinema: CinemaConfig,
   date: string,
+  movieDelayMs: number,
   progress?: ProgressPublisher
 ): Promise<{ filmsCount: number; showtimesCount: number }> {
   logger.info('Scraping cinema for date', { cinema: cinema.name, id: cinema.id, date });
@@ -84,7 +85,7 @@ async function scrapeTheater(
               film.duration_minutes = filmPageData.duration_minutes;
             }
 
-            await delay(500);
+            await delay(movieDelayMs);
           } catch (error) {
             logger.warn('Error fetching film page', { filmId: film.id, error });
           }
@@ -165,6 +166,10 @@ export async function runScraper(
 
   const startTime = Date.now();
 
+  // Read delay configuration from environment
+  const theaterDelayMs = parseInt(process.env.SCRAPE_THEATER_DELAY_MS || '3000', 10);
+  const movieDelayMs = parseInt(process.env.SCRAPE_MOVIE_DELAY_MS || '500', 10);
+
   try {
     let cinemas = await getCinemaConfigs(db);
     
@@ -172,7 +177,7 @@ export async function runScraper(
     if (options?.cinemaId) {
       // First verify cinema exists in database (source of truth)
       const allCinemasFromDb = await getCinemas(db);
-      const cinemaExistsInDb = allCinemasFromDb.some(c => c.id === options.cinemaId);
+      const cinemaExistsInDb = allCinemasFromDb.some((c: Cinema) => c.id === options.cinemaId);
       
       if (!cinemaExistsInDb) {
         throw new Error(`Cinema not found in database: ${options.cinemaId}`);
@@ -194,6 +199,7 @@ export async function runScraper(
     const scrapeDays = options?.days || parseInt(process.env.SCRAPE_DAYS || '7', 10);
     const dates = getScrapeDates(scrapeMode, scrapeDays);
     logger.info('Scrape config', { mode: scrapeMode, dates: dates.length, scrapeDays });
+    logger.info('Delay config', { theaterDelayMs, movieDelayMs });
 
     summary.total_cinemas = cinemas.length;
     summary.total_dates = dates.length;
@@ -243,12 +249,11 @@ export async function runScraper(
       for (const date of datesToScrape) {
         logger.info('Attempting date', { cinema: cinema.name, date });
         try {
-          const { filmsCount, showtimesCount } = await scrapeTheater(db, cinema, date, progress);
+          const { filmsCount, showtimesCount } = await scrapeTheater(db, cinema, date, movieDelayMs, progress);
           cinemaFilmsCount += filmsCount;
           cinemaShowtimesCount += showtimesCount;
           successfulDates++;
           logger.info('Date scraped successfully', { date, films: filmsCount, showtimes: showtimesCount });
-          await delay(500);
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error);
           logger.error('Date scrape failed', { cinema: cinema.name, date, error: errorMessage });
@@ -291,6 +296,12 @@ export async function runScraper(
       } else {
         summary.failed_cinemas++;
         logger.error('Cinema failed completely', { cinema: cinema.name, dates: datesToScrape.length });
+      }
+
+      // Apply delay between cinemas (except after the last one)
+      if (i < cinemas.length - 1) {
+        logger.info('Waiting before next cinema', { delayMs: theaterDelayMs });
+        await delay(theaterDelayMs);
       }
     }
 

--- a/server/src/services/scraper/index.ts
+++ b/server/src/services/scraper/index.ts
@@ -47,6 +47,7 @@ async function scrapeTheater(
   db: DB,
   cinema: CinemaConfig,
   date: string,
+  movieDelayMs: number,
   progress?: ProgressTracker
 ): Promise<{ filmsCount: number; showtimesCount: number }> {
   logger.info(`\n📍 Scraping ${cinema.name} (${cinema.id}) for ${date}...`);
@@ -86,7 +87,7 @@ async function scrapeTheater(
               film.duration_minutes = filmPageData.duration_minutes;
             }
 
-            await delay(500); // Délai pour éviter le rate limiting
+            await delay(movieDelayMs); // Délai pour éviter le rate limiting
           } catch (error) {
             logger.error(`  ⚠️  Error fetching film page for ${film.id}:`, error);
           }
@@ -183,10 +184,11 @@ export async function addCinemaAndScrape(
   const { availableDates, cinema } = await loadTheaterMetadata(db, tempConfig);
 
   // 4. Scrape available dates
+  const movieDelayMs = parseInt(process.env.SCRAPE_MOVIE_DELAY_MS || '500', 10);
   logger.info(`   📅 Scraping ${availableDates.length} available date(s)...`);
   for (const date of availableDates) {
     try {
-      await scrapeTheater(db, tempConfig, date, progress);
+      await scrapeTheater(db, tempConfig, date, movieDelayMs, progress);
     } catch (error) {
       logger.error(`   ❌ Failed to scrape date ${date}:`, error);
       // Continue with other dates
@@ -220,6 +222,10 @@ export async function runScraper(
     errors: [],
   };
 
+  // Read delay configuration from environment
+  const theaterDelayMs = parseInt(process.env.SCRAPE_THEATER_DELAY_MS || '3000', 10);
+  const movieDelayMs = parseInt(process.env.SCRAPE_MOVIE_DELAY_MS || '500', 10);
+
   try {
     // Charger la configuration des cinémas depuis la base de données
     let cinemas = await getCinemaConfigs(db);
@@ -240,6 +246,7 @@ export async function runScraper(
     const scrapeDays = options?.days || parseInt(process.env.SCRAPE_DAYS || '7', 10);
     const dates = getScrapeDates(scrapeMode, scrapeDays);
     logger.info(`📅 Mode: ${scrapeMode}, Scraping ${dates.length} date(s) (SCRAPE_DAYS=${scrapeDays}): ${dates.join(', ')}\n`);
+    logger.info(`⏱️  Delays: ${theaterDelayMs}ms between cinemas, ${movieDelayMs}ms between films\n`);
 
     summary.total_cinemas = cinemas.length;
     summary.total_dates = dates.length;
@@ -294,12 +301,11 @@ export async function runScraper(
       for (const date of datesToScrape) {
         logger.info(`\n   📅 Attempting date: ${date}`);
         try {
-          const { filmsCount, showtimesCount } = await scrapeTheater(db, cinema, date, progress);
+          const { filmsCount, showtimesCount } = await scrapeTheater(db, cinema, date, movieDelayMs, progress);
           cinemaFilmsCount += filmsCount;
           cinemaShowtimesCount += showtimesCount;
           successfulDates++;
           logger.info(`   ✅ Date ${date} completed: ${filmsCount} films, ${showtimesCount} showtimes`);
-          await delay(500); // Délai entre chaque requête
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error);
           logger.error(`   ❌ Date ${date} failed:`, errorMessage);
@@ -336,6 +342,12 @@ export async function runScraper(
       } else {
         summary.failed_cinemas++;
         logger.error(`❌ ${cinema.name} failed completely (0/${datesToScrape.length} dates successful)`);
+      }
+
+      // Apply delay between cinemas (except after the last one)
+      if (i < cinemas.length - 1) {
+        logger.info(`⏸️  Waiting ${theaterDelayMs}ms before next cinema...`);
+        await delay(theaterDelayMs);
       }
     }
 


### PR DESCRIPTION
## Summary

This PR adds configurable delay environment variables to prevent 429 (Too Many Requests) errors when scraping multiple cinemas from AlloCiné.

## Changes

- **Environment variables**:
  - Replaced unused `SCRAPE_DELAY_MS` with two new variables:
    - `SCRAPE_THEATER_DELAY_MS` (default 3000ms) - delay between each cinema
    - `SCRAPE_MOVIE_DELAY_MS` (default 500ms) - delay between movie detail fetches
  
- **Scraper logic** (both legacy and microservice modes):
  - Added delay between cinemas (not just between dates)
  - Removed redundant delay between dates within same cinema
  - Added logging to indicate when delays are applied
  
- **Database queries**:
  - Added `getCinemaConfigs()` export to `scraper/src/db/queries.ts` (was missing)

## Testing

- ✅ TypeScript compilation passes for both `server` and `scraper`
- ✅ All files properly staged and committed

## Impact

This change should eliminate 429 errors during full scraping sessions by spacing out requests more appropriately between cinemas.

Closes #154