### PR TITLE
refactor(cinemas): migrate cinemas routes to use req.app.get('db')

### DIFF
--- a/server/src/routes/cinemas.security.test.ts
+++ b/server/src/routes/cinemas.security.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as queries from '../db/queries.js';
 import router from './cinemas.js';
+import { db } from '../db/client.js';
 
 // Mock the dependencies
 vi.mock('../db/client.js', () => ({
@@ -31,15 +32,22 @@ describe('Routes - Cinemas - Security', () => {
   let mockRes: any;
   let mockReq: any;
   let mockNext: any;
+  let mockApp: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockApp = {
+      get: vi.fn((key: string) => {
+        if (key === 'db') return db;
+        return undefined;
+      })
+    };
     mockRes = {
       json: vi.fn().mockReturnThis(),
       status: vi.fn().mockReturnThis()
     };
     mockNext = vi.fn();
-    mockReq = {};
+    mockReq = { app: mockApp };
   });
 
   it('should delegate error handling to next() and NOT expose sensitive details directly', async () => {

--- a/server/src/routes/cinemas.test.ts
+++ b/server/src/routes/cinemas.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as cinemaConfig from '../services/cinema-config.js';
 import router from './cinemas.js';
+import { db } from '../db/client.js';
 
 // Mock the dependencies
 vi.mock('../db/client.js', () => ({
@@ -36,9 +37,16 @@ describe('Routes - Cinemas', () => {
   let mockRes: any;
   let mockReq: any;
   let mockNext: any;
+  let mockApp: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockApp = {
+      get: vi.fn((key: string) => {
+        if (key === 'db') return db;
+        return undefined;
+      })
+    };
     mockRes = {
       json: vi.fn().mockReturnThis(),
       status: vi.fn().mockReturnThis(),
@@ -50,7 +58,8 @@ describe('Routes - Cinemas', () => {
   describe('POST /', () => {
     it('should create a new cinema and return 201', async () => {
       mockReq = {
-        body: { id: 'C0099', name: 'New Cinema', url: 'https://www.allocine.fr/seance/salle_gen_csalle=C0099.html' }
+        body: { id: 'C0099', name: 'New Cinema', url: 'https://www.allocine.fr/seance/salle_gen_csalle=C0099.html' },
+        app: mockApp
       };
       const created = { id: 'C0099', name: 'New Cinema', url: 'https://www.allocine.fr/seance/salle_gen_csalle=C0099.html' };
       (cinemaConfig.addCinemaWithSync as any).mockResolvedValue(created);
@@ -64,7 +73,7 @@ describe('Routes - Cinemas', () => {
     });
 
     it('should return 400 when id is missing', async () => {
-      mockReq = { body: { name: 'Missing ID', url: 'https://www.allocine.fr/seance/salle_gen_csalle=C0099.html' } };
+      mockReq = { body: { name: 'Missing ID', url: 'https://www.allocine.fr/seance/salle_gen_csalle=C0099.html' }, app: mockApp };
 
       const handler = getRouteHandler('/', 'post');
       await handler(mockReq, mockRes, mockNext);
@@ -74,7 +83,7 @@ describe('Routes - Cinemas', () => {
     });
 
     it('should return 400 when name is missing', async () => {
-      mockReq = { body: { id: 'C0099', url: 'https://www.allocine.fr/seance/salle_gen_csalle=C0099.html' } };
+      mockReq = { body: { id: 'C0099', url: 'https://www.allocine.fr/seance/salle_gen_csalle=C0099.html' }, app: mockApp };
 
       const handler = getRouteHandler('/', 'post');
       await handler(mockReq, mockRes, mockNext);
@@ -83,7 +92,7 @@ describe('Routes - Cinemas', () => {
     });
 
     it('should return 400 when url is missing', async () => {
-      mockReq = { body: { id: 'C0099', name: 'New Cinema' } };
+      mockReq = { body: { id: 'C0099', name: 'New Cinema' }, app: mockApp };
 
       const handler = getRouteHandler('/', 'post');
       await handler(mockReq, mockRes, mockNext);
@@ -92,7 +101,7 @@ describe('Routes - Cinemas', () => {
     });
 
     it('should return 400 when url is invalid', async () => {
-      mockReq = { body: { id: 'C0099', name: 'New Cinema', url: 'https://example.com' } };
+      mockReq = { body: { id: 'C0099', name: 'New Cinema', url: 'https://example.com' }, app: mockApp };
 
       const handler = getRouteHandler('/', 'post');
       await handler(mockReq, mockRes, mockNext);
@@ -102,7 +111,7 @@ describe('Routes - Cinemas', () => {
     });
 
     it('should return 409 on duplicate cinema id', async () => {
-      mockReq = { body: { id: 'W7504', name: 'Duplicate', url: 'https://www.allocine.fr/seance/salle_affich-salle=W7504.html' } };
+      mockReq = { body: { id: 'W7504', name: 'Duplicate', url: 'https://www.allocine.fr/seance/salle_affich-salle=W7504.html' }, app: mockApp };
       (cinemaConfig.addCinemaWithSync as any).mockRejectedValue(new Error('duplicate key value violates unique constraint'));
 
       const handler = getRouteHandler('/', 'post');
@@ -113,7 +122,7 @@ describe('Routes - Cinemas', () => {
     });
 
     it('should call next(error) on unexpected error', async () => {
-      mockReq = { body: { id: 'C0099', name: 'New Cinema', url: 'https://www.allocine.fr/seance/salle_gen_csalle=C0099.html' } };
+      mockReq = { body: { id: 'C0099', name: 'New Cinema', url: 'https://www.allocine.fr/seance/salle_gen_csalle=C0099.html' }, app: mockApp };
       const error = new Error('Unexpected DB error');
       (cinemaConfig.addCinemaWithSync as any).mockRejectedValue(error);
 
@@ -126,7 +135,7 @@ describe('Routes - Cinemas', () => {
 
   describe('PUT /:id', () => {
     it('should update a cinema and return the updated record', async () => {
-      mockReq = { params: { id: 'W7504' }, body: { name: 'Updated Name', url: 'https://www.allocine.fr/new-url.html' } };
+      mockReq = { params: { id: 'W7504' }, body: { name: 'Updated Name', url: 'https://www.allocine.fr/new-url.html' }, app: mockApp };
       const updated = { id: 'W7504', name: 'Updated Name', url: 'https://www.allocine.fr/new-url.html' };
       (cinemaConfig.updateCinemaWithSync as any).mockResolvedValue(updated);
 
@@ -138,7 +147,7 @@ describe('Routes - Cinemas', () => {
     });
 
     it('should return 400 when body is empty', async () => {
-      mockReq = { params: { id: 'W7504' }, body: {} };
+      mockReq = { params: { id: 'W7504' }, body: {}, app: mockApp };
 
       const handler = getRouteHandler('/:id', 'put');
       await handler(mockReq, mockRes, mockNext);
@@ -147,7 +156,7 @@ describe('Routes - Cinemas', () => {
     });
 
     it('should return 400 when url is invalid', async () => {
-      mockReq = { params: { id: 'W7504' }, body: { url: 'https://example.com' } };
+      mockReq = { params: { id: 'W7504' }, body: { url: 'https://example.com' }, app: mockApp };
 
       const handler = getRouteHandler('/:id', 'put');
       await handler(mockReq, mockRes, mockNext);
@@ -157,7 +166,7 @@ describe('Routes - Cinemas', () => {
     });
 
     it('should return 404 when cinema not found', async () => {
-      mockReq = { params: { id: 'UNKNOWN' }, body: { name: 'X' } };
+      mockReq = { params: { id: 'UNKNOWN' }, body: { name: 'X' }, app: mockApp };
       (cinemaConfig.updateCinemaWithSync as any).mockResolvedValue(undefined);
 
       const handler = getRouteHandler('/:id', 'put');
@@ -168,7 +177,7 @@ describe('Routes - Cinemas', () => {
     });
 
     it('should call next(error) on unexpected error', async () => {
-      mockReq = { params: { id: 'W7504' }, body: { name: 'X' } };
+      mockReq = { params: { id: 'W7504' }, body: { name: 'X' }, app: mockApp };
       const error = new Error('DB Error');
       (cinemaConfig.updateCinemaWithSync as any).mockRejectedValue(error);
 
@@ -181,7 +190,7 @@ describe('Routes - Cinemas', () => {
 
   describe('DELETE /:id', () => {
     it('should delete a cinema and return 204', async () => {
-      mockReq = { params: { id: 'W7504' } };
+      mockReq = { params: { id: 'W7504' }, app: mockApp };
       (cinemaConfig.deleteCinemaWithSync as any).mockResolvedValue(true);
 
       const handler = getRouteHandler('/:id', 'delete');
@@ -193,7 +202,7 @@ describe('Routes - Cinemas', () => {
     });
 
     it('should return 404 when cinema not found', async () => {
-      mockReq = { params: { id: 'UNKNOWN' } };
+      mockReq = { params: { id: 'UNKNOWN' }, app: mockApp };
       (cinemaConfig.deleteCinemaWithSync as any).mockResolvedValue(false);
 
       const handler = getRouteHandler('/:id', 'delete');
@@ -204,7 +213,7 @@ describe('Routes - Cinemas', () => {
     });
 
     it('should call next(error) on unexpected error', async () => {
-      mockReq = { params: { id: 'W7504' } };
+      mockReq = { params: { id: 'W7504' }, app: mockApp };
       const error = new Error('DB Error');
       (cinemaConfig.deleteCinemaWithSync as any).mockRejectedValue(error);
 
@@ -217,7 +226,7 @@ describe('Routes - Cinemas', () => {
 
   describe('GET /sync', () => {
     it('should sync cinemas from DB to JSON and return count', async () => {
-      mockReq = {};
+      mockReq = { app: mockApp };
       (cinemaConfig.syncCinemasFromDatabase as any).mockResolvedValue(3);
 
       const handler = getRouteHandler('/sync', 'get');
@@ -234,7 +243,7 @@ describe('Routes - Cinemas', () => {
     });
 
     it('should call next(error) on sync failure', async () => {
-      mockReq = {};
+      mockReq = { app: mockApp };
       const error = new Error('Sync Error');
       (cinemaConfig.syncCinemasFromDatabase as any).mockRejectedValue(error);
 

--- a/server/src/routes/cinemas.ts
+++ b/server/src/routes/cinemas.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { db } from '../db/client.js';
+import type { DB } from '../db/client.js';
 import { getCinemas, getShowtimesByCinemaAndWeek } from '../db/queries.js';
 import { getWeekStart } from '../utils/date.js';
 import { addCinemaAndScrape } from '../services/scraper/index.js';
@@ -17,8 +17,9 @@ import { requireAuth } from '../middleware/auth.js';
 const router = express.Router();
 
 // GET /api/cinemas - Get all cinemas
-router.get('/', publicLimiter, async (_req, res, next) => {
+router.get('/', publicLimiter, async (req, res, next) => {
   try {
+    const db: DB = req.app.get('db');
     const cinemas = await getCinemas(db);
 
     const response: ApiResponse = {
@@ -35,6 +36,7 @@ router.get('/', publicLimiter, async (_req, res, next) => {
 // POST /api/cinemas - Add a new cinema
 router.post('/', requireAuth, protectedLimiter, async (req, res, next) => {
   try {
+    const db: DB = req.app.get('db');
     const { id, name, url } = req.body;
 
     // Smart add via URL only
@@ -135,6 +137,7 @@ router.post('/', requireAuth, protectedLimiter, async (req, res, next) => {
 // PUT /api/cinemas/:id - Update a cinema's name and/or URL
 router.put('/:id', requireAuth, protectedLimiter, async (req, res, next) => {
   try {
+    const db: DB = req.app.get('db');
     const cinemaId = req.params.id;
     const { name, url } = req.body;
 
@@ -198,6 +201,7 @@ router.put('/:id', requireAuth, protectedLimiter, async (req, res, next) => {
 // DELETE /api/cinemas/:id - Delete a cinema (cascades to showtimes and weekly_programs)
 router.delete('/:id', requireAuth, protectedLimiter, async (req, res, next) => {
   try {
+    const db: DB = req.app.get('db');
     const cinemaId = req.params.id;
     const deleted = await deleteCinemaWithSync(db, cinemaId);
 
@@ -216,8 +220,9 @@ router.delete('/:id', requireAuth, protectedLimiter, async (req, res, next) => {
 });
 
 // GET /api/cinemas/sync - Manual sync from database to JSON file
-router.get('/sync', requireAuth, protectedLimiter, async (_req, res, next) => {
+router.get('/sync', requireAuth, protectedLimiter, async (req, res, next) => {
   try {
+    const db: DB = req.app.get('db');
     const count = await syncCinemasFromDatabase(db);
 
     const response: ApiResponse = {
@@ -237,6 +242,7 @@ router.get('/sync', requireAuth, protectedLimiter, async (_req, res, next) => {
 // GET /api/cinemas/:id - Get cinema schedule
 router.get('/:id', publicLimiter, async (req, res, next) => {
   try {
+    const db: DB = req.app.get('db');
     const cinemaId = req.params.id;
     const weekStart = getWeekStart();
 

--- a/server/src/routes/cinemas.validation.test.ts
+++ b/server/src/routes/cinemas.validation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as cinemaConfig from '../services/cinema-config.js';
 import router from './cinemas.js';
+import { db } from '../db/client.js';
 
 // Mock dependencies
 vi.mock('../db/client.js', () => ({
@@ -32,9 +33,16 @@ describe('Routes - Cinemas - Validation', () => {
   let mockRes: any;
   let mockReq: any;
   let mockNext: any;
+  let mockApp: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockApp = {
+      get: vi.fn((key: string) => {
+        if (key === 'db') return db;
+        return undefined;
+      })
+    };
     mockRes = {
       json: vi.fn().mockReturnThis(),
       status: vi.fn().mockReturnThis()
@@ -50,7 +58,8 @@ describe('Routes - Cinemas - Validation', () => {
         id: 'invalid-id!',
         name: 'Test Cinema',
         url: 'https://www.allocine.fr/test'
-      }
+      },
+      app: mockApp
     };
 
     const handler = getRouteHandler('/', 'post');
@@ -70,7 +79,8 @@ describe('Routes - Cinemas - Validation', () => {
         id: 'A'.repeat(21),
         name: 'Test Cinema',
         url: 'https://www.allocine.fr/test'
-      }
+      },
+      app: mockApp
     };
 
     const handler = getRouteHandler('/', 'post');
@@ -89,7 +99,8 @@ describe('Routes - Cinemas - Validation', () => {
         id: 'C001',
         name: 'A'.repeat(101),
         url: 'https://www.allocine.fr/test'
-      }
+      },
+      app: mockApp
     };
 
     const handler = getRouteHandler('/', 'post');
@@ -107,7 +118,8 @@ describe('Routes - Cinemas - Validation', () => {
       params: { id: 'C001' },
       body: {
         name: 'A'.repeat(101)
-      }
+      },
+      app: mockApp
     };
 
     const handler = getRouteHandler('/:id', 'put');


### PR DESCRIPTION
## Summary
- Replace direct db import with dependency injection pattern in cinemas routes
- Update all 6 route handlers to use `req.app.get('db')`
  - GET / (get all cinemas)
  - POST / (add cinema)
  - PUT /:id (update cinema)
  - DELETE /:id (delete cinema)
  - GET /sync (sync cinemas from DB to JSON)
  - GET /:id (get cinema schedule)
- Update 3 test files with `mockApp.get('db')` pattern
  - cinemas.test.ts (17 tests)
  - cinemas.validation.test.ts (4 tests)
  - cinemas.security.test.ts (1 test)
- All 532 tests passing ✅

## Testing
- ✅ All 22 cinemas route tests passing (17 + 4 + 1)
- ✅ All 532 server tests passing
- ✅ TypeScript compilation successful
- ✅ Docker build verified

Closes #219