### PR TITLE
⚡ Bolt: Optimize React re-renders in HomePage and CinemaPage

### DIFF
--- a/client/src/components/CinemaDateSelector.tsx
+++ b/client/src/components/CinemaDateSelector.tsx
@@ -1,0 +1,56 @@
+import { memo } from 'react';
+import type { ShowtimeWithFilm } from '../types';
+
+interface CinemaDateSelectorProps {
+  dates: string[];
+  selectedDate: string;
+  showtimes: ShowtimeWithFilm[];
+  onSelectDate: (date: string) => void;
+  formatDateLabel: (dateStr: string) => { weekday: string; day: number; month: string };
+}
+
+function CinemaDateSelector({ dates, selectedDate, showtimes, onSelectDate, formatDateLabel }: CinemaDateSelectorProps) {
+  if (dates.length === 0) return null;
+
+  return (
+    <div className="mb-8 overflow-x-auto pb-2 -mx-4 px-4 md:mx-0 md:px-0">
+      <div className="flex gap-2 min-w-max">
+        {dates.map((date) => {
+          const label = formatDateLabel(date);
+          const isActive = date === selectedDate;
+          const dateShowtimes = showtimes.filter(s => s.date === date);
+          const hasShowtimes = dateShowtimes.length > 0;
+
+          return (
+            <button
+              key={date}
+              onClick={() => onSelectDate(date)}
+              className={`
+                px-4 py-3 rounded-xl border-2 transition-all text-center min-w-[90px] group cursor-pointer active:scale-95
+                ${isActive
+                  ? 'border-primary bg-yellow-50 text-black shadow-sm'
+                  : 'border-transparent bg-white text-gray-600 hover:bg-gray-50'
+                }
+                ${!hasShowtimes && !isActive ? 'opacity-50' : ''}
+              `}
+            >
+              <div className={`text-xs uppercase font-bold mb-0.5 ${isActive ? 'text-primary-dark' : 'text-gray-400 group-hover:text-gray-600'}`}>
+                {label.weekday}
+              </div>
+              <div className="text-lg font-bold leading-none">
+                {label.day}
+              </div>
+              <div className="text-[10px] text-gray-400 mt-1">
+                {label.month}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ⚡ PERFORMANCE: Memoize component to prevent re-renders when parent re-renders
+// but selectedDate and showtimes haven't changed.
+export default memo(CinemaDateSelector);

--- a/client/src/components/CinemasQuickLinks.tsx
+++ b/client/src/components/CinemasQuickLinks.tsx
@@ -1,0 +1,40 @@
+import { memo } from 'react';
+import { Link } from 'react-router-dom';
+import type { Cinema } from '../types';
+
+interface CinemasQuickLinksProps {
+  cinemas: Cinema[];
+  isAuthenticated: boolean;
+  onAddCinema: () => void;
+}
+
+function CinemasQuickLinks({ cinemas, isAuthenticated, onAddCinema }: CinemasQuickLinksProps) {
+  return (
+    <div className="bg-white rounded-xl border border-gray-100 p-4 shadow-sm mb-10">
+      <h2 className="text-xs font-bold text-gray-400 uppercase mb-3 px-1">Accès rapide par cinéma</h2>
+      <div className="flex flex-wrap gap-2">
+        {cinemas.map((cinema) => (
+          <Link
+            key={cinema.id}
+            to={`/cinema/${cinema.id}`}
+            className="px-3 py-1.5 bg-gray-50 text-gray-700 text-sm rounded-lg hover:bg-primary hover:text-black transition font-semibold"
+          >
+            {cinema.name}
+          </Link>
+        ))}
+        {isAuthenticated && (
+          <button
+            onClick={onAddCinema}
+            className="px-3 py-1.5 bg-white border border-dashed border-gray-300 text-gray-500 text-sm rounded-lg hover:border-primary hover:text-primary transition font-semibold cursor-pointer active:scale-95"
+          >
+            + Ajouter un cinéma
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ⚡ PERFORMANCE: Memoize component to prevent re-renders when parent re-renders
+// but cinemas and isAuthenticated haven't changed.
+export default memo(CinemasQuickLinks);

--- a/client/src/components/DaySelector.tsx
+++ b/client/src/components/DaySelector.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, memo } from 'react';
 
 interface DaySelectorProps {
   weekStart: string;
@@ -6,7 +6,7 @@ interface DaySelectorProps {
   onSelectDate: (date: string | null) => void;
 }
 
-export default function DaySelector({ weekStart, selectedDate, onSelectDate }: DaySelectorProps) {
+function DaySelector({ weekStart, selectedDate, onSelectDate }: DaySelectorProps) {
   const days = useMemo(() => {
     if (!weekStart) return [];
     
@@ -58,3 +58,7 @@ export default function DaySelector({ weekStart, selectedDate, onSelectDate }: D
     </div>
   );
 }
+
+// ⚡ PERFORMANCE: Memoize component to prevent re-renders when parent re-renders
+// but selectedDate and weekStart haven't changed.
+export default memo(DaySelector);

--- a/client/src/pages/CinemaPage.tsx
+++ b/client/src/pages/CinemaPage.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { getCinemas, getCinemaSchedule, triggerCinemaScrape, getScrapeStatus } from '../api/client';
 import type { Cinema, ShowtimeWithFilm } from '../types';
 import ShowtimeList from '../components/ShowtimeList';
 import ScrapeButton from '../components/ScrapeButton';
 import ScrapeProgress from '../components/ScrapeProgress';
+import CinemaDateSelector from '../components/CinemaDateSelector';
 
 interface FilmGroup {
   film: {
@@ -94,14 +95,14 @@ export default function CinemaPage() {
     return Array.from(filmMap.values());
   };
 
-  const formatDateLabel = (dateStr: string) => {
+  const formatDateLabel = useCallback((dateStr: string) => {
     const date = new Date(dateStr + 'T00:00:00');
     return {
       weekday: date.toLocaleDateString('fr-FR', { weekday: 'short' }).replace('.', ''),
       day: date.getDate(),
       month: date.toLocaleDateString('fr-FR', { month: 'short' }),
     };
-  };
+  }, []);
 
   const handleScrapeStart = () => {
     setShowProgress(true);
@@ -187,43 +188,13 @@ export default function CinemaPage() {
       </div>
 
       {/* Date Selector */}
-      {dates.length > 0 && (
-        <div className="mb-8 overflow-x-auto pb-2 -mx-4 px-4 md:mx-0 md:px-0">
-          <div className="flex gap-2 min-w-max">
-            {dates.map((date) => {
-              const label = formatDateLabel(date);
-              const isActive = date === selectedDate;
-              const dateShowtimes = showtimes.filter(s => s.date === date);
-              const hasShowtimes = dateShowtimes.length > 0;
-
-              return (
-                <button
-                  key={date}
-                  onClick={() => setSelectedDate(date)}
-                  className={`
-                    px-4 py-3 rounded-xl border-2 transition-all text-center min-w-[90px] group cursor-pointer active:scale-95
-                    ${isActive 
-                      ? 'border-primary bg-yellow-50 text-black shadow-sm' 
-                      : 'border-transparent bg-white text-gray-600 hover:bg-gray-50'
-                    }
-                    ${!hasShowtimes && !isActive ? 'opacity-50' : ''}
-                  `}
-                >
-                  <div className={`text-xs uppercase font-bold mb-0.5 ${isActive ? 'text-primary-dark' : 'text-gray-400 group-hover:text-gray-600'}`}>
-                    {label.weekday}
-                  </div>
-                  <div className="text-lg font-bold leading-none">
-                    {label.day}
-                  </div>
-                  <div className="text-[10px] text-gray-400 mt-1">
-                    {label.month}
-                  </div>
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      )}
+      <CinemaDateSelector
+        dates={dates}
+        selectedDate={selectedDate}
+        showtimes={showtimes}
+        onSelectDate={setSelectedDate}
+        formatDateLabel={formatDateLabel}
+      />
 
       {/* Films List for Selected Date */}
       <div className="min-h-[300px]">

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, useContext } from 'react';
-import { Link } from 'react-router-dom';
+import { useEffect, useState, useContext, useCallback } from 'react';
+
 import { getWeeklyFilms, getFilmsByDate, getCinemas, getScrapeStatus, addCinema, triggerScrape } from '../api/client';
 import type { FilmWithShowtimes, Cinema } from '../types';
 import FilmCard from '../components/FilmCard';
@@ -9,6 +9,7 @@ import DaySelector from '../components/DaySelector';
 import FilmSearchBar from '../components/FilmSearchBar';
 import ScrollToTop from '../components/ScrollToTop';
 import { AuthContext } from '../contexts/AuthContext';
+import CinemasQuickLinks from '../components/CinemasQuickLinks';
 
 export default function HomePage() {
   const [films, setFilms] = useState<FilmWithShowtimes[]>([]);
@@ -50,9 +51,9 @@ export default function HomePage() {
     loadData(selectedDate);
   }, [selectedDate]);
 
-  const handleDateSelect = (date: string | null) => {
+  const handleDateSelect = useCallback((date: string | null) => {
     setSelectedDate(date);
-  };
+  }, []);
 
   const formatDate = (dateStr: string) => {
     if (!dateStr) return '';
@@ -84,7 +85,7 @@ export default function HomePage() {
     }, 2000);
   };
 
-  const handleAddCinema = async () => {
+  const handleAddCinema = useCallback(async () => {
     const url = window.prompt("Entrez l'URL Allociné du cinéma à ajouter (ex: https://www.allocine.fr/seance/salle_affich-salle=C0013.html):");
     if (!url) return;
 
@@ -96,7 +97,7 @@ export default function HomePage() {
       setShowProgress(false);
       setError(err.message || 'Erreur lors de l\'ajout du cinéma');
     }
-  };
+  }, []);
 
   if (isLoading) {
     return (
@@ -172,28 +173,11 @@ export default function HomePage() {
       </div>
 
       {/* Quick Cinema Links - Below sticky header */}
-      <div className="bg-white rounded-xl border border-gray-100 p-4 shadow-sm mb-10">
-        <h2 className="text-xs font-bold text-gray-400 uppercase mb-3 px-1">Accès rapide par cinéma</h2>
-        <div className="flex flex-wrap gap-2">
-          {cinemas.map((cinema) => (
-            <Link
-              key={cinema.id}
-              to={`/cinema/${cinema.id}`}
-              className="px-3 py-1.5 bg-gray-50 text-gray-700 text-sm rounded-lg hover:bg-primary hover:text-black transition font-semibold"
-            >
-              {cinema.name}
-            </Link>
-          ))}
-          {isAuthenticated && (
-            <button
-              onClick={handleAddCinema}
-              className="px-3 py-1.5 bg-white border border-dashed border-gray-300 text-gray-500 text-sm rounded-lg hover:border-primary hover:text-primary transition font-semibold cursor-pointer active:scale-95"
-            >
-              + Ajouter un cinéma
-            </button>
-          )}
-        </div>
-      </div>
+      <CinemasQuickLinks
+        cinemas={cinemas}
+        isAuthenticated={isAuthenticated}
+        onAddCinema={handleAddCinema}
+      />
 
       {/* Films List */}
       <div className="space-y-8">


### PR DESCRIPTION
⚡ Bolt: Optimize React re-renders in HomePage and CinemaPage

💡 What:
- Extracted inline components like mapping over cinemas in `HomePage` into `CinemasQuickLinks` and wrapped it in `React.memo()`.
- Extracted inline rendering of date buttons in `CinemaPage` into `CinemaDateSelector` and wrapped it in `React.memo()`.
- Wrapped `DaySelector` in `React.memo()`.
- Added `useCallback()` to `handleDateSelect` in `HomePage.tsx` and `formatDateLabel` in `CinemaPage.tsx` to prevent invalidating memoized children components during unrelated state changes (like scraper progress ticks).

🎯 Why:
The `HomePage` and `CinemaPage` components experience frequent re-renders due to scraping progress updates (`showProgress`). This causes all their children, including expensive mapped lists and date selectors, to re-render unnecessarily.

📊 Impact:
Significantly reduces re-renders of the quick cinema links and date selectors on the main pages during background scraping and other state updates, leading to a smoother user experience and less CPU overhead.

🔬 Measurement:
Run the tests locally (`cd client && npm test`). You can also start the dev server and observe the React DevTools Profiler while triggering a scrape to see that `DaySelector`, `CinemasQuickLinks`, and `CinemaDateSelector` no longer re-render on every progress tick.

---
*PR created automatically by Jules for task [9468755313965617665](https://jules.google.com/task/9468755313965617665) started by @PhBassin*