### PR TITLE
🔒 Add authentication to cinema admin endpoints

### DIFF
--- a/server/src/routes/cinemas.ts
+++ b/server/src/routes/cinemas.ts
@@ -11,7 +11,8 @@ import {
   syncCinemasFromDatabase,
 } from '../services/cinema-config.js';
 import type { ApiResponse } from '../types/api.js';
-import { publicLimiter } from '../middleware/rate-limit.js';
+import { publicLimiter, protectedLimiter } from '../middleware/rate-limit.js';
+import { requireAuth } from '../middleware/auth.js';
 
 const router = express.Router();
 
@@ -32,7 +33,7 @@ router.get('/', publicLimiter, async (_req, res, next) => {
 });
 
 // POST /api/cinemas - Add a new cinema
-router.post('/', publicLimiter, async (req, res, next) => {
+router.post('/', requireAuth, protectedLimiter, async (req, res, next) => {
   try {
     const { id, name, url } = req.body;
 
@@ -132,7 +133,7 @@ router.post('/', publicLimiter, async (req, res, next) => {
 });
 
 // PUT /api/cinemas/:id - Update a cinema's name and/or URL
-router.put('/:id', publicLimiter, async (req, res, next) => {
+router.put('/:id', requireAuth, protectedLimiter, async (req, res, next) => {
   try {
     const cinemaId = req.params.id;
     const { name, url } = req.body;
@@ -195,7 +196,7 @@ router.put('/:id', publicLimiter, async (req, res, next) => {
 });
 
 // DELETE /api/cinemas/:id - Delete a cinema (cascades to showtimes and weekly_programs)
-router.delete('/:id', publicLimiter, async (req, res, next) => {
+router.delete('/:id', requireAuth, protectedLimiter, async (req, res, next) => {
   try {
     const cinemaId = req.params.id;
     const deleted = await deleteCinemaWithSync(db, cinemaId);
@@ -215,7 +216,7 @@ router.delete('/:id', publicLimiter, async (req, res, next) => {
 });
 
 // GET /api/cinemas/sync - Manual sync from database to JSON file
-router.get('/sync', publicLimiter, async (_req, res, next) => {
+router.get('/sync', requireAuth, protectedLimiter, async (_req, res, next) => {
   try {
     const count = await syncCinemasFromDatabase(db);
 


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Administrative endpoints in `server/src/routes/cinemas.ts` (`POST /`, `PUT /:id`, `DELETE /:id`, and `GET /sync`) lacked authentication, allowing unauthorized users to modify or delete cinema data.

⚠️ **Risk:** The potential impact if left unfixed
An attacker could manipulate the database, deleting legitimate cinemas, injecting malicious URLs, or tampering with scraping configuration, leading to a loss of data integrity and potential downstream scraping vulnerabilities.

🛡️ **Solution:** How the fix addresses the vulnerability
The `requireAuth` middleware was added to these specific endpoints to ensure only authenticated users can access them. Additionally, the rate limiter was upgraded from `publicLimiter` to `protectedLimiter` for better protection against brute-force or DoS abuse on authenticated routes.

---
*PR created automatically by Jules for task [7474246348385784032](https://jules.google.com/task/7474246348385784032) started by @PhBassin*