### PR TITLE
fix(ci): explicitly checkout main branch in version-tag workflow

### DIFF
--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: main  # Explicitly checkout main branch
           fetch-depth: 0  # Need full history for git describe
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -221,7 +222,7 @@ jobs:
           
           # Push commit and tag using git with auth
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
-          git push origin main
+          git push origin HEAD:main
           git push origin "${NEW_TAG}"
           
           echo "Pushed commit and tag ${NEW_TAG}"


### PR DESCRIPTION
## Summary

Fixes the version-tag workflow push failure caused by checking out the wrong branch.

**Problem:**
- Repo default branch is `develop`
- `actions/checkout@v4` without explicit `ref:` checks out default branch
- Workflow tries to push to `main` but local `main` doesn't exist
- Error: `src refspec main does not match any`

**Solution:**
- Added `ref: main` to checkout step to explicitly checkout main
- Changed push from `git push origin main` to `git push origin HEAD:main` (more defensive)

Closes #501