### PR TITLE
ci: automate sync from main to develop after releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,12 @@ on:
       - develop
       - 'feat/**'
       - 'fix/**'
+      - 'docs/**'
       - 'chore/**'
+      - 'ci/**'
+      - 'refactor/**'
+      - 'test/**'
+      - 'perf/**'
   pull_request:
     branches:
       - main

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -1,13 +1,21 @@
 name: Sync main to develop
 
-# Disabled: automatic sync causes merge conflicts and complicates release workflow
-# Run manually when needed via workflow_dispatch
+# Automatically triggered after Version Tag & Release completes successfully on main
+# Also supports manual runs via workflow_dispatch
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Version Tag & Release"]
+    types:
+      - completed
 
 jobs:
   sync-main-to-develop:
     runs-on: ubuntu-latest
+    # Only run if manually triggered OR if Version Tag workflow succeeded
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
     permissions:
       contents: write
 


### PR DESCRIPTION
## Summary

Automates the sync from main to develop after each release, ensuring version bump commits are propagated automatically.

### Changes
- **sync-main-to-develop.yml**: Add `workflow_run` trigger for "Version Tag & Release"
- Add conditional to only run on successful completions from main branch
- Keep `workflow_dispatch` for manual runs
- **ci.yml**: Add branch patterns for all documented branch types (`docs/**`, `ci/**`, `refactor/**`, `test/**`, `perf/**`)

### Workflow chain
```
PR merged to main
  → Docker Build & Push
  → Version Tag & Release (creates vX.Y.Z, updates CHANGELOG.md + package.json)
  → Sync Main to Develop (automatic) ← NEW
```

### Benefits
- No more manual sync after releases
- Version bump commits (CHANGELOG.md + package.json) automatically included in develop
- Develop stays in sync with main
- Manual trigger still available via `workflow_dispatch`

### Safety
- Only triggers on successful Version Tag completions
- Only runs when triggered from main branch
- Merge conflicts still abort with error (same as before)

Closes #514