### PR TITLE
⚡ Bolt: [memoize filteredCinemas to prevent redundant re-renders]

### DIFF
--- a/client/src/pages/admin/CinemasPage.tsx
+++ b/client/src/pages/admin/CinemasPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { getCinemas, createCinema, updateCinema, deleteCinema } from '../../api/cinemas';
 import type { CinemaCreate, CinemaUpdate } from '../../api/cinemas';
 import type { Cinema } from '../../types';
@@ -84,15 +84,20 @@ const CinemasPage: React.FC = () => {
 
   // ── Filtering ────────────────────────────────────────────────────────────────
 
-  const filteredCinemas = cinemas.filter((cinema) => {
-    if (!searchQuery.trim()) return true;
-    const q = searchQuery.toLowerCase();
-    return (
-      cinema.name.toLowerCase().includes(q) ||
-      cinema.id.toLowerCase().includes(q) ||
-      (cinema.city ?? '').toLowerCase().includes(q)
-    );
-  });
+  // ⚡ PERFORMANCE: Memoize the filtered cinemas list to prevent expensive
+  // recalculation of the entire array on every render, especially when unrelated
+  // state (like modal visibility or form data) changes.
+  const filteredCinemas = useMemo(() => {
+    return cinemas.filter((cinema) => {
+      if (!searchQuery.trim()) return true;
+      const q = searchQuery.toLowerCase();
+      return (
+        cinema.name.toLowerCase().includes(q) ||
+        cinema.id.toLowerCase().includes(q) ||
+        (cinema.city ?? '').toLowerCase().includes(q)
+      );
+    });
+  }, [cinemas, searchQuery]);
 
   // ── Render ───────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
⚡ Bolt: [memoize filteredCinemas to prevent redundant re-renders]

💡 What: Wrapped the `filteredCinemas` calculation in `client/src/pages/admin/CinemasPage.tsx` with a `useMemo` hook, adding a performance comment.
🎯 Why: `filteredCinemas` was being recalculated synchronously on every render, even when underlying data (`cinemas` or `searchQuery`) hadn't changed, potentially causing performance bottlenecks on high-frequency renders or large datasets.
📊 Impact: Reduces unnecessary array filtering operations by caching the derived state until dependencies change. 
🔬 Measurement: Verify by running the existing unit tests (`npm test`) which pass, demonstrating no functional regression while ensuring React skips redundant computation.

---
*PR created automatically by Jules for task [2284651578123900438](https://jules.google.com/task/2284651578123900438) started by @PhBassin*