### PR TITLE
docs(database): add schema and migrations reference documentation

### DIFF
--- a/docs/reference/database/migrations.md
+++ b/docs/reference/database/migrations.md
@@ -1,0 +1,970 @@
+# Database Migrations Guide
+
+Complete guide to database migration system, workflows, and best practices.
+
+## Overview
+
+The Allo-Scrapper project uses an **automatic migration system** that runs at server startup. Migrations are SQL files that evolve the database schema safely and reproducibly.
+
+**Key Features:**
+
+- ✅ Automatic migration at startup (since v3.1.0)
+- ✅ SHA-256 checksum verification
+- ✅ Sequential execution with rollback on failure
+- ✅ Idempotent migrations (safe to re-run)
+- ✅ Audit trail in `schema_migrations` table
+
+---
+
+## How It Works
+
+### Automatic Migration Flow
+
+```
+1. Server starts
+2. Migration runner connects to database
+3. Creates schema_migrations table (if needed)
+4. Scans migrations/ directory for .sql files
+5. Compares with schema_migrations table
+6. Applies pending migrations in order (001, 002, 003, ...)
+7. Records each migration with SHA-256 checksum
+8. Server continues startup
+```
+
+**Configuration:**
+
+The `AUTO_MIGRATE` environment variable controls automatic migrations:
+
+```bash
+# .env file
+AUTO_MIGRATE=true   # Default: migrations run automatically at startup
+AUTO_MIGRATE=false  # Disable automatic migrations (manual mode)
+```
+
+### Migration Tracking
+
+Each applied migration is recorded in the `schema_migrations` table:
+
+```sql
+CREATE TABLE schema_migrations (
+  version TEXT PRIMARY KEY,           -- e.g., '001_neutralize_references.sql'
+  checksum TEXT NOT NULL,             -- SHA-256 hash of file contents
+  applied_at TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+**Checksum Verification:**
+
+- Migration files are hashed with SHA-256 before and after application
+- If a file is modified after being applied, a **warning** is logged (non-fatal)
+- Prevents accidental modifications to already-applied migrations
+
+---
+
+## Migration Files
+
+### Location
+
+All migration files live in the **root `migrations/` directory**:
+
+```
+allo-scrapper/
+├── migrations/
+│   ├── 001_neutralize_references.sql
+│   ├── 002_add_pg_trgm_extension.sql
+│   ├── 003_add_users_table.sql
+│   ├── 004_add_app_settings.sql
+│   ├── 005_add_user_roles.sql
+│   ├── 006_fix_app_settings_schema.sql
+│   ├── 007_seed_default_admin.sql
+│   └── README.md
+```
+
+### Naming Convention
+
+**Format:** `XXX_description.sql`
+
+- `XXX` = 3-digit sequential number (001, 002, 003, ...)
+- `description` = lowercase with underscores (e.g., `add_users_table`)
+- Extension must be `.sql`
+
+**Examples:**
+
+- ✅ `001_neutralize_references.sql`
+- ✅ `008_add_cinema_geolocation.sql`
+- ❌ `1_fix.sql` (wrong number format)
+- ❌ `010-add-feature.sql` (wrong separator)
+
+### Migration Template
+
+Use this template for new migrations:
+
+```sql
+-- Migration: <Short description>
+-- Version: <semantic version>
+-- Date: <YYYY-MM-DD>
+-- Description: <Detailed description>
+--
+-- IMPORTANT: Backup your database before running this migration!
+--   docker compose exec -T ics-db pg_dump -U postgres ics > backup_before_XXX.sql
+--
+-- Apply this migration:
+--   (Automatic if AUTO_MIGRATE=true, or manual via psql)
+
+BEGIN;
+
+-- Make migration idempotent with IF EXISTS / IF NOT EXISTS checks
+DO $$ 
+BEGIN
+    -- Check if change is needed
+    IF NOT EXISTS (
+        SELECT 1 
+        FROM information_schema.columns 
+        WHERE table_name='your_table' AND column_name='your_column'
+    ) THEN
+        -- Apply change
+        ALTER TABLE your_table ADD COLUMN your_column TEXT;
+        RAISE NOTICE 'Migration applied: your_column added';
+    ELSE
+        RAISE NOTICE 'Migration skipped: your_column already exists';
+    END IF;
+END $$;
+
+-- Verify the change
+DO $$ 
+BEGIN
+    IF EXISTS (
+        SELECT 1 
+        FROM information_schema.columns 
+        WHERE table_name='your_table' AND column_name='your_column'
+    ) THEN
+        RAISE NOTICE 'Migration successful: verification passed';
+    ELSE
+        RAISE EXCEPTION 'Migration failed: verification failed';
+    END IF;
+END $$;
+
+COMMIT;
+
+-- Rollback instructions (document for manual rollback if needed):
+-- To rollback this migration, run:
+-- BEGIN;
+-- ALTER TABLE your_table DROP COLUMN IF EXISTS your_column;
+-- COMMIT;
+```
+
+---
+
+## Migration Lifecycle
+
+### Fresh Install (No Existing Database)
+
+When the server starts with a **fresh database**:
+
+1. **Creates `schema_migrations` table**
+2. **Applies all migrations in order** (001 → 007)
+3. **Seeds default admin user** (migration 007):
+   - Generates random 16-character password
+   - Logs password prominently (save it immediately!)
+   - Password shown **only once** during this startup
+
+**Output Example:**
+
+```
+[info] Starting database migration process...
+[info] Schema migrations table verified
+[info] Found 7 migration files
+[info] Applying migration: 001_neutralize_references.sql
+[info] Migration applied successfully: 001_neutralize_references.sql
+[info] Applying migration: 002_add_pg_trgm_extension.sql
+[info] Migration applied successfully: 002_add_pg_trgm_extension.sql
+...
+[info] Applying migration: 007_seed_default_admin.sql
+[warn] ═══════════════════════════════════════════════════════════
+[warn] 🔐 DEFAULT ADMIN USER CREATED
+[warn] ═══════════════════════════════════════════════════════════
+[warn] Username: admin
+[warn] Password: Xk8#mP2qLz7!nV5w
+[warn] ═══════════════════════════════════════════════════════════
+[warn] ⚠️  SECURITY WARNING:
+[warn] 1. Save this password immediately
+[warn] 2. Change it after first login
+[warn] 3. This password will NOT be shown again
+[warn] ═══════════════════════════════════════════════════════════
+[info] All 7 migrations applied successfully
+```
+
+### Upgrade (Existing Database)
+
+When the server starts with an **existing database**:
+
+1. **Checks `schema_migrations` table** for applied migrations
+2. **Compares checksums** of applied migrations (warns if file modified)
+3. **Applies only new migrations** (e.g., if DB has 001-005, applies 006-007)
+4. **Skips admin seeding** if any admin user already exists
+
+**Output Example (Upgrading from v2.2.0 to v3.1.0):**
+
+```
+[info] Starting database migration process...
+[info] Schema migrations table verified
+[info] Found 7 migration files
+[info] Migration already applied: 001_neutralize_references.sql
+[info] Migration already applied: 002_add_pg_trgm_extension.sql
+[info] Migration already applied: 003_add_users_table.sql
+[info] Applying migration: 004_add_app_settings.sql
+[info] Migration applied successfully: 004_add_app_settings.sql
+[info] Applying migration: 005_add_user_roles.sql
+[info] Migration applied successfully: 005_add_user_roles.sql
+[info] Applying migration: 006_fix_app_settings_schema.sql
+[info] Migration applied successfully: 006_fix_app_settings_schema.sql
+[info] Applying migration: 007_seed_default_admin.sql
+[info] Admin user already exists, skipping admin seed
+[info] 3 new migrations applied successfully
+```
+
+### Checksum Mismatch (Modified Migration File)
+
+If a migration file is **modified after being applied**, you'll see:
+
+```
+[warn] ⚠️  Migration 006_fix_app_settings_schema.sql checksum mismatch (file modified after application)
+[warn]     Applied checksum: abc123def456...
+[warn]     Current checksum: 789ghi012jkl...
+```
+
+**What This Means:**
+
+- The migration file on disk differs from when it was originally applied
+- **Non-fatal** - server continues to start
+- **Action Required:** Investigate why the file changed:
+  - Check git history: `git log -p migrations/006_fix_app_settings_schema.sql`
+  - If intentional: Understand that the change **won't be applied** (migration already ran)
+  - If unintentional: Revert file to original version
+
+---
+
+## Applied Migrations Reference
+
+### 001_neutralize_references.sql
+
+**Version:** 2.0.1  
+**Date:** 2026-02-15  
+**Breaking Change:** Yes (column rename)
+
+**Description:**
+
+Renames `films.allocine_url` → `films.source_url` to use brand-neutral terminology.
+
+**Changes:**
+
+- `ALTER TABLE films RENAME COLUMN allocine_url TO source_url`
+
+**Rollback:**
+
+```sql
+BEGIN;
+ALTER TABLE films RENAME COLUMN source_url TO allocine_url;
+COMMIT;
+```
+
+---
+
+### 002_add_pg_trgm_extension.sql
+
+**Version:** 2.1.0  
+**Date:** 2026-02-21  
+**Breaking Change:** No
+
+**Description:**
+
+Enables PostgreSQL trigram extension for fuzzy text search on film titles.
+
+**Changes:**
+
+- `CREATE EXTENSION IF NOT EXISTS pg_trgm;`
+- `CREATE INDEX idx_films_title_trgm ON films USING gin(title gin_trgm_ops);`
+
+**Usage:**
+
+```sql
+-- Fuzzy search
+SELECT title, similarity(title, 'Godfather') AS sim
+FROM films
+WHERE title % 'Godfather'
+ORDER BY sim DESC;
+```
+
+**Rollback:**
+
+```sql
+BEGIN;
+DROP INDEX IF EXISTS idx_films_title_trgm;
+DROP EXTENSION IF EXISTS pg_trgm;
+COMMIT;
+```
+
+---
+
+### 003_add_users_table.sql
+
+**Version:** 2.2.0  
+**Date:** 2026-02-26  
+**Breaking Change:** No
+
+**Description:**
+
+Creates `users` table for JWT authentication.
+
+**Changes:**
+
+```sql
+CREATE TABLE IF NOT EXISTS users (
+  id SERIAL PRIMARY KEY,
+  username VARCHAR(255) UNIQUE NOT NULL,
+  password_hash VARCHAR(255) NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+**Note:** Admin user seeding moved to migration 007 in v3.1.0.
+
+**Rollback:**
+
+```sql
+BEGIN;
+DROP TABLE IF EXISTS users CASCADE;
+COMMIT;
+```
+
+**⚠️ Warning:** Rollback deletes all user accounts.
+
+---
+
+### 004_add_app_settings.sql
+
+**Version:** 3.0.0  
+**Date:** 2026-03-01  
+**Breaking Change:** No
+
+**Description:**
+
+Creates `app_settings` table for white-label branding configuration.
+
+**Changes:**
+
+- Creates table with 21 columns (identity, colors, typography, footer, email)
+- Enforces **singleton pattern** (only 1 row allowed via CHECK constraint)
+- Inserts default branding values
+- Creates index on `updated_at`
+
+**Key Columns:**
+
+- `site_name` (default: 'Allo-Scrapper')
+- 9 color fields (hex values)
+- 2 font fields (Google Fonts names)
+- `footer_links` (JSONB array)
+- `updated_by` (FK → `users(id)`)
+
+**Rollback:**
+
+```sql
+BEGIN;
+DROP INDEX IF EXISTS idx_app_settings_updated_at;
+DROP TABLE IF EXISTS app_settings CASCADE;
+COMMIT;
+```
+
+---
+
+### 005_add_user_roles.sql
+
+**Version:** 3.0.0  
+**Date:** 2026-03-01  
+**Breaking Change:** No
+
+**Description:**
+
+Adds role-based access control to users table.
+
+**Changes:**
+
+- `ALTER TABLE users ADD COLUMN role TEXT NOT NULL DEFAULT 'user';`
+- `ADD CONSTRAINT users_role_check CHECK (role IN ('admin', 'user'));`
+- `CREATE INDEX idx_users_role ON users(role);`
+- Promotes default 'admin' user to admin role
+
+**Role Values:**
+
+- `admin` - Full access (scraper, settings, user management)
+- `user` - Read-only access
+
+**Rollback:**
+
+```sql
+BEGIN;
+DROP INDEX IF EXISTS idx_users_role;
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_role_check;
+ALTER TABLE users DROP COLUMN IF EXISTS role;
+COMMIT;
+```
+
+---
+
+### 006_fix_app_settings_schema.sql
+
+**Version:** 3.0.1  
+**Date:** 2026-03-01  
+**Breaking Change:** No
+
+**Description:**
+
+Aligns `app_settings` table schema with TypeScript types (`server/src/types/settings.ts`).
+
+**Changes:**
+
+- **Adds columns:** `color_text_primary`, `color_text_secondary`, `color_surface`, `font_primary`, `font_secondary`, `email_from_address`
+- **Removes columns:** `color_text`, `color_link`, `color_warning`, `font_family_heading`, `font_family_body`, `footer_copyright`, `email_header_color`, `email_footer_text`
+- Copies values from old → new columns (if upgrading)
+- Validates `footer_links` is valid JSONB
+
+**Note:** On **fresh installs** (migration 004 already has final schema), this migration's UPDATE statements are skipped via `IF EXISTS` guards.
+
+**Rollback:**
+
+```sql
+BEGIN;
+-- Restore old columns
+ALTER TABLE app_settings ADD COLUMN color_text TEXT;
+ALTER TABLE app_settings ADD COLUMN font_family_heading TEXT;
+ALTER TABLE app_settings ADD COLUMN font_family_body TEXT;
+UPDATE app_settings SET 
+  color_text = color_text_primary, 
+  font_family_heading = font_primary, 
+  font_family_body = font_secondary;
+-- Drop new columns
+ALTER TABLE app_settings DROP COLUMN color_text_primary;
+ALTER TABLE app_settings DROP COLUMN color_text_secondary;
+ALTER TABLE app_settings DROP COLUMN color_surface;
+ALTER TABLE app_settings DROP COLUMN font_primary;
+ALTER TABLE app_settings DROP COLUMN font_secondary;
+ALTER TABLE app_settings DROP COLUMN email_from_address;
+COMMIT;
+```
+
+---
+
+### 007_seed_default_admin.sql
+
+**Version:** 3.1.0  
+**Date:** 2026-03-01  
+**Breaking Change:** No
+
+**Description:**
+
+Marker migration that triggers admin user seeding logic in the migration runner (`server/src/db/migrations.ts`).
+
+**Seeding Logic:**
+
+1. **If no admin users exist:**
+   - **AND** username 'admin' doesn't exist:
+     - Create `admin` user with **randomly generated 16-character password**
+     - Log password prominently (shown **only once**)
+   - **AND** username 'admin' exists but with wrong role:
+     - Fix role to `'admin'`
+     - Warn that password is unchanged
+2. **If any admin user exists:** Skip (no changes)
+
+**Password Requirements:**
+
+- Length: 16 characters
+- Includes: uppercase, lowercase, digits, special characters
+- Generated with Node.js `crypto.randomBytes()`
+
+**Security Notes:**
+
+- Password logged via `logger.warn()` with prominent banner
+- Password **never shown again** after initial startup
+- Must be changed after first login
+- Stored as bcrypt hash (10+ rounds)
+
+**Rollback:**
+
+```sql
+-- Delete default admin user (if created by this migration)
+BEGIN;
+DELETE FROM users WHERE username = 'admin';
+COMMIT;
+```
+
+**⚠️ Warning:** Only delete if you're certain the user was created by this migration.
+
+---
+
+## Creating New Migrations
+
+### Step 1: Determine Migration Number
+
+Find the highest existing migration number and increment:
+
+```bash
+ls migrations/*.sql | sort | tail -1
+# Output: migrations/007_seed_default_admin.sql
+
+# Next migration: 008_your_feature.sql
+```
+
+### Step 2: Write Migration SQL
+
+Create file `migrations/008_your_feature.sql`:
+
+```sql
+-- Migration: Add geolocation to cinemas
+-- Version: 3.2.0
+-- Date: 2026-03-15
+-- Description: Adds latitude/longitude columns for map features
+--
+-- IMPORTANT: Backup your database before running this migration!
+--   docker compose exec -T ics-db pg_dump -U postgres ics > backup_before_008.sql
+
+BEGIN;
+
+-- Add new columns
+ALTER TABLE cinemas ADD COLUMN IF NOT EXISTS latitude REAL;
+ALTER TABLE cinemas ADD COLUMN IF NOT EXISTS longitude REAL;
+
+-- Create spatial index (if using PostGIS)
+-- CREATE INDEX IF NOT EXISTS idx_cinemas_location 
+--   ON cinemas USING GIST (ll_to_earth(latitude, longitude));
+
+-- Verify the change
+DO $$ 
+BEGIN
+    IF EXISTS (
+        SELECT 1 
+        FROM information_schema.columns 
+        WHERE table_name='cinemas' AND column_name='latitude'
+    ) THEN
+        RAISE NOTICE 'Migration successful: latitude column exists';
+    ELSE
+        RAISE EXCEPTION 'Migration failed: latitude column missing';
+    END IF;
+END $$;
+
+COMMIT;
+
+-- Rollback:
+-- BEGIN;
+-- ALTER TABLE cinemas DROP COLUMN IF EXISTS latitude;
+-- ALTER TABLE cinemas DROP COLUMN IF EXISTS longitude;
+-- COMMIT;
+```
+
+### Step 3: Make It Idempotent
+
+**Always use:**
+
+- `IF NOT EXISTS` for `CREATE TABLE`, `CREATE INDEX`, `CREATE EXTENSION`
+- `IF EXISTS` for `DROP TABLE`, `DROP INDEX`, `DROP COLUMN`
+- `DO $$ ... END $$;` blocks with conditional logic for complex changes
+
+**Example Idempotent Patterns:**
+
+```sql
+-- Safe column addition
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name='films' AND column_name='imdb_id'
+    ) THEN
+        ALTER TABLE films ADD COLUMN imdb_id TEXT;
+    END IF;
+END $$;
+
+-- Safe index creation
+CREATE INDEX IF NOT EXISTS idx_films_imdb ON films(imdb_id);
+
+-- Safe constraint addition
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.table_constraints 
+        WHERE constraint_name='films_imdb_unique'
+    ) THEN
+        ALTER TABLE films ADD CONSTRAINT films_imdb_unique UNIQUE (imdb_id);
+    END IF;
+END $$;
+```
+
+### Step 4: Test Locally
+
+1. **Apply migration:**
+
+```bash
+# Automatic mode (recommended)
+docker compose restart ics-web
+
+# Manual mode (if AUTO_MIGRATE=false)
+docker compose exec -T ics-db psql -U postgres -d ics < migrations/008_your_feature.sql
+```
+
+2. **Verify:**
+
+```bash
+# Check schema
+docker compose exec ics-db psql -U postgres -d ics -c "\d cinemas"
+
+# Check migration tracking
+docker compose exec ics-db psql -U postgres -d ics -c "SELECT * FROM schema_migrations ORDER BY applied_at;"
+```
+
+3. **Test idempotency** (apply twice, verify no errors):
+
+```bash
+docker compose exec -T ics-db psql -U postgres -d ics < migrations/008_your_feature.sql
+# Should see "Migration skipped" notices
+```
+
+### Step 5: Document Migration
+
+Update `migrations/README.md` with:
+
+- Migration number and description
+- Version number
+- Breaking change status
+- Rollback instructions
+
+### Step 6: Commit and Deploy
+
+```bash
+git add migrations/008_your_feature.sql
+git commit -m "feat(db): add geolocation columns to cinemas table
+
+refs #<issue-number>"
+```
+
+On deployment, the migration runs automatically when the server starts.
+
+---
+
+## Manual Migration (Legacy Method)
+
+**When to Use:**
+
+- `AUTO_MIGRATE=false` in `.env`
+- Testing migrations before enabling auto-migration
+- Emergency rollback scenarios
+
+### Method 1: Docker Compose (Recommended)
+
+```bash
+# Backup database first
+docker compose exec -T ics-db pg_dump -U postgres ics > backup_before_migration.sql
+
+# Apply migration
+docker compose exec -T ics-db psql -U postgres -d ics < migrations/008_your_feature.sql
+
+# Verify
+docker compose exec ics-db psql -U postgres -d ics -c "\d your_table"
+```
+
+### Method 2: Inside Container
+
+```bash
+# Enter container
+docker compose exec ics-db sh
+
+# Inside container, apply migration
+psql -U postgres -d ics -f /app/migrations/008_your_feature.sql
+
+# Exit container
+exit
+```
+
+### Method 3: Remote Database (Production)
+
+```bash
+# Set connection variables
+export PGHOST=your-db-host.com
+export PGUSER=postgres
+export PGDATABASE=ics
+export PGPASSWORD=your-password
+
+# Backup
+pg_dump > backup_before_migration.sql
+
+# Apply
+psql < migrations/008_your_feature.sql
+```
+
+---
+
+## Rollback Strategies
+
+### Option 1: Rollback SQL (Preferred)
+
+Each migration documents rollback SQL in comments:
+
+```bash
+# Extract rollback SQL from migration file
+grep -A 10 "Rollback:" migrations/008_your_feature.sql
+
+# Apply rollback
+docker compose exec -T ics-db psql -U postgres -d ics <<EOF
+BEGIN;
+ALTER TABLE cinemas DROP COLUMN IF EXISTS latitude;
+ALTER TABLE cinemas DROP COLUMN IF EXISTS longitude;
+COMMIT;
+EOF
+
+# Remove from tracking table
+docker compose exec ics-db psql -U postgres -d ics -c \
+  "DELETE FROM schema_migrations WHERE version = '008_your_feature.sql';"
+```
+
+### Option 2: Restore from Backup
+
+```bash
+# Restore database from backup
+docker compose exec -T ics-db psql -U postgres -d ics < backup_before_migration.sql
+
+# Recreate schema_migrations table if needed
+docker compose restart ics-web  # Re-runs migration system
+```
+
+### Option 3: Forward-Only Migration
+
+**Best Practice:** Instead of rolling back, write a **new migration** that undoes the change:
+
+```sql
+-- migrations/009_remove_geolocation.sql
+BEGIN;
+ALTER TABLE cinemas DROP COLUMN IF EXISTS latitude;
+ALTER TABLE cinemas DROP COLUMN IF EXISTS longitude;
+COMMIT;
+```
+
+**Why?**
+
+- Preserves migration history
+- Works in production without downtime
+- Matches "migrations are immutable" principle
+
+---
+
+## Best Practices
+
+### ✅ DO
+
+1. **Always backup before manual migrations:**
+   ```bash
+   docker compose exec -T ics-db pg_dump -U postgres ics > backup_$(date +%Y%m%d_%H%M%S).sql
+   ```
+
+2. **Make migrations idempotent:**
+   - Use `IF NOT EXISTS` and `IF EXISTS` guards
+   - Safe to run multiple times without errors
+
+3. **Test migrations locally first:**
+   - Apply to dev database
+   - Verify schema changes: `\d table_name`
+   - Test rollback
+   - Re-apply to verify idempotency
+
+4. **Use transactions (BEGIN/COMMIT):**
+   - Entire migration rolls back on error
+   - Database stays consistent
+
+5. **Verify after applying:**
+   ```sql
+   -- Check column exists
+   SELECT column_name, data_type 
+   FROM information_schema.columns 
+   WHERE table_name = 'your_table';
+   
+   -- Check index exists
+   SELECT indexname FROM pg_indexes WHERE tablename = 'your_table';
+   ```
+
+6. **Document rollback steps:**
+   - Include rollback SQL in migration comments
+   - Explain manual steps if needed
+
+7. **Increment version numbers semantically:**
+   - Major (v3.0.0) - Breaking change (column rename, type change)
+   - Minor (v3.1.0) - New feature (new table, new column)
+   - Patch (v3.0.1) - Bug fix (schema correction)
+
+### ❌ DON'T
+
+1. **Don't modify migrations after applying:**
+   - Once applied to production, migrations are **immutable**
+   - If you need to change something, create a new migration
+
+2. **Don't skip sequential numbering:**
+   - Always use next number in sequence
+   - Gaps are confusing (001, 002, 005)
+
+3. **Don't assume migration order:**
+   - Migrations run in **filename sort order** (001 before 002)
+   - Use 3-digit numbers (001-999, not 1-9)
+
+4. **Don't use non-idempotent operations:**
+   - Avoid `ALTER TABLE ... ADD COLUMN` without `IF NOT EXISTS`
+   - Avoid `INSERT` without `ON CONFLICT DO NOTHING`
+
+5. **Don't forget data migrations:**
+   - Schema changes are easy; data transformations are hard
+   - Test with realistic data volumes
+
+6. **Don't rely on manual steps:**
+   - Everything should be automated in SQL
+   - If manual steps needed, document clearly
+
+---
+
+## Troubleshooting
+
+### Migration fails with "column already exists"
+
+**Cause:** Migration is not idempotent.
+
+**Solution:** Update migration to use `IF NOT EXISTS`:
+
+```sql
+-- Before (fails on re-run)
+ALTER TABLE films ADD COLUMN imdb_id TEXT;
+
+-- After (idempotent)
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name='films' AND column_name='imdb_id'
+    ) THEN
+        ALTER TABLE films ADD COLUMN imdb_id TEXT;
+    END IF;
+END $$;
+```
+
+### Checksum mismatch warning
+
+**Cause:** Migration file modified after being applied.
+
+**Solution:**
+
+1. Check git history:
+   ```bash
+   git log -p migrations/006_fix_app_settings_schema.sql
+   ```
+
+2. If intentional change:
+   - Understand that the change **won't be applied** (migration already ran)
+   - If you need the change, create a **new migration**
+
+3. If unintentional:
+   - Revert file to original version
+   - Restart server (warning will disappear)
+
+### Server fails to start after migration
+
+**Cause:** Migration error or database connection issue.
+
+**Solution:**
+
+1. Check server logs:
+   ```bash
+   docker compose logs ics-web | grep -i migration
+   ```
+
+2. Check database logs:
+   ```bash
+   docker compose logs ics-db | tail -50
+   ```
+
+3. Test database connection:
+   ```bash
+   docker compose exec ics-db psql -U postgres -d ics -c "SELECT 1;"
+   ```
+
+4. If migration is broken:
+   - Rollback migration (see Rollback Strategies)
+   - Fix migration SQL
+   - Re-apply
+
+### No admin password logged on fresh install
+
+**Cause:** Migration 007 detected an existing admin user.
+
+**Solution:**
+
+```bash
+# Check existing users
+docker compose exec ics-db psql -U postgres -d ics -c "SELECT username, role FROM users;"
+
+# If admin exists with wrong role, migration will fix it automatically
+# If no admin exists, check migration logs for errors
+```
+
+### Migration stuck or taking too long
+
+**Cause:** Large dataset migration or table lock.
+
+**Solution:**
+
+1. Check active queries:
+   ```bash
+   docker compose exec ics-db psql -U postgres -d ics -c \
+     "SELECT pid, query, state FROM pg_stat_activity WHERE state != 'idle';"
+   ```
+
+2. Check table locks:
+   ```bash
+   docker compose exec ics-db psql -U postgres -d ics -c \
+     "SELECT locktype, relation::regclass, mode, granted FROM pg_locks WHERE NOT granted;"
+   ```
+
+3. If safe, terminate stuck query:
+   ```sql
+   SELECT pg_terminate_backend(<pid>);
+   ```
+
+4. Restart database:
+   ```bash
+   docker compose restart ics-db
+   ```
+
+### AUTO_MIGRATE=false but tables don't exist
+
+**Cause:** You disabled automatic migrations but never ran manual migrations.
+
+**Solution:**
+
+**Option A (Recommended):** Enable automatic migrations:
+
+```bash
+# Edit .env
+AUTO_MIGRATE=true
+
+# Restart server
+docker compose restart ics-web
+```
+
+**Option B:** Apply migrations manually:
+
+```bash
+for migration in migrations/*.sql; do
+  echo "Applying $migration..."
+  docker compose exec -T ics-db psql -U postgres -d ics < "$migration"
+done
+```
+
+---
+
+## See Also
+
+- [Database Schema Reference](./schema.md) - Complete table definitions
+- [Troubleshooting: Database](../../troubleshooting/database.md) - Database issues
+- [Production Deployment Guide](../../guides/deployment/production.md) - Deployment workflows
+- [AGENTS.md](../../../AGENTS.md) - Development workflow (includes migration guidelines)

--- a/docs/reference/database/schema.md
+++ b/docs/reference/database/schema.md
@@ -1,0 +1,684 @@
+# Database Schema Reference
+
+Complete PostgreSQL schema reference for the Allo-Scrapper database.
+
+## Overview
+
+The database uses **PostgreSQL 15** with the following tables:
+
+- **cinemas** - Cinema/theater information
+- **films** - Movie metadata
+- **showtimes** - Individual screening times
+- **weekly_programs** - Weekly film schedules per cinema
+- **scrape_reports** - Scraping job execution logs
+- **users** - Authentication and user management
+- **app_settings** - White-label branding configuration
+- **schema_migrations** - Migration tracking system
+
+## Table Definitions
+
+### cinemas
+
+Stores cinema/theater information scraped from external sources.
+
+**Columns:**
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | `TEXT` | PRIMARY KEY | Unique cinema identifier (extracted from source URL) |
+| `name` | `TEXT` | NOT NULL | Cinema name |
+| `address` | `TEXT` | | Street address |
+| `postal_code` | `TEXT` | | Postal/ZIP code |
+| `city` | `TEXT` | | City name |
+| `screen_count` | `INTEGER` | | Number of screens |
+| `image_url` | `TEXT` | | Cinema image URL |
+| `url` | `TEXT` | | Source URL for scraping |
+
+**Indexes:**
+
+None (primary key index on `id`)
+
+**Notes:**
+
+- `id` is typically extracted from the source URL (e.g., `C0053` from AlloCiné URL)
+- Deleting a cinema cascades to `showtimes` and `weekly_programs` tables
+- `url` field stores the scraping source URL for updates
+
+**Sample Query:**
+
+```sql
+-- Find all cinemas in a specific city
+SELECT * FROM cinemas 
+WHERE city = 'Paris' 
+ORDER BY name;
+```
+
+---
+
+### films
+
+Stores movie metadata including cast, ratings, and synopsis.
+
+**Columns:**
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | `INTEGER` | PRIMARY KEY | Film ID (from source) |
+| `title` | `TEXT` | NOT NULL | Film title (localized) |
+| `original_title` | `TEXT` | | Original title (non-localized) |
+| `poster_url` | `TEXT` | | Poster image URL |
+| `duration_minutes` | `INTEGER` | | Runtime in minutes |
+| `release_date` | `TEXT` | | Original release date (ISO 8601) |
+| `rerelease_date` | `TEXT` | | Re-release date for reruns |
+| `genres` | `TEXT` | | JSON array of genres |
+| `nationality` | `TEXT` | | Country of origin |
+| `director` | `TEXT` | | Director name |
+| `actors` | `TEXT` | | JSON array of actor names |
+| `synopsis` | `TEXT` | | Film synopsis/description |
+| `certificate` | `TEXT` | | Age rating/certificate (e.g., "PG-13", "12+") |
+| `press_rating` | `REAL` | | Press/critic rating (0-5) |
+| `audience_rating` | `REAL` | | Audience rating (0-5) |
+| `source_url` | `TEXT` | NOT NULL | Source URL for metadata updates |
+
+**Indexes:**
+
+| Index | Type | Columns | Purpose |
+|-------|------|---------|---------|
+| `idx_films_title_trgm` | GIN (trigram) | `title` | Fuzzy text search with `pg_trgm` extension |
+
+**Notes:**
+
+- `genres` and `actors` are stored as JSON text (e.g., `["Drama", "Thriller"]`)
+- `source_url` replaced the legacy `allocine_url` column in migration 001
+- The trigram index enables similarity search: `SELECT * FROM films WHERE title % 'query'`
+- Ratings are on a 0-5 scale (some sources may use different scales)
+
+**Sample Queries:**
+
+```sql
+-- Fuzzy search by title (requires pg_trgm extension)
+SELECT title, similarity(title, 'Godfather') AS sim
+FROM films
+WHERE title % 'Godfather'
+ORDER BY sim DESC
+LIMIT 5;
+
+-- Films released in 2024
+SELECT title, release_date, genres
+FROM films
+WHERE release_date LIKE '2024-%'
+ORDER BY release_date DESC;
+
+-- Parse JSON genres field
+SELECT title, json_array_elements_text(genres::json) AS genre
+FROM films
+WHERE genres IS NOT NULL;
+```
+
+---
+
+### showtimes
+
+Individual screening times linking films to cinemas.
+
+**Columns:**
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | `TEXT` | PRIMARY KEY | Composite ID (cinema-film-datetime) |
+| `film_id` | `INTEGER` | NOT NULL, FK → `films(id)` | Film being shown |
+| `cinema_id` | `TEXT` | NOT NULL, FK → `cinemas(id)` ON DELETE CASCADE | Cinema location |
+| `date` | `TEXT` | NOT NULL | Date of screening (ISO 8601: YYYY-MM-DD) |
+| `time` | `TEXT` | NOT NULL | Time of screening (HH:MM) |
+| `datetime_iso` | `TEXT` | NOT NULL | Full ISO 8601 datetime for sorting |
+| `version` | `TEXT` | | Language version (e.g., "VO", "VF") |
+| `format` | `TEXT` | | Projection format (e.g., "35mm", "Digital") |
+| `experiences` | `TEXT` | | JSON array of special experiences |
+| `week_start` | `TEXT` | NOT NULL | Monday of the week (ISO 8601: YYYY-MM-DD) |
+
+**Indexes:**
+
+| Index | Columns | Purpose |
+|-------|---------|---------|
+| `idx_showtimes_cinema_date` | `cinema_id, date` | Find showtimes by cinema and date |
+| `idx_showtimes_film_date` | `film_id, date` | Find showtimes by film and date |
+| `idx_showtimes_week` | `week_start` | Weekly schedule queries |
+
+**Foreign Keys:**
+
+- `film_id` → `films(id)` (no cascade - orphaned showtimes preserved)
+- `cinema_id` → `cinemas(id)` ON DELETE CASCADE (deleting cinema removes showtimes)
+
+**Notes:**
+
+- `experiences` stores JSON like `["IMAX", "3D", "Dolby Atmos"]`
+- `week_start` is always the Monday of the week containing the showtime
+- `id` is typically generated as `${cinema_id}-${film_id}-${datetime_iso}`
+- Deleting a cinema cascades to showtimes; deleting a film does NOT
+
+**Sample Queries:**
+
+```sql
+-- All showtimes for a specific cinema on a date
+SELECT s.time, f.title, s.version, s.format
+FROM showtimes s
+JOIN films f ON s.film_id = f.id
+WHERE s.cinema_id = 'C0053' 
+  AND s.date = '2026-03-10'
+ORDER BY s.time;
+
+-- Showtimes for a film in the next 7 days
+SELECT c.name AS cinema, s.date, s.time, s.version
+FROM showtimes s
+JOIN cinemas c ON s.cinema_id = c.id
+WHERE s.film_id = 12345
+  AND s.date >= CURRENT_DATE
+  AND s.date < CURRENT_DATE + INTERVAL '7 days'
+ORDER BY s.date, s.time;
+
+-- Special format screenings (IMAX)
+SELECT f.title, c.name, s.date, s.time
+FROM showtimes s
+JOIN films f ON s.film_id = f.id
+JOIN cinemas c ON s.cinema_id = c.id
+WHERE s.experiences::text LIKE '%IMAX%'
+ORDER BY s.date;
+```
+
+---
+
+### weekly_programs
+
+Tracks which films are playing at each cinema each week, with "new this week" flag.
+
+**Columns:**
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | `SERIAL` | PRIMARY KEY | Auto-incrementing ID |
+| `cinema_id` | `TEXT` | NOT NULL, FK → `cinemas(id)` ON DELETE CASCADE | Cinema |
+| `film_id` | `INTEGER` | NOT NULL, FK → `films(id)` | Film |
+| `week_start` | `TEXT` | NOT NULL | Monday of week (ISO 8601) |
+| `is_new_this_week` | `INTEGER` | NOT NULL, DEFAULT 0 | 1 if film is new, 0 otherwise |
+| `scraped_at` | `TEXT` | NOT NULL | When this program was scraped |
+| **UNIQUE** | | `(cinema_id, film_id, week_start)` | One row per cinema-film-week |
+
+**Indexes:**
+
+| Index | Columns | Purpose |
+|-------|---------|---------|
+| `idx_weekly_programs_week` | `week_start` | Filter by week |
+
+**Foreign Keys:**
+
+- `cinema_id` → `cinemas(id)` ON DELETE CASCADE
+- `film_id` → `films(id)` (no cascade)
+
+**Notes:**
+
+- Used for "What's new this week?" queries
+- The UNIQUE constraint prevents duplicate entries for the same cinema-film-week
+- `is_new_this_week` is an integer (not boolean) for SQLite compatibility
+
+**Sample Queries:**
+
+```sql
+-- New films at a specific cinema this week
+SELECT f.title, wp.week_start
+FROM weekly_programs wp
+JOIN films f ON wp.film_id = f.id
+WHERE wp.cinema_id = 'C0053'
+  AND wp.week_start = '2026-03-10'
+  AND wp.is_new_this_week = 1;
+
+-- All cinemas showing a specific film this week
+SELECT c.name, c.city
+FROM weekly_programs wp
+JOIN cinemas c ON wp.cinema_id = c.id
+WHERE wp.film_id = 12345
+  AND wp.week_start = '2026-03-10';
+```
+
+---
+
+### scrape_reports
+
+Logs scraping job execution history and statistics.
+
+**Columns:**
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | `SERIAL` | PRIMARY KEY | Auto-incrementing report ID |
+| `started_at` | `TIMESTAMPTZ` | NOT NULL | Job start time (UTC) |
+| `completed_at` | `TIMESTAMPTZ` | | Job completion time (NULL if running) |
+| `status` | `TEXT` | NOT NULL | Job status (see values below) |
+| `trigger_type` | `TEXT` | NOT NULL | How job was triggered (see values below) |
+| `total_cinemas` | `INTEGER` | | Total cinemas to scrape |
+| `successful_cinemas` | `INTEGER` | | Successfully scraped cinemas |
+| `failed_cinemas` | `INTEGER` | | Failed cinema scrapes |
+| `total_films_scraped` | `INTEGER` | | Total films scraped |
+| `total_showtimes_scraped` | `INTEGER` | | Total showtimes scraped |
+| `errors` | `JSONB` | | Array of error objects |
+| `progress_log` | `JSONB` | | Array of progress events |
+
+**Status Values:**
+
+- `running` - Job in progress
+- `success` - All cinemas scraped successfully
+- `partial_success` - Some cinemas failed
+- `failed` - Job failed completely
+
+**Trigger Types:**
+
+- `manual` - User-initiated via API/admin panel
+- `cron` - Scheduled automatic scrape
+
+**Indexes:**
+
+| Index | Columns | Purpose |
+|-------|---------|---------|
+| `idx_scrape_reports_started_at` | `started_at DESC` | Recent jobs first |
+| `idx_scrape_reports_status` | `status` | Filter by status |
+
+**Notes:**
+
+- `errors` contains JSON like `[{"cinema_id": "C0053", "error": "Timeout", "timestamp": "..."}]`
+- `progress_log` tracks events: `[{"type": "cinema_start", "cinema_id": "C0053", "timestamp": "..."}]`
+- NULL `completed_at` indicates a running or crashed job
+
+**Sample Queries:**
+
+```sql
+-- Recent scrape jobs with success rate
+SELECT 
+  id,
+  started_at,
+  status,
+  successful_cinemas,
+  total_cinemas,
+  ROUND(100.0 * successful_cinemas / NULLIF(total_cinemas, 0), 1) AS success_rate_pct
+FROM scrape_reports
+ORDER BY started_at DESC
+LIMIT 10;
+
+-- Failed jobs in the last 24 hours
+SELECT id, started_at, errors
+FROM scrape_reports
+WHERE status = 'failed'
+  AND started_at > NOW() - INTERVAL '24 hours'
+ORDER BY started_at DESC;
+
+-- Extract specific errors from JSONB
+SELECT 
+  id,
+  started_at,
+  jsonb_array_elements(errors) AS error_detail
+FROM scrape_reports
+WHERE errors IS NOT NULL
+  AND jsonb_array_length(errors) > 0;
+```
+
+---
+
+### users
+
+User authentication and authorization.
+
+**Columns:**
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | `SERIAL` | PRIMARY KEY | Auto-incrementing user ID |
+| `username` | `VARCHAR(255)` | UNIQUE, NOT NULL | Username for login |
+| `password_hash` | `VARCHAR(255)` | NOT NULL | bcrypt password hash |
+| `role` | `TEXT` | NOT NULL, DEFAULT 'user' | User role (see values below) |
+| `created_at` | `TIMESTAMPTZ` | DEFAULT CURRENT_TIMESTAMP | Account creation time |
+
+**Role Values:**
+
+- `admin` - Full access (scraper control, settings, user management)
+- `user` - Read-only access (view data only)
+
+**Indexes:**
+
+| Index | Columns | Purpose |
+|-------|---------|---------|
+| `idx_users_role` | `role` | Filter users by role |
+
+**Constraints:**
+
+- `users_role_check` - CHECK constraint: `role IN ('admin', 'user')`
+- UNIQUE constraint on `username`
+
+**Notes:**
+
+- Passwords are hashed with bcrypt (minimum 10 rounds)
+- Default admin user created by migration 007 with random password (logged once)
+- JWT authentication uses `id` and `role` in token payload
+- Foreign key from `app_settings.updated_by` references `users(id)`
+
+**Sample Queries:**
+
+```sql
+-- All admin users
+SELECT id, username, created_at
+FROM users
+WHERE role = 'admin'
+ORDER BY created_at;
+
+-- User count by role
+SELECT role, COUNT(*) AS count
+FROM users
+GROUP BY role;
+```
+
+---
+
+### app_settings
+
+White-label branding configuration (singleton table - always 1 row).
+
+**Columns:**
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | `INTEGER` | PRIMARY KEY, DEFAULT 1 | Always 1 (singleton) |
+| `site_name` | `TEXT` | NOT NULL, DEFAULT 'Allo-Scrapper' | Site name shown in UI |
+| `logo_base64` | `TEXT` | | Base64-encoded logo image |
+| `favicon_base64` | `TEXT` | | Base64-encoded favicon |
+| `color_primary` | `TEXT` | NOT NULL, DEFAULT '#FECC00' | Primary brand color (hex) |
+| `color_secondary` | `TEXT` | NOT NULL, DEFAULT '#1F2937' | Secondary color (hex) |
+| `color_accent` | `TEXT` | NOT NULL, DEFAULT '#F59E0B' | Accent color (hex) |
+| `color_background` | `TEXT` | NOT NULL, DEFAULT '#FFFFFF' | Background color (hex) |
+| `color_surface` | `TEXT` | NOT NULL, DEFAULT '#F3F4F6' | Surface color (hex) |
+| `color_text_primary` | `TEXT` | NOT NULL, DEFAULT '#111827' | Primary text color (hex) |
+| `color_text_secondary` | `TEXT` | NOT NULL, DEFAULT '#6B7280' | Secondary text color (hex) |
+| `color_success` | `TEXT` | NOT NULL, DEFAULT '#10B981' | Success color (hex) |
+| `color_error` | `TEXT` | NOT NULL, DEFAULT '#EF4444' | Error color (hex) |
+| `font_primary` | `TEXT` | NOT NULL, DEFAULT 'Inter' | Primary font (Google Fonts) |
+| `font_secondary` | `TEXT` | NOT NULL, DEFAULT 'Roboto' | Secondary font (Google Fonts) |
+| `footer_text` | `TEXT` | DEFAULT '...' | Footer disclaimer text |
+| `footer_links` | `JSONB` | DEFAULT '[]' | JSON array of footer links |
+| `email_from_name` | `TEXT` | DEFAULT 'Allo-Scrapper' | Email sender name |
+| `email_from_address` | `TEXT` | DEFAULT 'no-reply@...' | Email sender address |
+| `updated_at` | `TIMESTAMPTZ` | DEFAULT CURRENT_TIMESTAMP | Last update time |
+| `updated_by` | `INTEGER` | FK → `users(id)` | User who made last update |
+
+**Indexes:**
+
+| Index | Columns | Purpose |
+|-------|---------|---------|
+| `idx_app_settings_updated_at` | `updated_at` | Track update history |
+
+**Constraints:**
+
+- `singleton_check` - CHECK constraint: `id = 1` (only 1 row allowed)
+- Foreign key to `users(id)` for audit trail
+
+**Notes:**
+
+- Singleton pattern enforced by CHECK constraint
+- `footer_links` example: `[{"label": "Privacy", "url": "/privacy"}, ...]`
+- All hex colors must include `#` prefix (validated by frontend)
+- Fonts must be valid Google Fonts names
+- Images stored as base64 data URIs (validated max size: 2MB)
+
+**Sample Queries:**
+
+```sql
+-- Get current branding settings
+SELECT * FROM app_settings WHERE id = 1;
+
+-- Update site name
+UPDATE app_settings 
+SET site_name = 'My Cinema App', 
+    updated_at = NOW(), 
+    updated_by = 1
+WHERE id = 1;
+
+-- Parse footer links JSON
+SELECT 
+  site_name,
+  jsonb_array_elements(footer_links) AS footer_link
+FROM app_settings
+WHERE id = 1;
+```
+
+---
+
+### schema_migrations
+
+Tracks applied database migrations (managed automatically).
+
+**Columns:**
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `version` | `TEXT` | PRIMARY KEY | Migration filename (e.g., '001_neutralize_references.sql') |
+| `checksum` | `TEXT` | NOT NULL | SHA-256 hash of migration file |
+| `applied_at` | `TIMESTAMPTZ` | DEFAULT CURRENT_TIMESTAMP | When migration was applied |
+
+**Indexes:**
+
+| Index | Columns | Purpose |
+|-------|---------|---------|
+| `idx_schema_migrations_applied_at` | `applied_at` | Migration history |
+
+**Notes:**
+
+- Created automatically by migration runner at server startup
+- DO NOT manually modify this table
+- Checksums verify migration file integrity after application
+- Used to determine which migrations are pending
+
+**Sample Queries:**
+
+```sql
+-- View migration history
+SELECT * FROM schema_migrations 
+ORDER BY applied_at;
+
+-- Check if specific migration applied
+SELECT EXISTS (
+  SELECT 1 FROM schema_migrations 
+  WHERE version = '005_add_user_roles.sql'
+) AS is_applied;
+```
+
+---
+
+## Relationships
+
+### Entity-Relationship Diagram (Text)
+
+```
+cinemas (1) ──< showtimes (N)
+films (1) ──< showtimes (N)
+
+cinemas (1) ──< weekly_programs (N)
+films (1) ──< weekly_programs (N)
+
+users (1) ──< app_settings.updated_by (1)
+```
+
+### Foreign Key Details
+
+| Child Table | Child Column | Parent Table | Parent Column | On Delete |
+|-------------|--------------|--------------|---------------|-----------|
+| showtimes | `cinema_id` | cinemas | `id` | CASCADE |
+| showtimes | `film_id` | films | `id` | (none) |
+| weekly_programs | `cinema_id` | cinemas | `id` | CASCADE |
+| weekly_programs | `film_id` | films | `id` | (none) |
+| app_settings | `updated_by` | users | `id` | (none) |
+
+**Cascade Behavior:**
+
+- Deleting a **cinema** → deletes all showtimes and weekly programs for that cinema
+- Deleting a **film** → does NOT cascade (orphaned showtimes/programs preserved)
+- Deleting a **user** → does NOT cascade (app_settings.updated_by becomes NULL)
+
+---
+
+## Extensions
+
+### pg_trgm (PostgreSQL Trigram)
+
+**Purpose:** Enables fuzzy text search on film titles.
+
+**Installation:** Migration 002 (`CREATE EXTENSION IF NOT EXISTS pg_trgm;`)
+
+**Usage:**
+
+```sql
+-- Find films similar to "Godfather"
+SELECT title, similarity(title, 'Godfather') AS sim
+FROM films
+WHERE title % 'Godfather'  -- % operator = similarity match
+ORDER BY sim DESC
+LIMIT 10;
+```
+
+**Index:** GIN index on `films.title` (`idx_films_title_trgm`)
+
+---
+
+## Common Query Patterns
+
+### Find Showtimes for a Film at a Cinema
+
+```sql
+SELECT s.date, s.time, s.version, s.format
+FROM showtimes s
+WHERE s.cinema_id = 'C0053'
+  AND s.film_id = 12345
+  AND s.date >= CURRENT_DATE
+ORDER BY s.date, s.time;
+```
+
+### Weekly Schedule for a Cinema
+
+```sql
+SELECT 
+  f.title,
+  f.poster_url,
+  COUNT(DISTINCT s.date) AS days_showing,
+  MIN(s.time) AS first_showtime,
+  MAX(s.time) AS last_showtime
+FROM showtimes s
+JOIN films f ON s.film_id = f.id
+WHERE s.cinema_id = 'C0053'
+  AND s.week_start = '2026-03-10'
+GROUP BY f.id, f.title, f.poster_url
+ORDER BY f.title;
+```
+
+### New Films This Week
+
+```sql
+SELECT 
+  f.title,
+  f.poster_url,
+  c.name AS cinema,
+  c.city
+FROM weekly_programs wp
+JOIN films f ON wp.film_id = f.id
+JOIN cinemas c ON wp.cinema_id = c.id
+WHERE wp.week_start = '2026-03-10'
+  AND wp.is_new_this_week = 1
+ORDER BY c.city, c.name, f.title;
+```
+
+### Cinemas Showing a Specific Film
+
+```sql
+SELECT DISTINCT
+  c.id,
+  c.name,
+  c.city,
+  c.postal_code,
+  COUNT(s.id) AS showtime_count
+FROM cinemas c
+JOIN showtimes s ON c.id = s.cinema_id
+WHERE s.film_id = 12345
+  AND s.date >= CURRENT_DATE
+GROUP BY c.id, c.name, c.city, c.postal_code
+ORDER BY c.city, c.name;
+```
+
+### Recent Scrape Job Statistics
+
+```sql
+SELECT 
+  id,
+  started_at,
+  completed_at,
+  status,
+  total_cinemas,
+  successful_cinemas,
+  failed_cinemas,
+  total_films_scraped,
+  total_showtimes_scraped,
+  ROUND(100.0 * successful_cinemas / NULLIF(total_cinemas, 0), 1) AS success_rate
+FROM scrape_reports
+WHERE completed_at IS NOT NULL
+ORDER BY started_at DESC
+LIMIT 20;
+```
+
+---
+
+## Migration History
+
+| Migration | Version | Date | Description |
+|-----------|---------|------|-------------|
+| 001 | 2.0.1 | 2026-02-15 | Rename `allocine_url` → `source_url` |
+| 002 | 2.1.0 | 2026-02-21 | Add pg_trgm extension + GIN index |
+| 003 | 2.2.0 | 2026-02-26 | Create users table |
+| 004 | 3.0.0 | 2026-03-01 | Create app_settings table |
+| 005 | 3.0.0 | 2026-03-01 | Add role column to users |
+| 006 | 3.0.1 | 2026-03-01 | Fix app_settings schema alignment |
+| 007 | 3.1.0 | 2026-03-01 | Seed default admin user |
+
+See [Database Migrations Guide](./migrations.md) for detailed migration documentation.
+
+---
+
+## Performance Considerations
+
+### Index Usage
+
+All indexes are created automatically by migrations or init.sql:
+
+- **Primary keys** (`id` columns) - implicit B-tree indexes
+- **Foreign keys** - no automatic indexes (consider adding if joins are slow)
+- **GIN trigram index** on `films.title` - enables fast fuzzy search
+- **Composite indexes** on `showtimes` - optimized for date-range queries
+
+### Query Optimization Tips
+
+1. **Use indexes effectively:**
+   - Filter by indexed columns first (`cinema_id`, `film_id`, `date`, `week_start`)
+   - Use `EXPLAIN ANALYZE` to verify index usage
+
+2. **Date filtering:**
+   - Store dates in ISO 8601 format for consistent sorting
+   - Use `>=` and `<` instead of `BETWEEN` for date ranges
+
+3. **JSON fields:**
+   - Use `jsonb_array_elements()` to expand JSON arrays
+   - Add GIN indexes on JSONB columns if filtering frequently
+
+4. **Avoid N+1 queries:**
+   - Use JOINs instead of separate queries per row
+   - Frontend should batch API requests when possible
+
+---
+
+## See Also
+
+- [Database Migrations Guide](./migrations.md) - Migration system and workflow
+- [Troubleshooting: Database](../../troubleshooting/database.md) - Common database issues
+- [API Reference: Cinemas](../api/cinemas.md) - Cinema endpoints
+- [API Reference: Films](../api/films.md) - Films endpoints
+- [API Reference: Showtimes](../api/showtimes.md) - Showtimes endpoints


### PR DESCRIPTION
## Summary

Adds comprehensive database reference documentation:

- **schema.md** - Complete table definitions with all 8 tables (cinemas, films, showtimes, weekly_programs, scrape_reports, users, app_settings, schema_migrations)
- **migrations.md** - Migration system guide with workflow, best practices, and troubleshooting

## Details

### schema.md
- Table definitions with columns, types, constraints
- Relationships and foreign keys with cascade behavior
- All indexes documented
- Sample queries for common patterns
- Performance considerations
- Links to related docs

### migrations.md
- Automatic migration system explained
- All 7 migrations documented (001-007) with rollback instructions
- Migration lifecycle (fresh install vs upgrade)
- Checksum verification system
- Creating new migrations (template + best practices)
- Manual migration methods (legacy)
- Rollback strategies
- Troubleshooting common issues

## Testing

✅ All 569 tests passed
✅ Pre-push hooks passed (TypeScript + tests)
✅ Schema verified against migration files and init.sql
✅ All references cross-checked

## Impact

Fixes 8 broken documentation links:
- 7 references to `docs/reference/database/schema.md`
- 1 reference to `docs/reference/database/migrations.md`

Closes #313