### PR TITLE
fix(ci): filter non-semver tags and move stable tag on release

### DIFF
--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -35,8 +35,9 @@ jobs:
       - name: Get last version tag
         id: last_tag
         run: |
-          # Get the last tag, or default to v0.0.0 if no tags exist
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          # Get the last semver tag, or default to v0.0.0 if no tags exist
+          # --match 'v[0-9]*' filters out non-semver tags (e.g. 'stable', 'backup-*')
+          LAST_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null || echo "v0.0.0")
           echo "tag=${LAST_TAG}" >> $GITHUB_OUTPUT
           echo "Last tag: ${LAST_TAG}"
 
@@ -105,6 +106,12 @@ jobs:
           
           # Parse semantic version
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+          
+          # Validate parsed version components are numeric
+          if ! [[ "$MAJOR" =~ ^[0-9]+$ && "$MINOR" =~ ^[0-9]+$ && "$PATCH" =~ ^[0-9]+$ ]]; then
+            echo "::error::Failed to parse semver from tag '${LAST_TAG}': MAJOR=${MAJOR}, MINOR=${MINOR}, PATCH=${PATCH}"
+            exit 1
+          fi
           
           # Bump the appropriate component
           case "$BUMP_TYPE" in
@@ -226,6 +233,16 @@ jobs:
           git push origin "${NEW_TAG}"
           
           echo "Pushed commit and tag ${NEW_TAG}"
+
+      - name: Move stable tag to new release
+        run: |
+          NEW_TAG="${{ steps.new_version.outputs.tag }}"
+          
+          # Move the stable tag to point to this release commit
+          git tag -fa stable -m "Latest stable release: ${NEW_TAG}"
+          git push origin stable --force
+          
+          echo "Moved stable tag to ${NEW_TAG}"
 
       - name: Create GitHub release
         run: |


### PR DESCRIPTION
## Summary

Fixes the version-tag workflow that was failing with `fatal: 'vstable..1' is not a valid tag name`.

### Changes

1. **Filter git describe to semver tags only**: Added `--match 'v[0-9]*'` to ensure only version tags are considered when finding the last release
2. **Add semver validation guard**: Fail fast with a clear error if version parsing produces non-numeric values
3. **Move stable tag on each release**: Keep the `stable` git tag always pointing to the latest release

### Testing

After merging to develop, PR develop → main to test the automated versioning workflow.

Closes #504