### PR TITLE
docs: add sharp dependency installation instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,8 +311,17 @@ allo-scrapper/
 ### Setup (run once after cloning)
 
 ```bash
-./scripts/install-hooks.sh   # Install git hooks (pre-push: tsc + tests)
+# Install git hooks (pre-push: tsc + tests)
+./scripts/install-hooks.sh
+
+# Install dependencies (CRITICAL: run from server/ directory)
+cd server && npm install
+
+# Install client dependencies
+cd ../client && npm install
 ```
+
+**⚠️ Always run `npm install` from `server/` directory, not root.** See "Native Dependencies" gotcha below.
 
 ### Development
 
@@ -487,6 +496,36 @@ The `Cinema` interface in `client/src/types/index.ts` must include `url?: string
 ### Pre-Push Hook
 
 A git pre-push hook runs `tsc --noEmit` + `vitest run` before every push. Fix all TypeScript errors and test failures before pushing — the hook will block the push otherwise.
+
+### Native Dependencies — `sharp` Package
+
+The `sharp` package is a native binary dependency used for image validation and compression in the white-label branding system (`server/src/utils/image-validator.ts`). It requires platform-specific binaries during installation.
+
+**Problem:** Tests fail with `Error: Cannot find package 'sharp'` if:
+- `npm install` was run from the wrong directory (root instead of `server/`)
+- Installation was interrupted mid-process
+- `node_modules/` was deleted or corrupted
+
+**Affected files:**
+- `server/src/routes/settings.ts` — imports `image-validator.ts`
+- `server/src/utils/image-validator.ts` — direct import
+- `server/src/utils/image-validator.test.ts` — test file
+
+**Solution:** Always run `npm install` from the `server/` directory:
+
+```bash
+cd server && npm install
+```
+
+If tests still fail after `npm install`:
+
+```bash
+cd server
+rm -rf node_modules
+npm install
+```
+
+**Why this happens:** `sharp` downloads native binaries during postinstall scripts. Running `npm install` from the root directory or interrupting the installation can result in incomplete or missing binaries, even though `package.json` and `package-lock.json` are correct.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -306,6 +306,53 @@ docker compose exec ics-web npm run db:migrate
 curl -X POST http://localhost:3000/api/scraper/trigger
 ```
 
+### Option C: Local Development (No Docker)
+
+For active development without Docker:
+
+**Prerequisites:**
+- Node.js 20.19+ or 22.12+
+- PostgreSQL 15+
+- Redis (optional, only if `USE_REDIS_SCRAPER=true`)
+
+**Setup:**
+```bash
+# Clone repository
+git clone https://github.com/PhBassin/allo-scrapper.git
+cd allo-scrapper
+
+# Install server dependencies (IMPORTANT: run from server/ directory)
+cd server
+npm install
+
+# Install client dependencies
+cd ../client
+npm install
+
+# Setup environment and database
+cd ../server
+cp .env.example .env
+# Edit .env with your PostgreSQL credentials
+npm run db:migrate
+
+# Run development servers (in separate terminals)
+# Terminal 1 - API server
+cd server && npm run dev    # API on http://localhost:3000
+
+# Terminal 2 - Frontend dev server
+cd client && npm run dev    # UI on http://localhost:5173
+```
+
+**⚠️ Important:** Always run `npm install` from the `server/` directory, not the root. The `sharp` image processing library requires native binaries that may not install correctly if run from the wrong directory.
+
+**Troubleshooting:**
+If you encounter `Cannot find package 'sharp'` errors:
+```bash
+cd server
+rm -rf node_modules
+npm install
+```
+
 For production deployment and advanced configuration, see [DEPLOYMENT.md](./DEPLOYMENT.md) and [DOCKER.md](./DOCKER.md).
 
 ---


### PR DESCRIPTION
## Summary

- Add **Option C: Local Development (No Docker)** to README.md with comprehensive setup instructions
- Document the `sharp` native dependency gotcha in AGENTS.md "Gotchas / Lessons Learned" section
- Add `npm install` commands to AGENTS.md setup section with warnings about correct directory
- Include troubleshooting steps for "Cannot find package 'sharp'" errors

## Changes

### README.md
- Added new "Option C: Local Development" section after "Option B: Building Locally"
- Includes prerequisites (Node.js 20.19+, PostgreSQL 15+, Redis optional)
- Step-by-step setup instructions emphasizing `cd server && npm install`
- Warning about running npm install from correct directory
- Troubleshooting section for sharp installation issues

### AGENTS.md
- Updated "Setup" section to include npm install commands
- Added warning to always run npm install from server/ directory
- Created new "Native Dependencies — sharp Package" gotcha section with:
  - Problem description
  - Affected files list
  - Solution with commands
  - Explanation of why this happens

## Testing

✅ All tests passing (569/569, 13 skipped)
✅ Documentation builds successfully
✅ No code changes, docs only

## Related

Closes #284

## Impact

Documentation only - helps new contributors and AI agents avoid the common pitfall of running `npm install` from the wrong directory, which causes `sharp` (native binary dependency) to fail.