### PR TITLE
🛡️ Sentinel: [MEDIUM] Add input length limits for users pagination

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -13,3 +13,7 @@
 **Vulnerability:** Weak shuffling of generated passwords using `Array.prototype.sort(() => crypto.randomInt(0, 2) - 0.5)`. This introduces bias, leading to an uneven distribution of characters where the first 4 specific characters (Uppercase, Lowercase, Digit, Special) might remain in predictable positions, reducing the password's entropy and strength.
 **Learning:** `Array.prototype.sort()` is designed for sorting, not shuffling. Its implementation (often TimSort or QuickSort) makes it non-uniform for shuffling, even with a cryptographically secure random number generator in the comparison function.
 **Prevention:** Use a cryptographically secure algorithm like Fisher-Yates shuffle combined with a secure random number generator (e.g., `crypto.randomInt`) for security-sensitive shuffling tasks such as password generation.
+## 2026-03-11 - [Add input length limits for users pagination]
+**Vulnerability:** The `limit` query parameter on `GET /api/users` lacked an upper bound.
+**Learning:** This exposes the application to Denial of Service (DoS) attacks if a malicious user requests millions of records, causing high memory and DB strain.
+**Prevention:** Always validate and safely clamp all unbounded inputs related to database pagination arrays/limits (e.g., max 100 limits).

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1782,7 +1782,6 @@
       "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.18",
         "fflate": "^0.8.2",
@@ -2393,7 +2392,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -3307,7 +3305,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -3405,7 +3402,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4218,7 +4214,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4306,7 +4301,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4382,7 +4376,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",

--- a/server/src/routes/users.test.ts
+++ b/server/src/routes/users.test.ts
@@ -132,6 +132,17 @@ describe('User Management Routes', () => {
       expect(userQueries.getAllUsers).toHaveBeenCalledWith(db, { limit: 50, offset: 0 });
     });
 
+    it('should clamp limit query parameter to 100 max', async () => {
+      vi.mocked(userQueries.getAllUsers).mockResolvedValue([]);
+
+      const response = await request(app)
+        .get('/api/users?limit=1000')
+        .set('Authorization', 'Bearer valid-admin-token');
+
+      expect(response.status).toBe(200);
+      expect(userQueries.getAllUsers).toHaveBeenCalledWith(db, { limit: 100, offset: 0 });
+    });
+
     it('should support offset query parameter', async () => {
       vi.mocked(userQueries.getAllUsers).mockResolvedValue([]);
 

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -37,7 +37,7 @@ router.get(
       const db: DB = req.app.get('db');
 
       // Parse pagination params
-      const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 100;
+      let limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 100;
       const offset = req.query.offset ? parseInt(req.query.offset as string, 10) : 0;
 
       // Validate pagination params
@@ -55,6 +55,9 @@ router.get(
         } as ApiResponse);
         return;
       }
+
+      // Security: Validate and clamp pagination parameters to prevent DoS
+      if (limit > 100) limit = 100;
 
       const users = await getAllUsers(db, { limit, offset });
 


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add input length limits for users pagination

🚨 Severity: MEDIUM
💡 Vulnerability: The `limit` query parameter on `GET /api/users` lacked an upper bound, allowing a user to request millions of records and thus creating a Denial of Service (DoS) risk.
🎯 Impact: High memory and CPU consumption could crash the backend and/or database by retrieving an unbounded number of records in a single query.
🔧 Fix: Clamped the `limit` query parameter strictly to a maximum of 100 within the handler.
✅ Verification: Tested via unit tests (`server/src/routes/users.test.ts`) that specifically supply `?limit=1000` and assert the backend properly scales it down to 100 before execution. Run `npm test --prefix server` to confirm.

---
*PR created automatically by Jules for task [8975394903373348392](https://jules.google.com/task/8975394903373348392) started by @PhBassin*