### PR TITLE
fix(ci): add explicit git auth for version-tag workflow

### DIFF
--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: write
   pull-requests: read
+  actions: read
 
 jobs:
   create-version-tag:
@@ -215,10 +216,13 @@ jobs:
           echo "Created tag ${NEW_TAG}"
 
       - name: Push changes and tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           NEW_TAG="${{ steps.new_version.outputs.tag }}"
           
-          # Push commit and tag
+          # Push commit and tag using git with auth
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
           git push origin main
           git push origin "${NEW_TAG}"
           


### PR DESCRIPTION
## Problem

The Version Tag workflow was failing when trying to push commits and tags because workflow_run workflows have read-only GITHUB_TOKEN by default.

## Solution

Explicitly configure git remote with an authenticated token URL to enable push operations.

### Changes
- Add explicit git remote auth in push step
- Add actions: read permission
- Properly configure GITHUB_TOKEN for authentication

## Testing
- PR #496 was used to test the workflow
- First run failed at push step (now fixed)
- Ready to merge and test again

Closes #495