### PR TITLE
refactor(routes/scraper): replace *WithSync calls with direct DB queries, remove GET /sync

### DIFF
--- a/server/src/routes/cinemas.security.test.ts
+++ b/server/src/routes/cinemas.security.test.ts
@@ -97,12 +97,6 @@ describe('Routes - Cinemas - Security', () => {
       expect(names).toContain('requireAdmin');
     });
 
-    it('GET /sync should require both requireAuth and requireAdmin middleware', () => {
-      const names = getMiddlewareNames('/sync', 'get');
-      expect(names).toContain('requireAuth');
-      expect(names).toContain('requireAdmin');
-    });
-
     it('GET / should NOT require authentication', () => {
       const names = getMiddlewareNames('/', 'get');
       expect(names).not.toContain('requireAuth');

--- a/server/src/routes/cinemas.test.ts
+++ b/server/src/routes/cinemas.test.ts
@@ -52,7 +52,7 @@ describe('Routes - Cinemas', () => {
   });
 
   describe('POST /', () => {
-    it.skip('should create a new cinema and return 201', async () => { // pending #277 — route still calls addCinemaWithSync
+    it('should create a new cinema and return 201', async () => {
       mockReq = {
         body: { id: 'C0099', name: 'New Cinema', url: 'https://www.allocine.fr/seance/salle_gen_csalle=C0099.html' },
         app: mockApp
@@ -130,7 +130,7 @@ describe('Routes - Cinemas', () => {
   });
 
   describe('PUT /:id', () => {
-    it.skip('should update a cinema and return the updated record', async () => { // pending #277 — route still calls updateCinemaWithSync
+    it('should update a cinema and return the updated record', async () => {
       mockReq = { params: { id: 'W7504' }, body: { name: 'Updated Name', url: 'https://www.allocine.fr/new-url.html' }, app: mockApp };
       const updated = { id: 'W7504', name: 'Updated Name', url: 'https://www.allocine.fr/new-url.html' };
       (queries.updateCinemaConfig as any).mockResolvedValue(updated);
@@ -185,7 +185,7 @@ describe('Routes - Cinemas', () => {
   });
 
   describe('DELETE /:id', () => {
-    it.skip('should delete a cinema and return 204', async () => { // pending #277 — route still calls deleteCinemaWithSync
+    it('should delete a cinema and return 204', async () => {
       mockReq = { params: { id: 'W7504' }, app: mockApp };
       (queries.deleteCinema as any).mockResolvedValue(true);
 

--- a/server/src/routes/cinemas.ts
+++ b/server/src/routes/cinemas.ts
@@ -1,15 +1,9 @@
 import express from 'express';
 import type { DB } from '../db/client.js';
-import { getCinemas, getShowtimesByCinemaAndWeek } from '../db/queries.js';
+import { getCinemas, getShowtimesByCinemaAndWeek, addCinema, updateCinemaConfig, deleteCinema } from '../db/queries.js';
 import { getWeekStart } from '../utils/date.js';
 import { addCinemaAndScrape } from '../services/scraper/index.js';
 import { isValidAllocineUrl } from '../services/scraper/utils.js';
-import {
-  addCinemaWithSync,
-  updateCinemaWithSync,
-  deleteCinemaWithSync,
-  syncCinemasFromDatabase,
-} from '../services/cinema-config.js';
 import type { ApiResponse } from '../types/api.js';
 import { publicLimiter, protectedLimiter } from '../middleware/rate-limit.js';
 import { requireAuth } from '../middleware/auth.js';
@@ -115,7 +109,7 @@ router.post('/', requireAuth, requireAdmin, protectedLimiter, async (req, res, n
       return res.status(400).json(response);
     }
 
-    const cinema = await addCinemaWithSync(db, { id, name, url });
+    const cinema = await addCinema(db, { id, name, url });
 
     const response: ApiResponse = {
       success: true,
@@ -178,7 +172,7 @@ router.put('/:id', requireAuth, requireAdmin, protectedLimiter, async (req, res,
     if (name) updates.name = name;
     if (url) updates.url = url;
 
-    const cinema = await updateCinemaWithSync(db, cinemaId, updates);
+    const cinema = await updateCinemaConfig(db, cinemaId, updates);
 
     if (!cinema) {
       const response: ApiResponse = {
@@ -204,7 +198,7 @@ router.delete('/:id', requireAuth, requireAdmin, protectedLimiter, async (req, r
   try {
     const db: DB = req.app.get('db');
     const cinemaId = req.params.id;
-    const deleted = await deleteCinemaWithSync(db, cinemaId);
+    const deleted = await deleteCinema(db, cinemaId);
 
     if (!deleted) {
       const response: ApiResponse = {
@@ -215,26 +209,6 @@ router.delete('/:id', requireAuth, requireAdmin, protectedLimiter, async (req, r
     }
 
     return res.status(204).send();
-  } catch (error) {
-    return next(error);
-  }
-});
-
-// GET /api/cinemas/sync - Manual sync from database to JSON file
-router.get('/sync', requireAuth, requireAdmin, protectedLimiter, async (req, res, next) => {
-  try {
-    const db: DB = req.app.get('db');
-    const count = await syncCinemasFromDatabase(db);
-
-    const response: ApiResponse = {
-      success: true,
-      data: {
-        count,
-        message: `Synced ${count} cinema(s) to JSON file`,
-      },
-    };
-
-    return res.json(response);
   } catch (error) {
     return next(error);
   }

--- a/server/src/services/scraper/index.test.ts
+++ b/server/src/services/scraper/index.test.ts
@@ -24,11 +24,6 @@ vi.mock('../../db/queries.js', () => ({
   getCinemaConfigs: vi.fn(),
 }));
 
-// Mock cinema-config
-vi.mock('../cinema-config.js', () => ({
-  syncCinemasFromDatabase: vi.fn(),
-}));
-
 describe('addCinemaAndScrape', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -51,7 +46,7 @@ describe('addCinemaAndScrape', () => {
       expect.objectContaining({
         id: 'W7517',
         name: 'Club de l Etoile',
-        url: mockUrl, // This is expected to fail currently
+        url: mockUrl,
       })
     );
 

--- a/server/src/services/scraper/index.ts
+++ b/server/src/services/scraper/index.ts
@@ -195,10 +195,7 @@ export async function addCinemaAndScrape(
 
   await closeBrowser();
 
-  // 5. Sync cinemas to JSON file after successful scrape
-  const { syncCinemasFromDatabase } = await import('../cinema-config.js');
-  await syncCinemasFromDatabase(db);
-  logger.info('✅ Cinema added and synced to JSON file');
+  logger.info('✅ Cinema added successfully');
 
   return cinema;
 }


### PR DESCRIPTION
## Summary

- `routes/cinemas.ts`: replace `addCinemaWithSync` / `updateCinemaWithSync` / `deleteCinemaWithSync` with `addCinema` / `updateCinemaConfig` / `deleteCinema` from `db/queries`; remove `GET /sync` route; remove `cinema-config` import entirely
- `scraper/index.ts`: remove `syncCinemasFromDatabase` dynamic import call after `addCinemaAndScrape`; `cinema-config` is no longer invoked at runtime
- `scraper/index.test.ts`: remove dead `vi.mock('../cinema-config.js')` block (closes #276)
- `cinemas.test.ts`: un-skip 3 happy-path tests that are now green
- `cinemas.security.test.ts`: remove test for deleted `GET /sync` route

Closes #277
refs #276
refs #274