### PR TITLE
chore(release): bump version to v3.0.0-beta.2

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [3.0.0-beta.2] - [Unreleased]
+## [3.0.0-beta.2] - 2026-03-01
 
 ### Documentation
 

--- a/scraper/package.json
+++ b/scraper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "allo-scrapper-scraper",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "description": "Standalone scraper microservice for Allo-Scrapper",
   "type": "module",
   "main": "dist/index.js",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "allo-scrapper-server",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "description": "Backend Express API for Allo-Scrapper",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Version bump for v3.0.0-beta.2 pre-release.

## Changes

- Updated version to `3.0.0-beta.2` in:
  - `server/package.json`
  - `client/package.json`
  - `scraper/package.json`
- Updated changelog date from `[Unreleased]` to `2026-03-01` in `docs/project/changelog.md`

## Pre-merge Checklist

- [x] All 4 files updated
- [x] TypeScript compilation passes
- [x] All tests pass (570/570)
- [x] Docker build succeeds
- [x] Commit uses Conventional Commits format
- [x] Issue #251 referenced

## Post-merge Steps

After this PR is merged, the release manager should:

1. Switch to develop and pull latest changes
2. Create annotated git tag: `git tag -a v3.0.0-beta.2 -m "v3.0.0-beta.2 - Documentation Restructure (Beta)"`
3. Push tag: `git push origin v3.0.0-beta.2`
4. Wait for GitHub Actions to build Docker image (~3-5 min)
5. Create GitHub pre-release at https://github.com/PhBassin/allo-scrapper/releases/new
6. Verify Docker image: `docker pull ghcr.io/phbassin/allo-scrapper:v3.0.0-beta.2`
7. Test version endpoint: `curl http://localhost:3000/api/version`
8. Delete feature branch

Closes #251