### PR TITLE
feat(client): make header sticky on vertical scroll

### DIFF
--- a/client/src/components/HeaderSticky.test.tsx
+++ b/client/src/components/HeaderSticky.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import Layout from './Layout';
+import { AuthContext } from '../contexts/AuthContext';
+import { SettingsContext } from '../contexts/SettingsContext';
+
+const mockAuthContext = {
+  isAuthenticated: false,
+  user: null,
+  logout: vi.fn(),
+  login: vi.fn(),
+  isAdmin: false,
+  hasPermission: vi.fn(() => false),
+  token: null,
+};
+
+const mockSettingsContext = {
+  publicSettings: {
+    site_name: 'Allo-Scrapper',
+    logo_base64: null,
+    favicon_base64: null,
+    color_primary: '#1976d2',
+    color_secondary: '#dc004e',
+    color_accent: '#ff9800',
+    color_background: '#ffffff',
+    color_text: '#000000',
+    color_text_secondary: '#666666',
+    color_border: '#e0e0e0',
+    color_success: '#4caf50',
+    color_error: '#f44336',
+    font_family_heading: 'Roboto',
+    font_family_body: 'Roboto',
+    footer_text: 'Test Footer',
+    footer_links: [],
+  },
+  adminSettings: null,
+  isLoading: false,
+  isLoadingPublic: false,
+  error: null,
+  refreshPublicSettings: vi.fn(),
+  refreshAdminSettings: vi.fn(),
+  updateSettings: vi.fn(),
+};
+
+describe('Header Stickiness', () => {
+  it('should have sticky classes on the header element', () => {
+    render(
+      <BrowserRouter>
+        <AuthContext.Provider value={mockAuthContext}>
+          <SettingsContext.Provider value={mockSettingsContext}>
+            <Layout>Test Content</Layout>
+          </SettingsContext.Provider>
+        </AuthContext.Provider>
+      </BrowserRouter>
+    );
+
+    const header = screen.getByRole('banner');
+    expect(header).toHaveClass('sticky');
+    expect(header).toHaveClass('top-0');
+    expect(header).toHaveClass('z-50');
+  });
+});

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -48,7 +48,7 @@ export default function Layout({ children, title }: LayoutProps) {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <header className="bg-secondary text-white shadow-lg">
+      <header className="bg-secondary text-white shadow-lg sticky top-0 z-50">
         <div className="container mx-auto px-4 py-4">
           <div className="flex items-center justify-between">
             <Link to="/" className="text-2xl font-bold flex items-center gap-2">


### PR DESCRIPTION
## Summary
- Added Tailwind CSS classes `sticky top-0 z-50` to the header in `Layout.tsx`.
- Added a unit test `HeaderSticky.test.tsx` to verify the fix.

## Resume of Execution
- Created issue #466.
- Created feature branch `feature/466-sticky-header`.
- Implemented the sticky header.
- Verified with unit tests (`HeaderSticky.test.tsx` and `Layout.test.tsx`).
- All pre-push checks passed.

Closes #466