### PR TITLE
chore(docker): configure production deployment with registry image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ temp/
 out.txt
 test.out
 *.out
+backup_*.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,8 @@ services:
 
   # Production web server (serves both API and frontend)
   ics-web:
-    #image: ghcr.io/phbassin/allo-scrapper:${IMAGE_TAG:-latest}
-    build: .
+    image: ghcr.io/phbassin/allo-scrapper:${IMAGE_TAG:-stable}
+    #build: .
     user: root
     pull_policy: always
     restart: unless-stopped
@@ -62,6 +62,8 @@ services:
       LOG_LEVEL: ${LOG_LEVEL:-info}
       OTEL_ENABLED: ${OTEL_ENABLED:-false}
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://ics-tempo:4317}
+      # Authentication configuration (required for v2.0.0+)
+      JWT_SECRET: ${JWT_SECRET}
     depends_on:
       ics-db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Switch from local image build to GitHub Container Registry image
- Use `:stable` tag for production deployments
- Add JWT_SECRET environment variable for v2.0.0 authentication
- Prevent accidental commits of database backup files

## Changes
- **docker-compose.yml**: Use `ghcr.io/phbassin/allo-scrapper:stable` image
- **docker-compose.yml**: Add `JWT_SECRET` environment variable
- **.gitignore**: Add `backup_*.sql` pattern

## Testing
✅ Production deployment verified:
- Container running with registry image
- Authentication working (JWT tokens generated)
- Health check passing
- All endpoints functional

## Related Issue
Closes #177