### PR TITLE
fix(ci): add explicit branch check to version-tag workflow

### DIFF
--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -6,8 +6,6 @@ on:
     workflows: ["Docker Build & Push"]
     types:
       - completed
-    branches:
-      - main
 
 permissions:
   contents: write
@@ -18,8 +16,8 @@ jobs:
   create-version-tag:
     name: Create Version Tag
     runs-on: ubuntu-latest
-    # Only run if Docker build succeeded
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Only run if Docker build succeeded AND triggered from main branch
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- Fixed workflow_run trigger not respecting branch filter
- Added explicit check using `github.event.workflow_run.head_branch`
- Ensures version tagging only runs on main branch

Closes #498