### PR TITLE
refactor(client): migrate data fetching to React Query (Issue 453)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.90.21",
+    "@tanstack/react-query-devtools": "^5.91.3",
     "axios": "^1.13.6",
     "clsx": "^2.1.1",
     "react": "^19.2.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,6 +13,17 @@ import ProtectedRoute from './components/ProtectedRoute';
 import RequirePermission from './components/RequirePermission';
 import ErrorBoundary from './components/ErrorBoundary';
 import { useTheme } from './hooks/useTheme';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
 
 function LoadingScreen() {
   return (
@@ -90,13 +101,16 @@ function AppRoutes() {
 function App() {
   return (
     <ErrorBoundary>
-      <AuthProvider>
-        <SettingsProvider>
-          <BrowserRouter>
-            <AppRoutes />
-          </BrowserRouter>
-        </SettingsProvider>
-      </AuthProvider>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <SettingsProvider>
+            <BrowserRouter>
+              <AppRoutes />
+            </BrowserRouter>
+          </SettingsProvider>
+        </AuthProvider>
+        <ReactQueryDevtools initialIsOpen={false} />
+      </QueryClientProvider>
     </ErrorBoundary>
   );
 }

--- a/client/src/pages/CinemaPage.tsx
+++ b/client/src/pages/CinemaPage.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useParams, Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import { getCinemas, getCinemaSchedule } from '../api/client';
-import type { Cinema, ShowtimeWithFilm } from '../types';
+import type { ShowtimeWithFilm } from '../types';
 import ShowtimeList from '../components/ShowtimeList';
 import CinemaDateSelector from '../components/CinemaDateSelector';
 
@@ -21,49 +22,43 @@ interface FilmGroup {
 
 export default function CinemaPage() {
   const { id } = useParams<{ id: string }>();
-  const [cinema, setCinema] = useState<Cinema | null>(null);
-  const [showtimes, setShowtimes] = useState<ShowtimeWithFilm[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [selectedDate, setSelectedDate] = useState<string>('');
 
-  const loadData = async () => {
-    if (!id) return;
+  const { data: cinemasData, isLoading: cinemasLoading, error: cinemasError } = useQuery({
+    queryKey: ['cinemas'],
+    queryFn: getCinemas
+  });
 
-    try {
-      setIsLoading(true);
-      setError(null);
-      
-      // Fetch cinema details and schedule in parallel
-      const [cinemas, schedule] = await Promise.all([
-        getCinemas(),
-        getCinemaSchedule(id),
-      ]);
-      
-      const foundCinema = cinemas.find(c => c.id === id);
-      if (!foundCinema) {
-        throw new Error('Cinema not found');
-      }
-      
-      setCinema(foundCinema);
-      setShowtimes(schedule.showtimes);
+  const { data: scheduleData, isLoading: scheduleLoading, error: scheduleError } = useQuery({
+    queryKey: ['cinema-schedule', id],
+    queryFn: () => getCinemaSchedule(id!),
+    enabled: !!id
+  });
 
-      // Set default selected date (today or first available)
-      if (schedule.showtimes.length > 0) {
-        const today = new Date().toISOString().split('T')[0];
-        const dates = getUniqueDates(schedule.showtimes);
-        setSelectedDate(dates.includes(today) ? today : dates[0]);
-      }
-    } catch (err: any) {
-      setError(err.message || 'Failed to load cinema data');
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  const isLoading = cinemasLoading || scheduleLoading;
+  const queryError = cinemasError || scheduleError;
+  const error = queryError instanceof Error ? queryError.message : (queryError ? 'Failed to load cinema data' : null);
 
+  // Validate if cinema was not found in cinemasData
+  if (!isLoading && cinemasData && !cinemasData.some(c => c.id === id)) {
+    // Setting an error message similar to before if cinema is not found
+    // however returning 'Cinema not found' directly in JSX handles it below
+  }
+
+  const cinema = cinemasData?.find(c => c.id === id) || null;
+  const showtimes = scheduleData?.showtimes || [];
+
+  // Set default selected date (today or first available) when schedule is loaded
   useEffect(() => {
-    loadData();
-  }, [id]);
+    if (showtimes.length > 0 && !selectedDate) {
+      const today = new Date().toISOString().split('T')[0];
+      
+      const dates = new Set(showtimes.map(s => s.date));
+      const uniqueDates = Array.from(dates).sort();
+      
+      setSelectedDate(uniqueDates.includes(today) ? today : uniqueDates[0]);
+    }
+  }, [showtimes, selectedDate]);
 
   const getUniqueDates = (showtimes: ShowtimeWithFilm[]): string[] => {
     const dates = new Set(showtimes.map(s => s.date));

--- a/client/src/pages/FilmPage.tsx
+++ b/client/src/pages/FilmPage.tsx
@@ -1,41 +1,21 @@
-import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import { getFilmById } from '../api/client';
-import type { FilmWithShowtimes } from '../types';
 import CinemaShowtimes from '../components/CinemaShowtimes';
 
 export default function FilmPage() {
   const { id } = useParams<{ id: string }>();
-  const [film, setFilm] = useState<FilmWithShowtimes | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  
+  const filmId = id ? Number(id) : NaN;
+  const isInvalidId = Number.isNaN(filmId);
 
-  useEffect(() => {
-    const loadData = async () => {
-      if (!id) return;
+  const { data: film, isLoading, error: queryError } = useQuery({
+    queryKey: ['film', filmId],
+    queryFn: () => getFilmById(filmId),
+    enabled: !isInvalidId
+  });
 
-      const filmId = Number(id);
-      if (Number.isNaN(filmId)) {
-        setError('Invalid film ID');
-        setIsLoading(false);
-        return;
-      }
-
-      try {
-        setIsLoading(true);
-        setError(null);
-        
-        const data = await getFilmById(filmId);
-        setFilm(data);
-      } catch (err: any) {
-        setError(err.message || 'Failed to load film data');
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    loadData();
-  }, [id]);
+  const error = isInvalidId ? 'Invalid film ID' : (queryError instanceof Error ? queryError.message : (queryError ? 'Failed to load film data' : null));
 
   if (isLoading) {
     return (

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useState, useContext, useCallback, useMemo } from 'react';
-
+import { useState, useContext, useCallback, useMemo } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getWeeklyFilms, getFilmsByDate, getCinemas, addCinema } from '../api/client';
-import type { FilmWithShowtimes, Cinema } from '../types';
 import FilmCard from '../components/FilmCard';
 import DaySelector from '../components/DaySelector';
 import FilmSearchBar from '../components/FilmSearchBar';
@@ -10,40 +9,28 @@ import { AuthContext } from '../contexts/AuthContext';
 import CinemasQuickLinks from '../components/CinemasQuickLinks';
 
 export default function HomePage() {
-  const [films, setFilms] = useState<FilmWithShowtimes[]>([]);
-  const [cinemas, setCinemas] = useState<Cinema[]>([]);
-  const [weekStart, setWeekStart] = useState<string>('');
-  const [selectedDate, setSelectedDate] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const [selectedDate, setSelectedDate] = useState<string>('');
   const { isAuthenticated, hasPermission } = useContext(AuthContext);
 
-  const loadData = async (date?: string | null) => {
-    try {
-      setIsLoading(true);
-      setError(null);
-      
-      const [filmsData, cinemasData] = await Promise.all([
-        date ? getFilmsByDate(date) : getWeeklyFilms(),
-        getCinemas(),
-      ]);
-      
-      setFilms(filmsData.films);
-      setWeekStart(filmsData.weekStart);
-      setCinemas(cinemasData);
-    } catch (err: any) {
-      setError(err.message || 'Failed to load data');
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  const { data: cinemas = [], isLoading: isLoadingCinemas } = useQuery({
+    queryKey: ['cinemas'],
+    queryFn: getCinemas,
+  });
 
-  useEffect(() => {
-    loadData(selectedDate);
-  }, [selectedDate]);
+  const { data: filmsData, isLoading: isLoadingFilms, error: filmsError } = useQuery({
+    queryKey: ['films', selectedDate],
+    queryFn: () => selectedDate ? getFilmsByDate(selectedDate) : getWeeklyFilms(),
+  });
+
+  const films = filmsData?.films || [];
+  const weekStart = filmsData?.weekStart || '';
+
+  const isLoading = isLoadingCinemas || isLoadingFilms;
+  const error = filmsError instanceof Error ? filmsError.message : null;
 
   const handleDateSelect = useCallback((date: string | null) => {
-    setSelectedDate(date);
+    setSelectedDate(date || '');
   }, []);
   const formatterDate = useMemo(() => new Intl.DateTimeFormat('fr-FR', {
     day: 'numeric',
@@ -66,17 +53,23 @@ export default function HomePage() {
     return formatDate(end.toISOString());
   };
 
+  const addCinemaMutation = useMutation({
+    mutationFn: addCinema,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['cinemas'] });
+      queryClient.invalidateQueries({ queryKey: ['films', selectedDate] });
+    },
+    onError: (err: any) => {
+      alert(err.message || 'Erreur lors de l\'ajout du cinéma');
+    }
+  });
+
   const handleAddCinema = useCallback(async () => {
     const url = window.prompt("Entrez l'URL Allociné du cinéma à ajouter (ex: https://www.allocine.fr/seance/salle_affich-salle=C0013.html):");
     if (!url) return;
 
-    try {
-      await addCinema(url);
-      await loadData(selectedDate);
-    } catch (err: any) {
-      setError(err.message || 'Erreur lors de l\'ajout du cinéma');
-    }
-  }, [selectedDate]);
+    addCinemaMutation.mutate(url);
+  }, [addCinemaMutation]);
 
   if (isLoading) {
     return (

--- a/client/src/pages/ReportsPage.tsx
+++ b/client/src/pages/ReportsPage.tsx
@@ -1,45 +1,40 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { Link, useSearchParams } from 'react-router-dom';
 import { getScrapeReports, getScrapeReportById } from '../api/client';
-import type { ScrapeReport, PaginatedResponse } from '../types';
+import type { ScrapeReport } from '../types';
 
 export default function ReportsPage() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const [reports, setReports] = useState<PaginatedResponse<ScrapeReport> | null>(null);
-  const [selectedReport, setSelectedReport] = useState<ScrapeReport | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  
   // Get reportId and page from URL query params
   const reportId = searchParams.get('reportId');
   const page = parseInt(searchParams.get('page') || '1', 10);
   const pageSize = 10;
 
-  useEffect(() => {
-    const loadReports = async () => {
-      try {
-        setIsLoading(true);
-        setError(null);
-        
-        if (reportId) {
-          // Load specific report
-          const report = await getScrapeReportById(Number(reportId));
-          setSelectedReport(report);
-        } else {
-          // Load reports list - RESET selectedReport to force list view
-          setSelectedReport(null);
-          const data = await getScrapeReports({ page, pageSize });
-          setReports(data);
-        }
-      } catch (err: any) {
-        setError(err.message || 'Failed to load reports');
-      } finally {
-        setIsLoading(false);
-      }
-    };
+  const {
+    data: reports,
+    isLoading: isLoadingReports,
+    error: errorReportsQuery
+  } = useQuery({
+    queryKey: ['reports', page],
+    queryFn: () => getScrapeReports({ page, pageSize }),
+    enabled: !reportId,
+  });
 
-    loadReports();
-  }, [reportId, page]);
+  const {
+    data: selectedReport,
+    isLoading: isLoadingReport,
+    error: errorReportQuery
+  } = useQuery({
+    queryKey: ['report', reportId],
+    queryFn: () => getScrapeReportById(Number(reportId)),
+    enabled: !!reportId,
+  });
+
+  const isLoading = reportId ? isLoadingReport : isLoadingReports;
+  const errorQuery = reportId ? errorReportQuery : errorReportsQuery;
+  const error = errorQuery instanceof Error ? errorQuery.message : null;
+
 
   // ⚡ PERFORMANCE: Cache Intl.DateTimeFormat instance to prevent expensive
   // re-initialization during loop renders for the reports list.

--- a/client/src/pages/admin/CinemasPage.tsx
+++ b/client/src/pages/admin/CinemasPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo, useContext } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getCinemas, createCinema, updateCinema, deleteCinema } from '../../api/cinemas';
 import type { CinemaCreate, CinemaUpdate } from '../../api/cinemas';
 import { triggerScrape, triggerCinemaScrape, getScrapeStatus } from '../../api/client';
@@ -22,9 +23,15 @@ const CinemasPage: React.FC = () => {
   const canUpdate = hasPermission('cinemas:update');
   const canDelete = hasPermission('cinemas:delete');
 
-  const [cinemas, setCinemas] = useState<Cinema[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+
+  const { data: cinemas = [], isLoading: loading, error: queryError } = useQuery({
+    queryKey: ['cinemas'],
+    queryFn: getCinemas
+  });
+
+  const error = queryError instanceof Error ? queryError.message : null;
+
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   // Search
@@ -40,25 +47,6 @@ const CinemasPage: React.FC = () => {
   const [cinemaToDelete, setCinemaToDelete] = useState<Cinema | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
-
-  // ── Data fetching ────────────────────────────────────────────────────────────
-
-  const fetchCinemas = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      const data = await getCinemas();
-      setCinemas(data);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch cinemas');
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchCinemas();
-  }, [fetchCinemas]);
 
   // ── Check if scrape is already running on mount ───────────────────────────────
 
@@ -82,33 +70,50 @@ const CinemasPage: React.FC = () => {
 
   // ── Handlers ─────────────────────────────────────────────────────────────────
 
+  const createMutation = useMutation({
+    mutationFn: createCinema,
+    onSuccess: () => {
+      setShowAddModal(false);
+      setSuccessMessage('Cinema added successfully');
+      queryClient.invalidateQueries({ queryKey: ['cinemas'] });
+    }
+  });
+
   const handleAdd = async (data: CinemaCreate) => {
-    await createCinema(data);
-    setShowAddModal(false);
-    setSuccessMessage('Cinema added successfully');
-    await fetchCinemas();
+    createMutation.mutate(data);
   };
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, updates }: { id: string; updates: CinemaUpdate }) => updateCinema(id, updates),
+    onSuccess: () => {
+      setCinemaToEdit(null);
+      setSuccessMessage('Cinema updated successfully');
+      queryClient.invalidateQueries({ queryKey: ['cinemas'] });
+    }
+  });
 
   const handleUpdate = async (id: string, updates: CinemaUpdate) => {
-    await updateCinema(id, updates);
-    setCinemaToEdit(null);
-    setSuccessMessage('Cinema updated successfully');
-    await fetchCinemas();
+    updateMutation.mutate({ id, updates });
   };
 
-  const handleDelete = async (cinemaId: string) => {
-    try {
-      setIsDeleting(true);
-      setDeleteError(null);
-      await deleteCinema(cinemaId);
+  const deleteMutation = useMutation({
+    mutationFn: deleteCinema,
+    onSuccess: () => {
       setCinemaToDelete(null);
       setSuccessMessage('Cinema deleted successfully');
-      await fetchCinemas();
-    } catch (err) {
+      queryClient.invalidateQueries({ queryKey: ['cinemas'] });
+      setIsDeleting(false);
+    },
+    onError: (err) => {
       setDeleteError(err instanceof Error ? err.message : 'Failed to delete cinema');
-    } finally {
       setIsDeleting(false);
     }
+  });
+
+  const handleDelete = async (cinemaId: string) => {
+    setIsDeleting(true);
+    setDeleteError(null);
+    deleteMutation.mutate(cinemaId);
   };
 
   // ── Scraping handlers ────────────────────────────────────────────────────────
@@ -121,9 +126,9 @@ const CinemasPage: React.FC = () => {
     setTimeout(() => {
       setShowProgress(false);
       setScrapingCinemaId(null);
-      fetchCinemas();
+      queryClient.invalidateQueries({ queryKey: ['cinemas'] });
     }, 2000);
-  }, [fetchCinemas]);
+  }, [queryClient]);
 
   // ── Filtering ────────────────────────────────────────────────────────────────
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,8 @@
     "client": {
       "version": "3.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.90.21",
+        "@tanstack/react-query-devtools": "^5.91.3",
         "axios": "^1.13.6",
         "clsx": "^2.1.1",
         "react": "^19.2.0",
@@ -4034,6 +4036,59 @@
         "@tailwindcss/oxide": "4.2.1",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.1"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.93.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.93.0.tgz",
+      "integrity": "sha512-+kpsx1NQnOFTZsw6HAFCW3HkKg0+2cepGtAWXjiiSOJJ1CtQpt72EE2nyZb+AjAbLRPoeRmPJ8MtQd8r8gsPdg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
+      "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.20"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.91.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.91.3.tgz",
+      "integrity": "sha512-nlahjMtd/J1h7IzOOfqeyDh5LNfG0eULwlltPEonYy0QL+nqrBB+nyzJfULV+moL7sZyxc2sHdNJki+vLA9BSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.93.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.90.20",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {


### PR DESCRIPTION
## Summary
- Migrated admin, reports, home, film, and cinema pages to use @tanstack/react-query
- Replaced useState/useEffect data fetching with useQuery and useMutation hooks for efficient caching and state management
- Simplified and standardized loading and error state handling across all refactored client pages
- Cleaned up typing and compilation errors in HomePage

### Resume of Execution
- Verified existing migration status of CinemasPage, ReportsPage, and HomePage.
- Successfully migrated `FilmPage.tsx` and `CinemaPage.tsx` to use `useQuery`.
- Cleaned up and fixed compilation errors left behind in `HomePage.tsx` preventing VITE build.
- Ran backend and frontend tests to ensure no breakage. Build succeeded.

Closes #453