### PR TITLE
docs: update documentation for scraper extraction (Phase 4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -231,15 +231,12 @@ SCRAPE_MODE=weekly
 # ============================================================================
 
 # Redis connection URL (used by backend and scraper microservice)
+# Redis is a mandatory dependency — the server requires Redis for scraping operations.
 REDIS_URL=redis://localhost:6379
 
 # ============================================================================
 # SCRAPER MICROSERVICE CONFIGURATION
 # ============================================================================
-
-# Feature flag: set to "true" to use the Redis-based scraper microservice
-# When false (default), the legacy in-process scraper is used
-USE_REDIS_SCRAPER=false
 
 # Scraper container run mode:
 # - "consumer"  : Long-running process polling Redis queue (for ics-scraper)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,10 +110,22 @@ npm test
 npm run test:run
 
 # Single file
-npx vitest run src/services/scraper/theater-parser.test.ts
+npx vitest run src/utils/url.test.ts
 
 # With coverage report
 npm run test:coverage
+```
+
+For scraper microservice tests:
+
+```bash
+cd scraper
+
+# Watch mode
+npm test
+
+# Single run
+npm run test:run
 ```
 
 ### Coverage Targets
@@ -126,18 +138,19 @@ npm run test:coverage
 ### Test File Locations
 
 ```
-server/src/services/scraper/theater-parser.test.ts  # Parser tests
-server/src/utils/date.test.ts                       # Utility tests
-server/tests/fixtures/                              # HTML fixtures
+scraper/src/scraper/theater-parser.test.ts  # Parser tests (scraper microservice)
+server/src/utils/date.test.ts               # Server utility tests
+server/src/utils/url.test.ts                # URL utility tests
+scraper/tests/unit/                         # Scraper unit tests
 ```
 
 ### Adding Test Fixtures
 
-For scraper tests, use real HTML fixtures:
+For scraper parser tests, use real HTML fixtures in the scraper package:
 
 ```bash
 curl "https://www.allocine.fr/seance/salle_gen_csalle=CXXXX.html" \
-  -o server/tests/fixtures/cinema-cxxxx-page.html
+  -o scraper/tests/fixtures/cinema-cxxxx-page.html
 ```
 
 ---
@@ -273,31 +286,30 @@ git branch -d feature/<issue-number>-<short-description>
 
 ```
 allo-scrapper/
-├── server/                     # Express.js backend
+├── server/                     # Express.js backend (API + frontend only — no scraping)
 │   ├── src/
 │   │   ├── config/             # Configuration (cinemas.json)
 │   │   ├── db/                 # Database queries and schema
 │   │   ├── routes/             # API route handlers
 │   │   ├── services/
-│   │   │   ├── scraper/        # In-process scraping logic
-│   │   │   │   ├── index.ts            # Orchestrator
-│   │   │   │   ├── theater-parser.ts   # HTML parsing
-│   │   │   │   └── http-client.ts      # HTTP requests
 │   │   │   ├── redis-client.ts         # Redis job publisher
-│   │   │   ├── scrape-manager.ts       # Scrape session management
-│   │   │   └── progress-tracker.ts     # SSE event system
+│   │   │   ├── progress-tracker.ts     # SSE event system
+│   │   │   ├── theme-generator.ts      # Dynamic CSS (/api/theme.css)
+│   │   │   └── system-info.ts          # System info helpers
 │   │   ├── middleware/         # Auth, admin, rate-limit middleware
 │   │   ├── types/              # TypeScript definitions
 │   │   └── utils/
 │   │       ├── logger.ts       # Winston structured logger (service=ics-web)
-│   │       └── date.ts         # Date utilities
-│   └── tests/
-│       └── fixtures/           # Test HTML files
+│   │       ├── date.ts         # Date utilities
+│   │       └── url.ts          # URL validation/parsing (isValidAllocineUrl, etc.)
 ├── scraper/                    # Standalone scraper microservice
 │   ├── src/
 │   │   ├── db/                 # Direct DB access (same schema)
 │   │   ├── redis/              # RedisJobConsumer + RedisProgressPublisher
-│   │   ├── scraper/            # Scraping logic (mirrors server/services/scraper)
+│   │   ├── scraper/            # All scraping/parsing logic
+│   │   │   ├── index.ts            # Orchestrator
+│   │   │   ├── theater-parser.ts   # HTML parsing
+│   │   │   └── http-client.ts      # HTTP requests
 │   │   └── utils/
 │   │       ├── logger.ts       # Winston logger (service=ics-scraper)
 │   │       ├── metrics.ts      # prom-client metrics (port 9091)
@@ -315,7 +327,6 @@ allo-scrapper/
 ├── e2e/                        # Playwright E2E tests (out of scope for now)
 ├── .github/                    # GitHub config (issues, workflows)
 ├── WHITE-LABEL.md              # White-label branding system docs
-├── MONITORING.md               # Observability stack documentation
 ├── CONTRIBUTING.md             # Human contributor guide
 └── AGENTS.md                   # This file
 ```
@@ -365,10 +376,9 @@ cd scraper && npm test
 
 ```bash
 docker compose build                                          # Build all images
-docker compose up -d                                         # Base stack (app + DB + Redis)
-docker compose --profile scraper up -d                       # With scraper microservice
+docker compose up -d                                         # Default stack (web + DB + Redis + scraper)
 docker compose --profile monitoring up -d                    # With Prometheus/Grafana/Loki/Tempo
-docker compose --profile monitoring --profile scraper up -d  # Everything
+docker compose --profile monitoring up -d                    # Everything (monitoring + default stack)
 ```
 
 ### Git
@@ -407,13 +417,15 @@ curl -X POST http://localhost:3000/api/cinemas \
 
 No file commit is needed — Postgres is the source of truth. `cinemas.json` is only a one-time bootstrap seed and is never written to by the application.
 
+The API inserts a minimal cinema record immediately and publishes an `add_cinema` Redis job. The scraper microservice picks it up asynchronously and enriches the cinema with showtimes and film data.
+
 For parser changes, write tests first (see Step 3).
 
 ### Fixing a Parser Bug
 
-1. Fetch HTML fixture: `curl "..." -o server/tests/fixtures/cinema-cxxxx-page.html`
-2. Write failing test reproducing the bug
-3. Fix the parser
+1. Fetch HTML fixture: `curl "..." -o scraper/tests/fixtures/cinema-cxxxx-page.html`
+2. Write failing test in `scraper/src/scraper/theater-parser.test.ts`
+3. Fix the parser in `scraper/src/scraper/theater-parser.ts`
 4. Verify test passes
 5. Commit: `fix(parser): <description>`
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 - **Performance Optimized**: JSON parse caching with LRU eviction (95-99% hit rate)
 - **Docker Ready**: Full containerization with multi-stage builds (linux/amd64)
 - **CI/CD**: GitHub Actions workflow for automated Docker image builds
-- **Redis Job Queue**: Scraper microservice mode via Redis pub/sub (`USE_REDIS_SCRAPER=true`)
+- **Scraper Microservice**: Standalone scraper service communicates with the API via Redis job queue and pub/sub
 - **Observability**: Prometheus metrics, Grafana dashboards, Loki log aggregation, Tempo distributed tracing
 - **Production Ready**: Health checks, error handling, and database migrations
 
@@ -57,13 +57,12 @@
 ┌─────────────────┐    Redis pub/sub    ┌───────────────────┐
 │  Express.js API │◄───────────────────►│ Scraper           │
 │  (TypeScript)   │   scrape:jobs queue │ Microservice      │
-│                 │───────────────────►│ (ics-scraper)     │
-│  feature flag:  │                    │                   │
-│  USE_REDIS_     │    (legacy mode)   │  ┌─────────────┐  │
-│  SCRAPER=false  │◄───in-process──────┤  │ Cron        │  │
-│  → in-process   │                    │  │ (ics-scraper│  │
-│  SCRAPER=true   │                    │  │  -cron)     │  │
-│  → Redis queue  │                    │  └─────────────┘  │
+│  API + frontend │────────────────────►│ (ics-scraper)     │
+│  only — no      │                    │                   │
+│  scraping code  │                    │  ┌─────────────┐  │
+│                 │                    │  │ Cron        │  │
+│                 │                    │  │ (ics-scraper│  │
+│                 │                    │  │  -cron)     │  │
 └────────┬────────┘                    └────────┬──────────┘
          │ SQL                                  │ SQL
          └──────────────────┬───────────────────┘
@@ -75,7 +74,7 @@
               └─────────────────────────┘
 
               ┌─────────────────────────┐
-              │   Redis  (in-memory)    │  Message queue + pub/sub
+              │   Redis  (mandatory)    │  Job queue + progress pub/sub
               └─────────────────────────┘
 
   Monitoring (--profile monitoring):
@@ -87,12 +86,11 @@
 **Data Flow:**
 1. Client makes HTTP requests to Express API (`/api/*`)
 2. API routes handle business logic and validate requests
-3. Scraper fetches data from the source website — either in-process (default) or via a Redis job queue (`USE_REDIS_SCRAPER=true`)
-4. Progress events flow back to the API via Redis pub/sub → SSE → client
-5. PostgreSQL stores structured cinema, film, and showtime data
-6. Client receives JSON responses and renders UI
-
-> See [MONITORING.md](./MONITORING.md) for the full observability stack documentation.
+3. API publishes scrape jobs to Redis (`scrape:jobs` queue) — the scraper microservice picks them up
+4. Scraper fetches data from the source website and writes results directly to PostgreSQL
+5. Progress events flow back to the API via Redis pub/sub → SSE → client
+6. PostgreSQL stores structured cinema, film, and showtime data
+7. Client receives JSON responses and renders UI
 
 ---
 
@@ -314,7 +312,7 @@ For active development without Docker:
 **Prerequisites:**
 - Node.js 20.19+ or 22.12+
 - PostgreSQL 15+
-- Redis (optional, only if `USE_REDIS_SCRAPER=true`)
+- Redis (required for scraping operations)
 
 **Setup:**
 ```bash
@@ -333,8 +331,11 @@ npm install
 # Setup environment and database
 cd ../server
 cp .env.example .env
-# Edit .env with your PostgreSQL credentials
+# Edit .env with your PostgreSQL and Redis credentials
 npm run db:migrate
+
+# Start Redis (required — scraping will not work without it)
+# e.g. via Docker: docker run -d -p 6379:6379 redis:7-alpine
 
 # Run development servers (in separate terminals)
 # Terminal 1 - API server
@@ -342,6 +343,9 @@ cd server && npm run dev    # API on http://localhost:3000
 
 # Terminal 2 - Frontend dev server
 cd client && npm run dev    # UI on http://localhost:5173
+
+# Terminal 3 - Scraper microservice (for scraping to work locally)
+cd scraper && npm run dev
 ```
 
 **⚠️ Important:** Always run `npm install` from the `server/` directory, not the root. The `sharp` image processing library requires native binaries that may not install correctly if run from the wrong directory.


### PR DESCRIPTION
## Summary

- **README.md**: architecture diagram updated to two-service model (no feature flag, no in-process path), Redis documented as mandatory, local dev setup includes scraper microservice startup, removed `USE_REDIS_SCRAPER` references
- **AGENTS.md**: project structure updated (deleted files/dirs removed, `url.ts` added), test file locations point to `scraper/`, Docker commands updated (`--profile scraper` removed — now part of default stack), common patterns updated (parser bug fixing references `scraper/src/scraper/`, adding cinema documents async Redis enrichment)
- **.env.example**: `USE_REDIS_SCRAPER` removed, Redis documented as mandatory dependency

Closes #347