### PR TITLE
docs: align branch naming with conventional commit types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,6 +268,7 @@ Closes #<issue-number>"
 - [ ] Code coverage maintained
 - [ ] Conventional Commits used
 - [ ] Documentation updated (if applicable)
+- [ ] Version label added (`patch`, `minor`, or `major`)
 - [ ] Issue referenced in PR body
 
 **After merge:**


### PR DESCRIPTION
## Summary

Updates AGENTS.md to use type-based branch naming that aligns with conventional commits and the automated versioning workflow.

### Changes
- Replace generic `feature/` prefix with type-based prefixes: `feat/`, `fix/`, `docs/`, `chore/`, `ci/`, `refactor/`, `test/`, `perf/`
- Add version bump mapping table showing which branch type corresponds to which semver bump
- Update all examples throughout the document to use new naming convention
- Add rule: "Branch type should match your PR title prefix"

### Benefits
Creates a consistent workflow chain:
```
feat/123-api → feat(api): ... → minor label → v4.1.0
fix/42-bug   → fix(parser): ... → patch label → v4.0.2
docs/512-update → docs: ... → patch label → v4.0.3
```

Closes #512