### PR TITLE
feat(docker): isole les contextes de build pour le scraper et le web

### DIFF
--- a/Dockerfile.dockerignore
+++ b/Dockerfile.dockerignore
@@ -1,0 +1,109 @@
+# Dependencies
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Build outputs
+dist
+build
+.next
+out
+.nuxt
+.cache
+
+# Frontend specific
+client/dist
+client/build
+client/node_modules
+
+# Backend specific
+server/dist
+server/build
+server/node_modules
+
+# Testing
+coverage
+.nyc_output
+*.lcov
+
+# Environment files
+.env
+.env.local
+.env.development
+.env.test
+.env.production
+.env*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+.DS_Store
+
+# Logs
+logs
+*.log
+
+# Database
+data/
+*.sqlite
+*.sqlite3
+*.db
+local.db
+
+# Docker
+docker-compose*
+.dockerignore
+Dockerfile*.dockerignore
+
+# Git
+.git
+.gitignore
+.gitattributes
+
+# CI/CD
+.github
+.gitlab-ci.yml
+.travis.yml
+.circleci
+
+# Documentation
+README.md
+CHANGELOG.md
+LICENSE
+docs/
+
+# Misc
+tmp
+temp
+*.tmp
+*.bak
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# Astro (old static site - not needed in Docker)
+.astro
+astro.config.mjs
+
+# ==========================================
+# WEB SPECIFIC IGNORES (Image A)
+# ==========================================
+# Ignore the entire scraper folder EXCEPT for its package.json (needed for npm workspaces)
+scraper/*
+!scraper/package.json
+
+# Ignore E2E tests folder
+e2e/

--- a/Dockerfile.scraper.dockerignore
+++ b/Dockerfile.scraper.dockerignore
@@ -1,0 +1,113 @@
+# Dependencies
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Build outputs
+dist
+build
+.next
+out
+.nuxt
+.cache
+
+# Frontend specific
+client/dist
+client/build
+client/node_modules
+
+# Backend specific
+server/dist
+server/build
+server/node_modules
+
+# Testing
+coverage
+.nyc_output
+*.lcov
+
+# Environment files
+.env
+.env.local
+.env.development
+.env.test
+.env.production
+.env*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+.DS_Store
+
+# Logs
+logs
+*.log
+
+# Database
+data/
+*.sqlite
+*.sqlite3
+*.db
+local.db
+
+# Docker
+docker-compose*
+.dockerignore
+Dockerfile*.dockerignore
+
+# Git
+.git
+.gitignore
+.gitattributes
+
+# CI/CD
+.github
+.gitlab-ci.yml
+.travis.yml
+.circleci
+
+# Documentation
+README.md
+CHANGELOG.md
+LICENSE
+docs/
+
+# Misc
+tmp
+temp
+*.tmp
+*.bak
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# Astro (old static site - not needed in Docker)
+.astro
+astro.config.mjs
+
+# ==========================================
+# SCRAPER SPECIFIC IGNORES (Image B)
+# ==========================================
+# Ignore client code
+client/*
+!client/package.json
+
+# Ignore server code
+server/*
+!server/package.json
+
+# Ignore E2E tests folder
+e2e/


### PR DESCRIPTION
## Summary
- Création de `Dockerfile.dockerignore` pour isoler l'image web
- Création de `Dockerfile.scraper.dockerignore` pour isoler l'image scraper
- Utilise la fonctionnalité de filtre de context de BuildKit pour un caching GHA plus rapide

## Resume of Execution
- Added Dockerfile.dockerignore filtering scraper files
- Added Dockerfile.scraper.dockerignore filtering client and server files

Closes #459