### PR TITLE
fix(ci): resolve merge conflict markers in version-tag workflow

### DIFF
--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -35,14 +35,9 @@ jobs:
       - name: Get last version tag
         id: last_tag
         run: |
-<<<<<<< develop
           # Get the last semver tag, or default to v0.0.0 if no tags exist
           # --match 'v[0-9]*' filters out non-semver tags (e.g. 'stable', 'backup-*')
           LAST_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null || echo "v0.0.0")
-=======
-          # Get the last tag, or default to v0.0.0 if no tags exist
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
->>>>>>> main
           echo "tag=${LAST_TAG}" >> $GITHUB_OUTPUT
           echo "Last tag: ${LAST_TAG}"
 
@@ -112,15 +107,12 @@ jobs:
           # Parse semantic version
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
           
-<<<<<<< develop
           # Validate parsed version components are numeric
           if ! [[ "$MAJOR" =~ ^[0-9]+$ && "$MINOR" =~ ^[0-9]+$ && "$PATCH" =~ ^[0-9]+$ ]]; then
             echo "::error::Failed to parse semver from tag '${LAST_TAG}': MAJOR=${MAJOR}, MINOR=${MINOR}, PATCH=${PATCH}"
             exit 1
           fi
           
-=======
->>>>>>> main
           # Bump the appropriate component
           case "$BUMP_TYPE" in
             major)
@@ -242,7 +234,6 @@ jobs:
           
           echo "Pushed commit and tag ${NEW_TAG}"
 
-<<<<<<< develop
       - name: Move stable tag to new release
         run: |
           NEW_TAG="${{ steps.new_version.outputs.tag }}"
@@ -253,8 +244,6 @@ jobs:
           
           echo "Moved stable tag to ${NEW_TAG}"
 
-=======
->>>>>>> main
       - name: Create GitHub release
         run: |
           NEW_TAG="${{ steps.new_version.outputs.tag }}"


### PR DESCRIPTION
## Summary

PR #506 was merged to `main` with **unresolved git merge conflict markers** in `version-tag.yml`, breaking the workflow on both branches. PR #507 fixed `develop`. This PR brings the clean version to `main`.

### Impact of the bug

- GitHub cannot parse the YAML → `workflow_run` trigger never fires
- Version Tag & Release workflow has been completely broken since the last merge
- Push events fail with "This run likely failed because of a workflow file issue"

### Fix

This PR removes all conflict markers and restores the correct version with our 3 fixes:
1. ✅ `git describe --match 'v[0-9]*'` filter to ignore non-semver tags like `stable`
2. ✅ Semver validation guard to fail fast on malformed versions  
3. ✅ Move `stable` git tag to latest release on each version bump

### What to expect after merge

1. Docker Build & Push runs on merge to main
2. **Version Tag workflow should now trigger via `workflow_run`**
3. Should successfully:
   - Find last semver tag: `v4.0.1`
   - Bump to `v4.0.2` (patch)
   - Create git tag `v4.0.2`
   - Move `stable` tag to `v4.0.2`
   - Create GitHub release
   - Trigger Docker build for the new tag

Closes #504