### PR TITLE
docs: remove 18 root-level backward compatibility symlinks

### DIFF
--- a/.opencode/agents/docs-writer.md
+++ b/.opencode/agents/docs-writer.md
@@ -71,7 +71,7 @@ Root documentation files:
 - README.md              # Main entry point (features, architecture, quick start)
 - AGENTS.md              # AI agent workflow (TDD, Git, commits)
 - WHITE-LABEL.md         # White-label branding system
-- MONITORING.md          # Observability stack
+- docs/guides/deployment/monitoring.md  # Observability stack (symlink removed later)
 - [Other root .md files] # Specific topics
 ```
 
@@ -369,7 +369,7 @@ Before completing a documentation task, verify:
 - `AGENTS.md` — Development workflow (TDD, Git, PRs)
 - `README.md` — Project overview and architecture
 - `WHITE-LABEL.md` — Branding system details
-- `MONITORING.md` — Observability stack
+- `docs/guides/deployment/monitoring.md` — Observability stack
 - `docs/README.md` — Documentation structure index
 
 **When documenting new features:**

--- a/ADMIN_PANEL.md
+++ b/ADMIN_PANEL.md
@@ -1,1 +1,0 @@
-docs/guides/administration/admin-panel.md

--- a/API.md
+++ b/API.md
@@ -1,1 +1,0 @@
-docs/reference/api/README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,0 @@
-docs/project/changelog.md

--- a/CICD.md
+++ b/CICD.md
@@ -1,1 +1,0 @@
-docs/guides/development/cicd.md

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,1 +1,0 @@
-docs/getting-started/configuration.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,0 @@
-docs/guides/development/contributing.md

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1,1 +1,0 @@
-docs/reference/database.md

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,1 +1,0 @@
-docs/guides/deployment/production.md

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,1 +1,0 @@
-docs/guides/deployment/docker.md

--- a/MONITORING.md
+++ b/MONITORING.md
@@ -1,1 +1,0 @@
-docs/guides/deployment/monitoring.md

--- a/NETWORKING.md
+++ b/NETWORKING.md
@@ -1,1 +1,0 @@
-docs/guides/deployment/networking.md

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,1 +1,0 @@
-docs/getting-started/quick-start.md

--- a/SCRAPER.md
+++ b/SCRAPER.md
@@ -1,1 +1,0 @@
-docs/reference/scraper.md

--- a/SECURITY_ISSUES.md
+++ b/SECURITY_ISSUES.md
@@ -1,1 +1,0 @@
-docs/project/security.md

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,1 +1,0 @@
-docs/getting-started/installation.md

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,1 +1,0 @@
-docs/guides/development/testing.md

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,1 +1,0 @@
-docs/troubleshooting/common-issues.md

--- a/WHITE_LABEL_PLAN.md
+++ b/WHITE_LABEL_PLAN.md
@@ -1,1 +1,0 @@
-docs/project/white-label-plan.md

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -345,7 +345,7 @@ curl -X POST http://localhost:3000/api/cinemas \
   -d '{"url":"https://www.allocine.fr/seance/salle_gen_csalle=C0001.html"}'
 ```
 
-See [SCRAPER.md](../../../SCRAPER.md) for cinema configuration details.
+See [SCRAPER.md](../../reference/scraper.md) for cinema configuration details.
 
 ### 3. Run First Scrape
 

--- a/docs/guides/deployment/production.md
+++ b/docs/guides/deployment/production.md
@@ -894,7 +894,7 @@ docker system prune -a --volumes
 
 ### For More Help
 
-- **Docker Issues**: [Docker Troubleshooting](../../../TROUBLESHOOTING.md#docker-issues)
+- **Docker Issues**: [Docker Troubleshooting](../../troubleshooting/common-issues.md#docker-issues)
 - **Database Issues**: [Database Troubleshooting](../../troubleshooting/database.md)
 - **Networking Issues**: [Networking Guide](./networking.md)
 - **GitHub Issues**: [Report a bug](https://github.com/PhBassin/allo-scrapper/issues)

--- a/docs/project/agents.md
+++ b/docs/project/agents.md
@@ -299,7 +299,6 @@ allo-scrapper/
 ├── e2e/                        # Playwright E2E tests (out of scope for now)
 ├── .github/                    # GitHub config (issues, workflows)
 ├── WHITE-LABEL.md              # White-label branding system docs
-├── MONITORING.md               # Observability stack documentation
 ├── CONTRIBUTING.md             # Human contributor guide
 └── AGENTS.md                   # This file
 ```

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -18,10 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Documentation Restructure (Issue #239)** — Complete reorganization of documentation into professional `/docs/` hierarchy
   - Migrated 12,586 lines of documentation from flat root structure to organized categories
   - Created 42 documentation files following Divio Documentation System (Tutorials, How-To Guides, Reference, Explanation)
-  - Split API.md (2,157 lines) into 10 modular endpoint files for better discoverability
+  - Split API.md (2,157 lines) (root symlink) into 10 modular endpoint files for better discoverability
   - Organized into 4 main categories: Getting Started, Guides, Reference, Troubleshooting
   - Added comprehensive navigation with READMEs, tables of contents, and breadcrumbs on all pages
-  - Created 19 backward compatibility symlinks (all root `.md` files now point to `/docs/`)
+  - Created 18 backward compatibility symlinks (removed later)
   - Zero information loss - all examples, code snippets, and formatting preserved
   - Completed through 9 incremental PRs (#240-#248) for reviewability
   - **New structure:**
@@ -132,12 +132,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
-- **ADMIN_PANEL.md** — Comprehensive admin panel user guide (new file)
+- **ADMIN_PANEL.md** (root symlink, removed later) — Comprehensive admin panel user guide (new file)
   - Complete walkthrough of all admin panel features
   - Best practices for branding and security
   - Troubleshooting common issues
   
-- **API.md** — Documented white-label APIs
+- **API.md** (root symlink, removed later) — Documented white-label APIs
   - Complete Settings Management API reference with examples
   - Complete User Management API reference with examples
   - Theme CSS endpoint documentation

--- a/docs/project/white-label-plan.md
+++ b/docs/project/white-label-plan.md
@@ -34,7 +34,7 @@
 - ✅ Backend API : Settings, Users, Theme Generator, System Info (2,380+ lignes de tests)
 - ✅ Frontend : SettingsPage (5 tabs), UsersPage, SystemPage, RequireAdmin
 - ✅ Thème dynamique : useTheme hook + /api/theme.css
-- ✅ Documentation : ADMIN_PANEL.md (822 lignes) + API.md (245 lignes ajoutées)
+- ✅ Documentation : ADMIN_PANEL.md (822 lignes) (root symlink, removed later) + API.md (245 lignes ajoutées) (root symlink, removed later)
 - ✅ E2E Tests : 853 lignes (theme, users, system)
 
 **✅ Phase 11 complétée (01/03/2026):**
@@ -564,14 +564,14 @@ CREATE INDEX idx_users_role ON users(role);
   - ✅ Responsive layout tests (desktop/mobile)
 
 **Documentation:**
-- ✅ **ADMIN_PANEL.md** - System Information section added (221 lignes)
+- ✅ **ADMIN_PANEL.md** (root symlink, removed later) - System Information section added (221 lignes)
   - ✅ Overview of system monitoring features
   - ✅ Detailed docs for all 5 dashboard components
   - ✅ Auto-refresh usage instructions
   - ✅ Health status indicators and troubleshooting
   - ✅ Monitoring workflows
 
-- ✅ **API.md** - System endpoints documented (245 lignes added)
+- ✅ **API.md** (root symlink, removed later) - System endpoints documented (245 lignes added)
   - ✅ `GET /api/system/info` with examples
   - ✅ `GET /api/system/migrations` with examples
   - ✅ `GET /api/system/health` with examples
@@ -651,7 +651,7 @@ CREATE INDEX idx_users_role ON users(role);
   - [ ] Screenshots (optionnel)
   - [ ] Credentials par défaut
   - [ ] Instructions export/import
-- [ ] Update API.md
+- [ ] Update API.md (root symlink, removed later)
   - [ ] Documenter `/api/settings` endpoints
   - [ ] Documenter `/api/users` endpoints
   - [ ] Documenter `/api/theme.css`
@@ -665,7 +665,7 @@ CREATE INDEX idx_users_role ON users(role);
   - [ ] Workflow branding customization
 - [ ] Commits
   - [ ] `docs: update README with admin panel documentation`
-  - [ ] `docs: update API.md with settings and users endpoints`
+  - [ ] `docs: update API.md with settings and users endpoints` (root symlink, removed later)
   - [ ] `chore(docker): verify full stack build`
 
 ---
@@ -700,7 +700,7 @@ CREATE INDEX idx_users_role ON users(role);
 - ✅ Tests unitaires frontend >= 70% coverage (UsersPage + composants admin testés)
 - ✅ Tests e2e passent (`./scripts/integration-test.sh`) - 664 lignes E2E tests
 - ✅ Docker build réussit (vérifié dans PRs #229, #230)
-- ✅ Documentation à jour (ADMIN_PANEL.md 601 lignes, API.md, AGENTS.md)
+- ✅ Documentation à jour (ADMIN_PANEL.md 601 lignes (root symlink, removed later), API.md (root symlink, removed later), AGENTS.md)
 - ✅ Aucun secret committé (.env, tokens)
 - ✅ Conventional Commits respectés (tous PRs)
 - ✅ Issues GitHub fermées avec "Closes #X" (#194-#230)
@@ -711,7 +711,7 @@ CREATE INDEX idx_users_role ON users(role);
 - ✅ Migrations Viewer implémenté (table avec applied/pending status)
 - ✅ Health Metrics implémenté (health checks avec status indicators)
 - ✅ E2E tests pour system page (11 test cases, 189 lignes)
-- ✅ Documentation API.md et ADMIN_PANEL.md complétée
+- ✅ Documentation API.md (root symlink, removed later) et ADMIN_PANEL.md (root symlink, removed later) complétée
 - ✅ 11 commits suivant Conventional Commits
 - ✅ Bugs critiques fixés (table names, scrape_reports query)
 
@@ -767,11 +767,11 @@ CREATE INDEX idx_users_role ON users(role);
 
 ## 📚 Ressources
 
-- [Documentation migrations](./migrations/README.md)
-- [Documentation AGENTS.md](./AGENTS.md)
-- [Guide TDD](./TESTING.md)
-- [API Documentation](./API.md)
-- [Admin Panel User Guide](./ADMIN_PANEL.md)
+- [Documentation migrations](../getting-started/installation.md#database-migrations)
+- [Documentation AGENTS.md](../../AGENTS.md)
+- [Guide TDD](../guides/development/testing.md)
+- [API Documentation](../reference/api/README.md)
+- [Admin Panel User Guide](../guides/administration/admin-panel.md)
 - [Issue #231 - System Tab](https://github.com/PhBassin/allo-scrapper/issues/231)
 
 ---
@@ -847,9 +847,9 @@ docker compose build
 docker compose up -d
 
 # Update docs
-# - ADMIN_PANEL.md (System tab section)
-# - API.md (/api/system/* endpoints)
-# - WHITE_LABEL_PLAN.md (mark Phase 11 complete)
+# - docs/guides/administration/admin-panel.md (System tab section)
+# - docs/reference/api/README.md (/api/system/* endpoints)
+# - docs/project/white-label-plan.md (mark Phase 11 complete)
 ```
 
 ### 5. Create PR

--- a/docs/reference/scraper.md
+++ b/docs/reference/scraper.md
@@ -274,7 +274,7 @@ fix(cinema): update Grand Action scraping URL
 
 ## API Endpoints
 
-See [API.md](./API.md) for complete API reference:
+See [API.md](./api/README.md) for complete API reference:
 
 - `GET /api/cinemas` - List all cinemas
 - `GET /api/cinemas/:id` - Get cinema details with showtimes
@@ -318,7 +318,7 @@ Express API (ics-web)
 - Enables horizontal scaling (multiple scraper workers)
 - Better observability (metrics, tracing)
 
-See [DOCKER.md](./DOCKER.md) for scraper microservice deployment.
+See [DOCKER.md](../guides/deployment/docker.md) for scraper microservice deployment.
 
 ---
 
@@ -341,7 +341,7 @@ Events include:
 - `completed` - Scrape finished successfully
 - `failed` - Fatal error
 
-See [API.md - Watch Scrape Progress](./API.md#watch-scrape-progress-sse) for full event reference.
+See [API.md - Watch Scrape Progress](./api/README.md#watch-scrape-progress-sse) for full event reference.
 
 ### Scrape Reports
 

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -413,7 +413,7 @@ docker compose exec db psql -U postgres -c "\du"
 
 ## Production Deployment
 
-For production deployment workflows including migration procedures, see **[DEPLOYMENT.md](../DEPLOYMENT.md)** in the root directory.
+For production deployment workflows including migration procedures, see **[Production Deployment](../docs/guides/deployment/production.md)**.
 
 **Critical Notes:**
 - **Automatic migrations run at startup** - No manual intervention needed


### PR DESCRIPTION
## Summary
- Fixed 9 broken link references across 5 files to use new docs/ structure paths
- Clarified historical references in 3 files (changelog, white-label-plan, agents)
- Deleted 18 root symlinks from project root
- Updated resource links in white-label-plan.md to point to new docs/ hierarchy

All external documentation links now use the canonical  paths. No backward compatibility maintained.

Closes #307