### PR TITLE
feat(ci): retag Docker images with semver tags on release

### DIFF
--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
   pull-requests: read
   actions: read
 
@@ -258,6 +259,40 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Retag Docker images with version
+        run: |
+          NEW_VERSION="${{ steps.new_version.outputs.version }}"
+          NEW_TAG="${{ steps.new_version.outputs.tag }}"
+          REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          
+          # Parse version components for semver tags
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$NEW_VERSION"
+          
+          # Retag both web and scraper images
+          for IMAGE in "ghcr.io/${REPO}" "ghcr.io/${REPO}-scraper"; do
+            echo "Retagging ${IMAGE}..."
+            
+            # Add semver tags to the existing 'main' manifest
+            docker buildx imagetools create \
+              --tag "${IMAGE}:${NEW_VERSION}" \
+              --tag "${IMAGE}:${MAJOR}.${MINOR}" \
+              --tag "${IMAGE}:${MAJOR}" \
+              --tag "${IMAGE}:${NEW_TAG}" \
+              "${IMAGE}:main"
+            
+            echo "Tagged ${IMAGE} with: ${NEW_TAG}, ${NEW_VERSION}, ${MAJOR}.${MINOR}, ${MAJOR}"
+          done
+
       - name: Summary
         run: |
           NEW_TAG="${{ steps.new_version.outputs.tag }}"
@@ -275,4 +310,4 @@ jobs:
           echo "✅ Created git tag \`${NEW_TAG}\`" >> $GITHUB_STEP_SUMMARY
           echo "✅ Created GitHub release" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "🐋 Docker images will be built for this tag automatically" >> $GITHUB_STEP_SUMMARY
+          echo "🐋 Docker images retagged with version tags" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Fixes the issue where Docker images aren't linked to GitHub releases. The version-tag workflow creates git tags, but tags pushed with `GITHUB_TOKEN` don't trigger downstream workflows, so the Docker Build's `tags: v*` trigger never fires.

## Solution

After creating the git tag and release, retag the **existing** Docker images (from the `main` branch build) with semver tags. This:
- ✅ Links images to the release immediately
- ✅ Avoids rebuilding (fast, efficient)
- ✅ Doesn't require extra secrets
- ✅ Uses existing multi-arch manifests

## Changes

1. **Add `packages:write` permission** — needed for GHCR push access
2. **Set up Docker Buildx** — provides `imagetools` command
3. **Log in to GHCR** — authenticate with `GITHUB_TOKEN`
4. **Retag both images** — `allo-scrapper` (web) and `allo-scrapper-scraper`
   - Tags added: `v4.0.x`, `4.0.x`, `4.0`, `4` (standard semver patterns)
   - Source: existing `main` tag manifest
5. **Update summary** — reflect what actually happens

## Testing

After merging to `main`, the next release should:
1. Create `v4.0.3` git tag
2. Retag Docker images: `ghcr.io/phbassin/allo-scrapper:v4.0.3`, `:4.0.3`, `:4.0`, `:4`
3. GitHub release shows linked Docker images with version tags

Closes #509