### PR TITLE
perf: optimize Docker build time with npm cache

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -59,6 +59,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Cache npm packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository)
         uses: docker/login-action@v4


### PR DESCRIPTION
## Summary

Add npm caching to GitHub Actions workflow to speed up Docker builds.

## Changes

- Added `actions/cache@v4` for npm packages
- Caches `~/.npm` between workflow runs
- Uses `package-lock.json` as cache key

## Expected Impact

30-60 seconds faster builds per job (4 jobs = 2-4 minutes total)

## Current Image Status

| Image | Size | Status |
|-------|------|--------|
| web | 252MB | Already optimized (node:24-alpine) |
| scraper | 1.41GB | Large (Playwright browsers) |

## Notes

- Web image is already using `node:24-alpine` (optimal)
- Scraper image is large due to Playwright Chromium (~800MB)
- Would need Puppeteer switch to reduce scraper size significantly

Closes #485