### PR TITLE
chore(release): v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.1.1] - 2026-03-01
+
+### Security
+
+- **Cinema Admin Endpoints** — Added JWT authentication requirement to cinema management endpoints (`POST /api/cinemas`, `PUT /api/cinemas/:id`, `DELETE /api/cinemas/:id`) to prevent unauthorized modifications (#191)
+
+### Fixed
+
+- **Browser Tab Title** — Fixed browser tab to display configured `VITE_APP_NAME` instead of hardcoded 'client' text (#193)
+- **Docker Build** — Fixed `VITE_APP_NAME` build arg not being passed correctly in Docker Compose and GitHub Actions workflow
+
+### Documentation
+
+- Added comprehensive frontend build configuration documentation
+- Documented `VITE_APP_NAME` environment variable for development and production builds
+
+---
+
 ## [2.1.0] - 2026-02-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "allo-scrapper",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Cinema showtimes aggregator - Full-stack Express.js + React application with PostgreSQL backend",
   "type": "module",
   "private": true,


### PR DESCRIPTION
## Summary

Patch release capturing security fixes and bug fixes before merging white-label features.

### Changes in v2.1.1

**Security:**
- Added JWT authentication to cinema admin endpoints (POST/PUT/DELETE `/api/cinemas`) to prevent unauthorized modifications (#191)

**Bug Fixes:**
- Fixed browser tab title to display configured `VITE_APP_NAME` instead of hardcoded 'client' (#193)
- Fixed `VITE_APP_NAME` build arg support in Docker Compose and GitHub Actions workflow

**Documentation:**
- Added frontend build configuration documentation
- Documented `VITE_APP_NAME` environment variable

### Release Process

This PR:
1. ✅ Bumps version from 2.1.0 → 2.1.1 in `package.json`
2. ✅ Updates `CHANGELOG.md` with v2.1.1 release notes
3. ✅ All tests pass (312 tests)
4. ✅ Pre-push hooks validated

After merge:
- Tag as `v2.1.1`
- Create GitHub release
- Merge to `main`
- Ready to proceed with PR #198 (white-label API features)

---

Refs: #191, #193