### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix API Error Message Leakage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** Consistent pattern of manually catching errors in route handlers and sending `res.status(500).json({ error: error.message })`. This exposed internal error details (e.g., database errors) to clients.
 **Learning:** Developers likely copied this pattern from one route to another without considering `NODE_ENV` or leveraging the global error handler.
 **Prevention:** Enforce use of `next(error)` for unexpected errors in route handlers. Ensure global error handler is configured to sanitize errors in production.
+
+## 2026-03-05 - Safe Error Response Handlers
+**Vulnerability:** Uncaught application errors in `/api/reports` and `/api/scraper` endpoints were exposing `error.message` directly in JSON responses, which could leak internal path structures, stack traces, or DB error semantics depending on the thrown error.
+**Learning:** While Express has a generic error handler, some routes explicitly managed the response payload and naively embedded `error.message`. Refactoring them to delegate to `next(error)` caused an API contract breakage by returning HTML default responses instead of expected JSON.
+**Prevention:** Avoid embedding `error.message` inside manually constructed JSON HTTP 500 responses unless the error strictly originates from known safe validation constraints. For unknown exceptions, manually log the context using `logger.error` and emit a static, sanitized error string like `'Failed to fetch reports'` to satisfy the `ApiResponse` schema safely.

--- a/server/src/routes/reports.ts
+++ b/server/src/routes/reports.ts
@@ -54,7 +54,7 @@ router.get('/', requireAuth, protectedLimiter, async (req, res) => {
     logger.error('Error fetching reports:', error);
     const response: ApiResponse = {
       success: false,
-      error: error instanceof Error ? error.message : 'Failed to fetch reports',
+      error: 'Failed to fetch reports',
     };
     res.status(500).json(response);
   }
@@ -94,7 +94,7 @@ router.get('/:id', requireAuth, protectedLimiter, async (req, res) => {
     logger.error('Error fetching report:', error);
     const response: ApiResponse = {
       success: false,
-      error: error instanceof Error ? error.message : 'Failed to fetch report',
+      error: 'Failed to fetch report',
     };
     return res.status(500).json(response);
   }

--- a/server/src/routes/scraper.ts
+++ b/server/src/routes/scraper.ts
@@ -93,7 +93,7 @@ router.post('/trigger', requireAuth, scraperLimiter, async (req, res) => {
     logger.error('Error starting scrape:', error);
     const response: ApiResponse = {
       success: false,
-      error: error instanceof Error ? error.message : 'Failed to start scrape',
+      error: 'Failed to start scrape',
     };
     return res.status(500).json(response);
   }
@@ -120,7 +120,7 @@ router.get('/status', async (_req, res) => {
     logger.error('Error fetching scrape status:', error);
     const response: ApiResponse = {
       success: false,
-      error: error instanceof Error ? error.message : 'Failed to fetch scrape status',
+      error: 'Failed to fetch scrape status',
     };
     res.status(500).json(response);
   }


### PR DESCRIPTION
### 🚨 Severity: MEDIUM
### 💡 Vulnerability: API Error Message Leakage
Several Express endpoints (`reports.ts` and `scraper.ts`) caught internal errors and directly formatted `error.message` into JSON response payloads. This pattern allows server-side internals, database trace clues, or other unanticipated diagnostic information to bleed into unauthenticated frontend contexts when 500 exceptions occur.
### 🎯 Impact:
Attackers or misconfigured clients could capture internal exception traces or environment details.
### 🔧 Fix:
Modified the catch blocks to emit a static generic response string (e.g., `'Failed to fetch reports'`) instead of exposing `error.message`. Contextual logging of the actual error to the server console remains intact.
### ✅ Verification:
Ran unit test suite via `cd server && npm run test` ensuring `ApiResponse` contract expectations are maintained. Added security learning documentation in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [16305740011422619862](https://jules.google.com/task/16305740011422619862) started by @PhBassin*