### PR TITLE
feat(ci): automated cleanup of short-lived Docker tags

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -48,14 +48,13 @@ This directory contains automated workflows for CI/CD and maintenance tasks.
 
 ### 2. 🧹 `cleanup-docker-images.yml` - Docker Image Cleanup
 
-**Purpose**: Periodic cleanup of old Docker images from ghcr.io registry
+**Purpose**: Manual cleanup of old Docker images from ghcr.io registry
 
 **Triggers**:
-- Push to `main` branch (automatic)
-- Manual trigger with dry-run control
+- Manual trigger only (workflow_dispatch)
 
 **Cleanup Policy**:
-- **Keep**: 10 versions maximum
+- **Keep**: 30 versions maximum (configurable)
 - **Delete**: Only untagged versions (SHA-based images without explicit tags)
 - **Protected**: All tagged versions (v*, latest, branch names, etc.)
 
@@ -68,14 +67,113 @@ This directory contains automated workflows for CI/CD and maintenance tasks.
   3. Click "Run workflow"
   4. Set `dry-run` to `false`
 
-**When to Disable Dry-Run**:
-- After verifying dry-run logs show correct behavior
-- When you're confident the cleanup policy is correct
-- When you understand which images will be deleted
+**When to Use**:
+- One-time cleanup of accumulated untagged images
+- Emergency cleanup when registry is full
+- Testing cleanup policies before automation
 
 ---
 
-### 3. 🔄 `sync-main-to-develop.yml` - Branch Synchronization
+### 3. 🧹 `ghcr-cleanup.yml` - Tag Lifecycle Management
+
+**Purpose**: Automated cleanup of short-lived Docker image tags while preserving important releases
+
+**Status**: ✅ **ENABLED** (runs weekly on schedule)
+
+**Triggers**:
+- **Automatic**: Every Sunday at 3:00 AM UTC
+- **Manual**: Via workflow_dispatch
+
+**Cleanup Policy**:
+
+| Tag Pattern | Retention | Examples |
+|-------------|-----------|----------|
+| `x.x.x*` (semver) | ✅ Forever | `3.0.0-beta.4`, `3.0`, `2.1.0` |
+| `latest`, `stable` | ✅ Forever | Special release tags |
+| `develop`, `main` | ✅ Forever | Branch tracking tags |
+| `pr-*` (last 5) | ✅ Forever | `pr-330`, `pr-329`, `pr-328`, ... |
+| `pr-*` (older) | 🗑️ 7 days | `pr-320`, `pr-315` (if > 7 days old) |
+| `sha-*` | 🗑️ 7 days | `sha-99e4de7`, `sha-abc1234` |
+| Untagged | 🗑️ 7 days | Digest-only images |
+
+**How It Works**:
+1. Scans all package versions in GitHub Container Registry
+2. Classifies each version by tag pattern
+3. Identifies the last 5 PR tags by PR number (keeps them regardless of age)
+4. Deletes old `sha-*`, old `pr-*` (not in last 5), and untagged images > 7 days old
+5. Preserves all semantic version tags and special tags forever
+
+**Dry-Run Mode**:
+
+The workflow starts in **dry-run mode** for safety:
+- Shows what **would** be deleted without actually deleting
+- Review logs to verify correct behavior
+- To enable actual deletion:
+  1. Edit `.github/workflows/ghcr-cleanup.yml`
+  2. Change `DRY_RUN: 'true'` to `DRY_RUN: 'false'`
+  3. Commit and push
+
+**Example Output** (dry-run mode):
+
+```
+Scanned: 45 package versions
+
+✅ KEEP: 3.0.0-beta.4 (protected semver)
+✅ KEEP: latest (protected special tag)
+✅ KEEP: pr-330 (recent PR, #1 of 5)
+✅ KEEP: sha-a9efa33 (too recent, age: 2 hours)
+🗑️  DELETE: pr-320 (age: 10 days, not in last 5 PRs)
+🗑️  DELETE: sha-99e4de7 (age: 14 days)
+
+Summary:
+- Protected: 35 versions
+- Would delete: 10 versions (DRY-RUN)
+```
+
+**Manual Trigger**:
+
+```bash
+# Run cleanup manually (uses dry-run setting from workflow)
+gh workflow run ghcr-cleanup.yml
+
+# Or via GitHub UI:
+# Actions → GHCR Cleanup → Run workflow
+```
+
+**Adjusting Retention**:
+
+Edit `.github/workflows/ghcr-cleanup.yml` environment variables:
+
+```yaml
+env:
+  RETENTION_DAYS: 7        # Change to desired days
+  KEEP_RECENT_PRS: 5       # Change number of recent PRs to keep
+  DRY_RUN: 'true'          # Set to 'false' to enable deletion
+```
+
+**Disabling Cleanup**:
+
+To temporarily disable:
+1. Comment out the `schedule:` section in the workflow
+2. Or add condition: `if: false` to the job
+
+**Monitoring**:
+
+- Check workflow runs: Actions tab → "GHCR Cleanup" workflow
+- Review job summaries for detailed breakdown
+- Weekly runs appear automatically every Sunday
+
+**Safety Features**:
+- ✅ Dry-run enabled by default
+- ✅ 7-day minimum age before deletion
+- ✅ Protected tag patterns (regex-based)
+- ✅ Always keeps last 5 PR builds
+- ✅ Detailed logging and summaries
+- ✅ Manual trigger for testing
+
+---
+
+### 4. 🔄 `sync-main-to-develop.yml` - Branch Synchronization
 
 **Purpose**: Automatically sync main branch into develop
 
@@ -214,4 +312,4 @@ To re-enable:
 
 ---
 
-**Last Updated**: 2026-02-20
+**Last Updated**: 2026-03-08

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,17 +1,22 @@
-name: GHCR Cleanup
+name: GHCR Cleanup - Tag Lifecycle Management
 
-# ⚠️ TEMPORARILY DISABLED
-# Automatic Docker image cleanup is disabled for manual control.
-# This workflow can still be triggered manually via workflow_dispatch.
-# To re-enable: uncomment the schedule block below.
+# Automated cleanup of short-lived Docker image tags
+# - Deletes sha-* tags older than 7 days
+# - Deletes pr-* tags older than 7 days (keeps last 5 PRs)
+# - Preserves semantic version tags forever (x.x.x*)
+# - Preserves special tags forever (latest, stable, develop, main)
+# - Runs weekly on Sunday at 3:00 AM UTC
+# - Manual trigger available via workflow_dispatch
 on:
-  # schedule:
-  #   - cron: '30 2 * * *' # Runs daily at 2:30 AM UTC
+  schedule:
+    - cron: '0 3 * * 0'  # Runs weekly on Sunday at 3:00 AM UTC
   workflow_dispatch:
 
 env:
   PACKAGE_NAME: allo-scrapper
-  RETENTION_DAYS: 15
+  RETENTION_DAYS: 7
+  KEEP_RECENT_PRS: 5
+  DRY_RUN: 'true'  # Set to 'false' to enable actual deletion
 
 jobs:
   cleanup:
@@ -20,24 +25,54 @@ jobs:
       packages: write
 
     steps:
-      - name: Delete untagged and old images
+      - name: Delete short-lived tags and old images
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const owner = context.repo.owner;
             const packageName = process.env.PACKAGE_NAME;
-            const retentionDays = Number(process.env.RETENTION_DAYS || '15');
+            const retentionDays = Number(process.env.RETENTION_DAYS || '7');
+            const keepRecentPRs = Number(process.env.KEEP_RECENT_PRS || '5');
+            const dryRun = process.env.DRY_RUN === 'true';
             const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
 
+            core.info(`🔍 Starting cleanup for ${packageName}`);
+            core.info(`📅 Retention: ${retentionDays} days (cutoff: ${cutoff.toISOString()})`);
+            core.info(`🔒 Keep recent PRs: ${keepRecentPRs}`);
+            core.info(`🧪 Mode: ${dryRun ? 'DRY-RUN' : 'PRODUCTION'}`);
+
+            // Tag classification functions
+            const isProtectedTag = (tags) => {
+              const protectedPatterns = [
+                /^v?\d+\.\d+/,                    // Semver: v3.0.0, 3.0, 3.0.0-beta.4
+                /^(latest|stable|develop|main)$/  // Special tags
+              ];
+              return tags.some(tag => protectedPatterns.some(pattern => pattern.test(tag)));
+            };
+
+            const isPRTag = (tags) => {
+              return tags.some(tag => /^pr-\d+$/.test(tag));
+            };
+
+            const isSHATag = (tags) => {
+              return tags.some(tag => /^sha-[a-f0-9]+$/.test(tag));
+            };
+
+            const extractPRNumber = (tags) => {
+              const prTag = tags.find(tag => /^pr-\d+$/.test(tag));
+              return prTag ? parseInt(prTag.split('-')[1]) : null;
+            };
+
+            // Determine owner scope
             const ownerInfo = await github.rest.users.getByUsername({ username: owner });
             const scope = ownerInfo.data.type === 'Organization' ? 'orgs' : 'users';
 
+            // Fetch all package versions with pagination
             let page = 1;
-            let scanned = 0;
-            let deleted = 0;
-            const versionsToDelete = [];
+            let allVersions = [];
 
+            core.info('📦 Fetching package versions...');
             while (true) {
               let versions;
 
@@ -55,7 +90,7 @@ jobs:
               } catch (error) {
                 if (error.status === 404) {
                   core.warning(`Package ${packageName} not found for owner ${owner}. Nothing to clean.`);
-                  break;
+                  return;
                 }
                 throw error;
               }
@@ -64,40 +99,196 @@ jobs:
                 break;
               }
 
-              for (const version of versions) {
-                scanned += 1;
-
-                const tags = version.metadata?.container?.tags ?? [];
-                const isUntagged = tags.length === 0;
-                const isOlderThanRetention = new Date(version.updated_at) < cutoff;
-
-                if (isUntagged || isOlderThanRetention) {
-                  versionsToDelete.push({ id: version.id, tags });
-                }
-              }
-
+              allVersions = allVersions.concat(versions);
               page += 1;
             }
 
-            for (const version of versionsToDelete) {
-              await github.request(
-                `DELETE /${scope}/{owner}/packages/container/{package_name}/versions/{package_version_id}`,
-                {
-                  owner,
-                  package_name: packageName,
-                  package_version_id: version.id,
-                }
-              );
+            core.info(`✅ Found ${allVersions.length} total versions`);
 
-              deleted += 1;
-              core.info(`Deleted version ${version.id} (tags: ${version.tags.join(', ') || 'none'})`);
+            // Extract and sort PR versions to find recent ones
+            const prVersions = allVersions
+              .filter(v => {
+                const tags = v.metadata?.container?.tags ?? [];
+                return isPRTag(tags);
+              })
+              .map(v => {
+                const tags = v.metadata?.container?.tags ?? [];
+                return {
+                  ...v,
+                  prNumber: extractPRNumber(tags)
+                };
+              })
+              .filter(v => v.prNumber !== null)
+              .sort((a, b) => b.prNumber - a.prNumber);
+
+            const recentPRNumbers = prVersions.slice(0, keepRecentPRs).map(v => v.prNumber);
+            core.info(`🔒 Protected recent PRs: ${recentPRNumbers.join(', ')}`);
+
+            // Analyze each version
+            const stats = {
+              scanned: 0,
+              protectedSemver: 0,
+              protectedSpecial: 0,
+              protectedRecentPR: 0,
+              keptTooRecent: 0,
+              deletedOldPR: 0,
+              deletedOldSHA: 0,
+              deletedUntagged: 0
+            };
+
+            const toDelete = [];
+            const protectedSemverTags = [];
+            const protectedSpecialTags = [];
+            const protectedRecentPRTags = [];
+            const deletedDetails = { pr: [], sha: [], untagged: [] };
+
+            for (const version of allVersions) {
+              stats.scanned += 1;
+              const tags = version.metadata?.container?.tags ?? [];
+              const age = new Date(version.updated_at);
+              const isOld = age < cutoff;
+              const ageInDays = Math.floor((Date.now() - age.getTime()) / (24 * 60 * 60 * 1000));
+              const prNumber = extractPRNumber(tags);
+
+              let action = 'UNKNOWN';
+              let reason = '';
+
+              // Decision logic
+              if (isProtectedTag(tags)) {
+                action = 'KEEP';
+                reason = 'protected semver/special';
+                const tagList = tags.join(', ');
+                if (tags.some(t => /^v?\d+\.\d+/.test(t))) {
+                  stats.protectedSemver += 1;
+                  if (protectedSemverTags.length < 10) protectedSemverTags.push(tagList);
+                } else {
+                  stats.protectedSpecial += 1;
+                  if (protectedSpecialTags.length < 10) protectedSpecialTags.push(tagList);
+                }
+              } else if (isPRTag(tags) && prNumber && recentPRNumbers.includes(prNumber)) {
+                action = 'KEEP';
+                reason = `recent PR (#${prNumber}, in top ${keepRecentPRs})`;
+                stats.protectedRecentPR += 1;
+                if (protectedRecentPRTags.length < 10) protectedRecentPRTags.push(tags.join(', '));
+              } else if (isPRTag(tags) && isOld) {
+                action = 'DELETE';
+                reason = `old PR (#${prNumber}, age: ${ageInDays}d)`;
+                stats.deletedOldPR += 1;
+                toDelete.push(version);
+                deletedDetails.pr.push(`pr-${prNumber} (${ageInDays}d old)`);
+              } else if (isSHATag(tags) && isOld) {
+                action = 'DELETE';
+                reason = `old SHA tag (age: ${ageInDays}d)`;
+                stats.deletedOldSHA += 1;
+                toDelete.push(version);
+                deletedDetails.sha.push(`${tags.join(', ')} (${ageInDays}d old)`);
+              } else if (tags.length === 0 && isOld) {
+                action = 'DELETE';
+                reason = `untagged (age: ${ageInDays}d)`;
+                stats.deletedUntagged += 1;
+                toDelete.push(version);
+                deletedDetails.untagged.push(`version ${version.id} (${ageInDays}d old)`);
+              } else {
+                action = 'KEEP';
+                reason = `too recent (age: ${ageInDays}d)`;
+                stats.keptTooRecent += 1;
+              }
+
+              // Log details for first few of each category (avoid spam)
+              if (stats.scanned <= 20 || action === 'DELETE') {
+                const tagDisplay = tags.length > 0 ? tags.join(', ') : '(untagged)';
+                core.info(`${action === 'DELETE' ? '🗑️' : '✅'} ${action}: ${tagDisplay} - ${reason}`);
+              }
             }
 
-            core.summary
-              .addHeading('GHCR cleanup summary')
-              .addRaw(`Scanned versions: ${scanned}`)
+            // Perform deletion (or dry-run)
+            let actuallyDeleted = 0;
+            if (toDelete.length > 0) {
+              core.info(`\n${'='.repeat(60)}`);
+              core.info(`${dryRun ? '🧪 DRY-RUN:' : '🗑️ DELETING:'} ${toDelete.length} versions`);
+              core.info(`${'='.repeat(60)}\n`);
+
+              for (const version of toDelete) {
+                const tags = version.metadata?.container?.tags ?? [];
+                const tagDisplay = tags.length > 0 ? tags.join(', ') : '(untagged)';
+
+                if (!dryRun) {
+                  try {
+                    await github.request(
+                      `DELETE /${scope}/{owner}/packages/container/{package_name}/versions/{package_version_id}`,
+                      {
+                        owner,
+                        package_name: packageName,
+                        package_version_id: version.id,
+                      }
+                    );
+                    actuallyDeleted += 1;
+                    core.info(`✅ Deleted: ${tagDisplay} (ID: ${version.id})`);
+                  } catch (error) {
+                    core.error(`❌ Failed to delete ${tagDisplay} (ID: ${version.id}): ${error.message}`);
+                  }
+                } else {
+                  core.info(`[DRY-RUN] Would delete: ${tagDisplay} (ID: ${version.id})`);
+                }
+              }
+            }
+
+            // Generate summary
+            const totalProtected = stats.protectedSemver + stats.protectedSpecial + stats.protectedRecentPR + stats.keptTooRecent;
+            const totalDeleted = dryRun ? 0 : actuallyDeleted;
+
+            await core.summary
+              .addHeading(`${dryRun ? '🧪 DRY-RUN:' : '✅'} GHCR Cleanup Summary`)
+              .addRaw(`\n**Mode:** ${dryRun ? '🔍 DRY-RUN (no actual deletion)' : '✅ PRODUCTION (actual deletion)'}\n`)
+              .addRaw(`**Retention:** ${retentionDays} days for short-lived tags\n`)
+              .addRaw(`**Keep recent PRs:** Last ${keepRecentPRs} PR tags\n`)
+              .addRaw(`**Cutoff date:** ${cutoff.toISOString()}\n`)
               .addBreak()
-              .addRaw(`Deleted versions: ${deleted}`)
+              .addHeading('📊 Statistics', 3)
+              .addTable([
+                [{ data: 'Category', header: true }, { data: 'Count', header: true }],
+                ['Total scanned', String(stats.scanned)],
+                ['Protected (semver)', String(stats.protectedSemver)],
+                ['Protected (special)', String(stats.protectedSpecial)],
+                ['Protected (recent PRs)', String(stats.protectedRecentPR)],
+                ['Kept (too recent)', String(stats.keptTooRecent)],
+                ['**Total Protected**', `**${totalProtected}**`],
+                ['---', '---'],
+                ['Deleted (old PR tags)', String(stats.deletedOldPR)],
+                ['Deleted (old SHA tags)', String(stats.deletedOldSHA)],
+                ['Deleted (untagged)', String(stats.deletedUntagged)],
+                ['**Total Deleted**', `**${dryRun ? '0 (dry-run)' : totalDeleted}**`],
+              ])
               .addBreak()
-              .addRaw(`Retention policy: untagged or older than ${retentionDays} days`)
-              .write();
+              .addHeading('✅ Protected Forever', 3)
+              .addRaw(`**Semver tags (${stats.protectedSemver}):** ${protectedSemverTags.slice(0, 10).join(', ')}${stats.protectedSemver > 10 ? '...' : ''}\n`)
+              .addBreak()
+              .addRaw(`**Special tags (${stats.protectedSpecial}):** ${protectedSpecialTags.slice(0, 10).join(', ')}${stats.protectedSpecial > 10 ? '...' : ''}\n`)
+              .addBreak()
+              .addRaw(`**Recent PRs (${stats.protectedRecentPR}):** ${protectedRecentPRTags.slice(0, 10).join(', ')}${stats.protectedRecentPR > 10 ? '...' : ''}\n`)
+              .addBreak()
+              .addHeading(`${dryRun ? '🗑️ Would Delete' : '✅ Deleted'} (>${retentionDays} days old)`, 3)
+              .addRaw(`**Old PR tags (${stats.deletedOldPR}):** ${deletedDetails.pr.slice(0, 10).join(', ')}${stats.deletedOldPR > 10 ? ` ... +${stats.deletedOldPR - 10} more` : ''}\n`)
+              .addBreak()
+              .addRaw(`**Old SHA tags (${stats.deletedOldSHA}):** ${deletedDetails.sha.slice(0, 10).join(', ')}${stats.deletedOldSHA > 10 ? ` ... +${stats.deletedOldSHA - 10} more` : ''}\n`)
+              .addBreak()
+              .addRaw(`**Untagged images (${stats.deletedUntagged}):** ${deletedDetails.untagged.slice(0, 5).join(', ')}${stats.deletedUntagged > 5 ? ` ... +${stats.deletedUntagged - 5} more` : ''}\n`)
+              .addBreak();
+
+            if (dryRun) {
+              await core.summary
+                .addRaw('---\n')
+                .addRaw('💡 **To enable actual deletion:**\n')
+                .addRaw('1. Edit `.github/workflows/ghcr-cleanup.yml`\n')
+                .addRaw('2. Change `DRY_RUN: \'true\'` to `DRY_RUN: \'false\'`\n')
+                .addRaw('3. Commit and push\n');
+            }
+
+            await core.summary.write();
+
+            core.info(`\n${'='.repeat(60)}`);
+            core.info(`✅ Cleanup complete!`);
+            core.info(`   Scanned: ${stats.scanned} versions`);
+            core.info(`   Protected: ${totalProtected} versions`);
+            core.info(`   ${dryRun ? 'Would delete' : 'Deleted'}: ${toDelete.length} versions`);
+            core.info(`${'='.repeat(60)}`);


### PR DESCRIPTION
## Summary

Enables automated weekly cleanup of short-lived Docker image tags ( and ) while preserving important releases.

## Changes

**Modified :**
- ✅ Enabled weekly schedule (Sunday 3:00 AM UTC)
- ✅ Added intelligent tag lifecycle management
- ✅ Retention period: 7 days for short-lived tags
- ✅ Keep last 5 PR tags regardless of age
- ✅ Start in dry-run mode for safe testing
- ✅ Enhanced summary with detailed statistics

**Updated :**
- 📝 Documented new cleanup policy
- 📝 Added tag retention table
- 📝 Included examples and usage instructions

## Cleanup Policy

| Tag Pattern | Retention | Examples |
|-------------|-----------|----------|
| `x.x.x*` (semver) | ✅ Forever | `3.0.0-beta.4`, `3.0`, `2.1.0` |
| `latest`, `stable` | ✅ Forever | Special release tags |
| `develop`, `main` | ✅ Forever | Branch tracking tags |
| `pr-*` (last 5) | ✅ Forever | `pr-330`, `pr-329`, ... |
| `pr-*` (older) | 🗑️ 7 days | Old PR tags not in last 5 |
| `sha-*` | 🗑️ 7 days | Commit-specific tags |
| Untagged | 🗑️ 7 days | Digest-only images |

## Safety Features

- ✅ **Dry-run enabled by default** - no accidental deletions
- ✅ **7-day minimum age** before deletion
- ✅ **Protected tag patterns** (regex-based safeguards)
- ✅ **Always keeps last 5 PR builds** for debugging
- ✅ **Detailed logging and summaries**
- ✅ **Manual trigger option** for testing

## Testing Plan

1. **Merge PR** to enable the workflow
2. **Manually trigger** workflow in dry-run mode
3. **Review output** to verify correct behavior
4. **Enable actual deletion** by changing `DRY_RUN: 'false'` (after verification)
5. **Monitor** weekly automated runs

## Benefits

- Reduces registry storage usage
- Keeps registry clean and organized
- Preserves important builds and releases
- Fully automated with safety controls

## Example Output (Dry-Run)

```
Scanned: 45 package versions

✅ KEEP: 3.0.0-beta.4 (protected semver)
✅ KEEP: latest (protected special tag)
✅ KEEP: pr-330 (recent PR, #1 of 5)
✅ KEEP: sha-a9efa33 (too recent, age: 2 hours)
🗑️  DELETE: pr-320 (age: 10 days, not in last 5 PRs)
🗑️  DELETE: sha-99e4de7 (age: 14 days)

Summary:
- Protected: 35 versions
- Would delete: 10 versions (DRY-RUN)
```

---

Closes #331