### PR TITLE
⚡ Bolt: optimize CinemaPage rendering with useMemo

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-05-17 - [Optimizing Component Renders with useMemo]
+**Learning:** Found that some derived states, particularly arrays/computations on arrays like grouping or filtering (e.g., `getUniqueDates`, `filter`, `groupByFilm` in `CinemaPage.tsx`), were being recalculated on every component render. Since components can re-render frequently due to other unrelated state changes (like showing a scrape progress bar, `showProgress`), memoizing these computations prevents potentially expensive recalculations and optimizes rendering speed.
+**Action:** When working on components rendering lists from derived state arrays, always evaluate if `useMemo` can be used to prevent recalculation when the underlying source data (`showtimes`) or filter criteria (`selectedDate`) haven't changed.

--- a/client/src/pages/CinemaPage.tsx
+++ b/client/src/pages/CinemaPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { getCinemas, getCinemaSchedule, triggerCinemaScrape, getScrapeStatus } from '../api/client';
 import type { Cinema, ShowtimeWithFilm } from '../types';
@@ -115,6 +115,13 @@ export default function CinemaPage() {
     }, 2000);
   };
 
+  // ⚡ PERFORMANCE: Memoize derived state calculations to prevent expensive
+  // array operations (getUniqueDates, filter, groupByFilm) on every render,
+  // especially when showtimes array is large or during unrelated state updates (like scrape progress).
+  const dates = useMemo(() => getUniqueDates(showtimes), [showtimes]);
+  const selectedShowtimes = useMemo(() => showtimes.filter(s => s.date === selectedDate), [showtimes, selectedDate]);
+  const filmGroups = useMemo(() => groupByFilm(selectedShowtimes), [selectedShowtimes]);
+
   if (isLoading) {
     return (
       <div className="flex justify-center items-center min-h-[400px]">
@@ -131,10 +138,6 @@ export default function CinemaPage() {
       </div>
     );
   }
-
-  const dates = getUniqueDates(showtimes);
-  const selectedShowtimes = showtimes.filter(s => s.date === selectedDate);
-  const filmGroups = groupByFilm(selectedShowtimes);
 
   return (
     <div>


### PR DESCRIPTION
💡 **What**: The optimization implemented
Added `useMemo` hooks in `client/src/pages/CinemaPage.tsx` to memoize derived state calculations: `dates`, `selectedShowtimes`, and `filmGroups`.

🎯 **Why**: The performance problem it solves
Previously, these array operations (`getUniqueDates`, `filter`, and `groupByFilm`) were being executed on every render cycle of `CinemaPage`. This component re-renders not just on data load, but also when unrelated states like `showProgress` change. Memoizing these expensive calculations prevents unneeded processing when the underlying data (`showtimes` and `selectedDate`) hasn't changed.

📊 **Impact**: Expected performance improvement
Reduces redundant array filtering and grouping logic. Speeds up rendering when interacting with unrelated state elements like the scrape button or during loading states.

🔬 **Measurement**: How to verify the improvement
Run the application and navigate to `/cinema/:id`. Initiate a scrape using the "Scraper uniquement ce cinéma" button. The progress bar updates will no longer trigger recalculation of the schedules, resulting in smoother UI interactions.

---
*PR created automatically by Jules for task [2051795033054592501](https://jules.google.com/task/2051795033054592501) started by @PhBassin*