### PR TITLE
🛡️ Sentinel: [HIGH] Fix rate limiting bypass in proxy environments

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -34,6 +34,9 @@ collectDefaultMetrics({ register: serverRegistry, prefix: 'ics_web_' });
 export function createApp() {
   const app = express();
 
+  // Trust the first proxy to ensure accurate IP resolution for rate limiting
+  app.set('trust proxy', 1);
+
   // Middleware
   app.use(
     helmet({


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix rate limiting bypass in proxy environments

🚨 Severity: HIGH
💡 Vulnerability: The `express-rate-limit` middleware relies on `req.ip` for rate limiting. When deployed behind a reverse proxy (like Docker or Nginx), without `trust proxy` configured, `req.ip` incorrectly resolves to the proxy's IP. This either rate limits all users as one (DoS) or allows users to bypass rate limits entirely via X-Forwarded-For spoofing.
🎯 Impact: Attackers can bypass rate limits (e.g., login brute-forcing or scraping endpoints).
🔧 Fix: Added `app.set('trust proxy', 1);` to correctly identify client IPs.
✅ Verification: Ran `npm run test` on the server and verified that the `trust proxy` configuration passes regression checks.

---
*PR created automatically by Jules for task [12713865262937101613](https://jules.google.com/task/12713865262937101613) started by @PhBassin*