### PR TITLE
refactor(reports): migrate reports routes to use req.app.get('db')

### DIFF
--- a/server/src/routes/reports.test.ts
+++ b/server/src/routes/reports.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import router from './reports.js';
 import * as queries from '../db/queries.js';
+import { db } from '../db/client.js';
 
 // Mock dependencies
 vi.mock('../middleware/auth.js', () => ({
@@ -34,9 +35,16 @@ describe('Routes - Reports', () => {
   let mockRes: any;
   let mockReq: any;
   let mockNext: any;
+  let mockApp: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockApp = {
+      get: vi.fn((key: string) => {
+        if (key === 'db') return db;
+        return undefined;
+      })
+    };
     mockRes = {
       json: vi.fn().mockReturnThis(),
       status: vi.fn().mockReturnThis(),
@@ -50,7 +58,8 @@ describe('Routes - Reports', () => {
         query: {
           page: '1',
           pageSize: '1000' // Requesting excessive page size
-        }
+        },
+        app: mockApp
       };
 
       (queries.getScrapeReports as any).mockResolvedValue({ reports: [], total: 0 });
@@ -67,7 +76,8 @@ describe('Routes - Reports', () => {
 
     it('should use default pageSize of 20 if not provided', async () => {
       mockReq = {
-        query: {}
+        query: {},
+        app: mockApp
       };
 
       (queries.getScrapeReports as any).mockResolvedValue({ reports: [], total: 0 });
@@ -84,7 +94,8 @@ describe('Routes - Reports', () => {
       mockReq = {
         query: {
           page: '-5'
-        }
+        },
+        app: mockApp
       };
 
       (queries.getScrapeReports as any).mockResolvedValue({ reports: [], total: 0 });

--- a/server/src/routes/reports.ts
+++ b/server/src/routes/reports.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { db } from '../db/client.js';
+import type { DB } from '../db/client.js';
 import { getScrapeReports, getScrapeReport } from '../db/queries.js';
 import type { ApiResponse, PaginatedResponse, GetReportsQuery } from '../types/api.js';
 import type { ScrapeReport } from '../db/queries.js';
@@ -12,6 +12,7 @@ const router = express.Router();
 // GET /api/reports - Get all scrape reports (paginated)
 router.get('/', requireAuth, protectedLimiter, async (req, res) => {
   try {
+    const db: DB = req.app.get('db');
     const query = req.query as GetReportsQuery;
     let page = parseInt(query.page || '1');
     let pageSize = parseInt(query.pageSize || '20');
@@ -62,6 +63,7 @@ router.get('/', requireAuth, protectedLimiter, async (req, res) => {
 // GET /api/reports/:id - Get a specific report
 router.get('/:id', requireAuth, protectedLimiter, async (req, res) => {
   try {
+    const db: DB = req.app.get('db');
     const reportId = parseInt(req.params.id);
 
     if (isNaN(reportId)) {


### PR DESCRIPTION
## Summary
- Replace direct db import with dependency injection via `req.app.get('db')` in reports routes
- Update route handlers: `GET /` (list reports) and `GET /:id` (get report by ID)
- Update tests to include `mockApp` with `get('db')` method in `mockReq`

## Changes
- **server/src/routes/reports.ts**: Refactored 2 route handlers to use DI pattern
- **server/src/routes/reports.test.ts**: Updated 3 tests with `mockApp` pattern

## Testing
- ✅ All 532 tests pass
- ✅ TypeScript compilation succeeds
- ✅ Docker build succeeds

## Related
Closes #220
Part of Phase 2 (#215) - Database access standardization