### PR TITLE
⚡ Bolt: Optimize film search with index and query tuning

### DIFF
--- a/server/src/db/queries.ts
+++ b/server/src/db/queries.ts
@@ -1072,32 +1072,32 @@ export async function searchFilms(
       CASE
         -- Exact match (highest priority)
         WHEN LOWER(title) = LOWER($1) THEN 1.0
-        WHEN LOWER(COALESCE(original_title, '')) = LOWER($1) THEN 0.95
+        WHEN original_title IS NOT NULL AND LOWER(original_title) = LOWER($1) THEN 0.95
         
         -- Starts with query (very high priority)
         WHEN LOWER(title) LIKE LOWER($1) || '%' THEN 0.9
-        WHEN LOWER(COALESCE(original_title, '')) LIKE LOWER($1) || '%' THEN 0.85
+        WHEN original_title IS NOT NULL AND LOWER(original_title) LIKE LOWER($1) || '%' THEN 0.85
         
         -- Good trigram similarity (high priority)
         WHEN similarity(title, $1) > 0.3 THEN similarity(title, $1) * 0.8
-        WHEN similarity(COALESCE(original_title, ''), $1) > 0.3 THEN similarity(COALESCE(original_title, ''), $1) * 0.75
+        WHEN original_title IS NOT NULL AND similarity(original_title, $1) > 0.3 THEN similarity(original_title, $1) * 0.75
         
         -- Moderate trigram similarity (permissive - medium priority)
         WHEN similarity(title, $1) > 0.1 THEN similarity(title, $1) * 0.6
-        WHEN similarity(COALESCE(original_title, ''), $1) > 0.1 THEN similarity(COALESCE(original_title, ''), $1) * 0.55
+        WHEN original_title IS NOT NULL AND similarity(original_title, $1) > 0.1 THEN similarity(original_title, $1) * 0.55
         
         -- Contains anywhere in title (lower priority)
         WHEN title ILIKE '%' || $1 || '%' THEN 0.4
-        WHEN COALESCE(original_title, '') ILIKE '%' || $1 || '%' THEN 0.35
+        WHEN original_title IS NOT NULL AND original_title ILIKE '%' || $1 || '%' THEN 0.35
         
         ELSE 0.1
       END AS score
     FROM films
     WHERE 
       similarity(title, $1) > 0.1
-      OR similarity(COALESCE(original_title, ''), $1) > 0.1
+      OR (original_title IS NOT NULL AND similarity(original_title, $1) > 0.1)
       OR title ILIKE '%' || $1 || '%'
-      OR COALESCE(original_title, '') ILIKE '%' || $1 || '%'
+      OR (original_title IS NOT NULL AND original_title ILIKE '%' || $1 || '%')
     ORDER BY score DESC, title ASC
     LIMIT $2`,
     [query, limit]

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -52,6 +52,7 @@ export async function initializeDatabase() {
 
     // Index for films title (trigram similarity for fuzzy search)
     `CREATE INDEX IF NOT EXISTS idx_films_title_trgm ON films USING gin(title gin_trgm_ops)`,
+    `CREATE INDEX IF NOT EXISTS idx_films_original_title_trgm ON films USING gin(original_title gin_trgm_ops)`,
 
     // Table: showtimes
     `CREATE TABLE IF NOT EXISTS showtimes (


### PR DESCRIPTION
⚡ Bolt: Optimized film search performance

💡 What:
- Added a GIN trigram index on `films.original_title`.
- Rewrote the `searchFilms` SQL query to use `original_title IS NOT NULL` instead of `COALESCE(original_title, '')`.

🎯 Why:
- The previous query used `COALESCE` on `original_title`, which prevented the database from using an index on that column (unless an expression index was created).
- Searching for films by original title likely resulted in a full table scan or inefficient index usage.

📊 Impact:
- significantly faster search results when querying by original title, especially as the dataset grows.
- reduces CPU usage on the database server during search operations.

🔬 Measurement:
- `EXPLAIN ANALYZE` on the new query should show `Bitmap Index Scan` on `idx_films_original_title_trgm` instead of `Seq Scan` or unindexed filter.
- `npm run test:run -- src/db/queries.test.ts` passes.

---
*PR created automatically by Jules for task [11830929117312321983](https://jules.google.com/task/11830929117312321983) started by @PhBassin*