### PR TITLE
test(client): fix failing vitest tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ client/dist/
 .env
 .env.*
 !.env.example
+.env-*
 
 # Database
 data/

--- a/client/src/components/StickyElements.test.tsx
+++ b/client/src/components/StickyElements.test.tsx
@@ -12,6 +12,7 @@ vi.mock('../api/client', () => ({
   getFilmsByDate: vi.fn(),
   getCinemas: vi.fn(),
   getCinemaSchedule: vi.fn(),
+  addCinema: vi.fn(),
 }));
 
 const mockAuthContext = {

--- a/client/src/pages/CinemaPage.test.tsx
+++ b/client/src/pages/CinemaPage.test.tsx
@@ -10,6 +10,36 @@ vi.mock('../api/client', () => ({
   getCinemaSchedule: vi.fn(),
 }));
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AuthContext } from '../contexts/AuthContext';
+
+const mockAuthContext = {
+  isAuthenticated: true,
+  user: { id: 1, username: 'testuser', role_id: 1, role_name: 'admin', is_system_role: true, permissions: ['cinemas:create', 'scraper:trigger'] as any[] },
+  logout: vi.fn(),
+  login: vi.fn(),
+  isAdmin: false,
+  hasPermission: vi.fn(() => true),
+  token: 'mock-token',
+};
+
+const renderWithClient = (ui: React.ReactElement) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AuthContext.Provider value={mockAuthContext}>
+        {ui}
+      </AuthContext.Provider>
+    </QueryClientProvider>
+  );
+};
+
 describe('CinemaPage - renders cinema details', () => {
   const mockCinema: Cinema = {
     id: 'C0153',
@@ -29,7 +59,7 @@ describe('CinemaPage - renders cinema details', () => {
   });
 
   it('renders the cinema name heading', async () => {
-    render(
+    renderWithClient(
       <MemoryRouter initialEntries={['/cinema/C0153']}>
         <Routes>
           <Route path="/cinema/:id" element={<CinemaPage />} />
@@ -42,7 +72,7 @@ describe('CinemaPage - renders cinema details', () => {
   });
 
   it('does NOT render a scrape button (scraping moved to admin)', async () => {
-    render(
+    renderWithClient(
       <MemoryRouter initialEntries={['/cinema/C0153']}>
         <Routes>
           <Route path="/cinema/:id" element={<CinemaPage />} />
@@ -57,7 +87,7 @@ describe('CinemaPage - renders cinema details', () => {
   });
 
   it('calls getCinemas and getCinemaSchedule on mount', async () => {
-    render(
+    renderWithClient(
       <MemoryRouter initialEntries={['/cinema/C0153']}>
         <Routes>
           <Route path="/cinema/:id" element={<CinemaPage />} />
@@ -74,7 +104,7 @@ describe('CinemaPage - renders cinema details', () => {
   it('shows error message when cinema is not found', async () => {
     vi.mocked(clientApi.getCinemas).mockResolvedValue([]);
 
-    render(
+    renderWithClient(
       <MemoryRouter initialEntries={['/cinema/C0153']}>
         <Routes>
           <Route path="/cinema/:id" element={<CinemaPage />} />

--- a/client/src/pages/HomePage.test.tsx
+++ b/client/src/pages/HomePage.test.tsx
@@ -3,8 +3,36 @@ import HomePage from './HomePage';
 import * as clientApi from '../api/client';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AuthContext } from '../contexts/AuthContext';
 
 // Mock the API client
+const mockAuthContext = {
+  isAuthenticated: true,
+  user: { id: 1, username: 'testuser', role_id: 1, role_name: 'admin', is_system_role: true, permissions: ['cinemas:create', 'scraper:trigger'] as any[] },
+  logout: vi.fn(),
+  login: vi.fn(),
+  isAdmin: false,
+  hasPermission: vi.fn(() => true),
+  token: 'mock-token',
+};
+
+const renderWithClient = (ui: React.ReactElement) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AuthContext.Provider value={mockAuthContext}>
+        {ui}
+      </AuthContext.Provider>
+    </QueryClientProvider>
+  );
+};
 vi.mock('../api/client', () => ({
   getWeeklyFilms: vi.fn(),
   getCinemas: vi.fn(),
@@ -33,7 +61,7 @@ describe('HomePage', () => {
   });
 
   it('should load data on mount', async () => {
-    render(
+    renderWithClient(
       <MemoryRouter>
         <HomePage />
       </MemoryRouter>
@@ -46,7 +74,7 @@ describe('HomePage', () => {
   });
 
   it('should NOT show ScrapeProgress on the home page', async () => {
-    render(
+    renderWithClient(
       <MemoryRouter>
         <HomePage />
       </MemoryRouter>
@@ -61,7 +89,7 @@ describe('HomePage', () => {
   });
 
   it('should NOT show a scrape button on the home page', async () => {
-    render(
+    renderWithClient(
       <MemoryRouter>
         <HomePage />
       </MemoryRouter>

--- a/client/src/pages/ReportsPage.test.tsx
+++ b/client/src/pages/ReportsPage.test.tsx
@@ -43,12 +43,23 @@ const mockReportDetail = {
   progress_log: [],
 };
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
 const renderWithRouter = (initialRoute = '/admin?tab=rapports') => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
   window.history.pushState({}, 'Test', initialRoute);
   return render(
-    <BrowserRouter>
-      <ReportsPage />
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <ReportsPage />
+      </BrowserRouter>
+    </QueryClientProvider>
   );
 };
 

--- a/client/src/pages/admin/CinemasPage.test.tsx
+++ b/client/src/pages/admin/CinemasPage.test.tsx
@@ -81,12 +81,24 @@ const mockAuthContext = {
   hasPermission: vi.fn<(p: PermissionName) => boolean>(() => true),
 };
 
-const renderWithAuth = (ui: React.ReactElement, authOverrides?: Partial<typeof mockAuthContext>) =>
-  render(
-    <AuthContext.Provider value={{ ...mockAuthContext, ...authOverrides }}>
-      <MemoryRouter>{ui}</MemoryRouter>
-    </AuthContext.Provider>
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const renderWithAuth = (ui: React.ReactElement, authOverrides?: Partial<typeof mockAuthContext>) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AuthContext.Provider value={{ ...mockAuthContext, ...authOverrides }}>
+        <MemoryRouter>{ui}</MemoryRouter>
+      </AuthContext.Provider>
+    </QueryClientProvider>
   );
+};
 
 const mockCinemas = [
   { id: 'C0153', name: 'UGC Ciné Cité Paris', city: 'Paris', screen_count: 12 },


### PR DESCRIPTION
## Summary
This PR fixes 5 failing test suites in the client workspace related to the recent React Query migration.

### Changes:
- Added `QueryClientProvider` wrapper to components rendering in `HomePage.test.tsx`, `CinemaPage.test.tsx`, `ReportsPage.test.tsx`, and `admin/CinemasPage.test.tsx`.
- Added a missing mocked `addCinema` export in `StickyElements.test.tsx` to resolve initialization failure.
- Updated `.gitignore` to ignore specialized `.env-*` files.

## Resume of Execution
- Identified 5 failing test suites using `npx vitest run`.
- Implemented `QueryClient` context provision for isolated test renders.
- Verified all 373 tests pass successfully.

Closes #470