### PR TITLE
⚡ Bolt: Memoize visible tabs by permission checks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,6 @@
 ## 2026-03-18 - [Optimize Array Transformations]
 **Learning:** Chaining `.map().filter()` creates unnecessary intermediate arrays, increasing memory allocation and garbage collection overhead, especially in rendering loops or reactive memoized computations.
 **Action:** When filtering and transforming data simultaneously, replace `.map().filter()` chains with a single `.reduce()` or a combination of `.flatMap()` to compute the result in one pass and avoid allocating unused intermediate objects.
+## 2026-03-24 - [Memoizing Expensive Filtering on Static Data]
+**Learning:** Found that static data collections like `tabs` in navigation components (e.g., `AdminPage.tsx`) were being filtered on every render using `hasPermission`. Although computationally small, doing an $O(N)$ operation inside an unmemoized functional component leads to unnecessary recalculations.
+**Action:** When filtering static arrays based on context values (like permissions or authentication state), wrap the calculation in a `useMemo` hook with the context value as the dependency. This prevents recalculation on every unrelated state update while ensuring updates happen only when necessary.

--- a/client/src/pages/admin/AdminPage.tsx
+++ b/client/src/pages/admin/AdminPage.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import CinemasPage from './CinemasPage';
 import SettingsPage from './SettingsPage';
@@ -103,17 +103,24 @@ const AdminPage: React.FC = () => {
   const { hasPermission } = useContext(AuthContext);
   const currentTab = searchParams.get('tab') || 'cinemas';
 
-  // Filter tabs to only those the user has permission to see
-  const visibleTabs = tabs.filter((tab) => {
-    if (tab.anyPermissions) {
-      return tab.anyPermissions.some((p) => hasPermission(p));
-    }
-    if (tab.permissions) {
-      return tab.permissions.every((p) => hasPermission(p));
-    }
-    return !tab.permission || hasPermission(tab.permission);
-  });
-  const visibleTabIds = visibleTabs.map((t) => t.id);
+  // ⚡ PERFORMANCE: Memoize visible tabs and their IDs based on user permissions
+  // to avoid recalculating the filtered array and mapped IDs on every component render.
+  const { visibleTabs, visibleTabIds } = useMemo(() => {
+    const filteredTabs = tabs.filter((tab) => {
+      if (tab.anyPermissions) {
+        return tab.anyPermissions.some((p) => hasPermission(p));
+      }
+      if (tab.permissions) {
+        return tab.permissions.every((p) => hasPermission(p));
+      }
+      return !tab.permission || hasPermission(tab.permission);
+    });
+
+    return {
+      visibleTabs: filteredTabs,
+      visibleTabIds: filteredTabs.map((t) => t.id)
+    };
+  }, [hasPermission]);
 
   // Validate tab and fallback to first visible tab (or 'cinemas')
   const fallbackTab: TabId = visibleTabIds[0] ?? 'cinemas';


### PR DESCRIPTION
💡 What: The optimization implemented
Wrapped the calculation for `visibleTabs` and `visibleTabIds` in `client/src/pages/admin/AdminPage.tsx` using `useMemo`.

🎯 Why: The performance problem it solves
The `tabs` array contains static data for navigation. The check to filter them based on the `hasPermission` context value was running on every single render. Since `hasPermission` only updates when the context provider does (e.g. login/logout), doing this check continuously adds small, unnecessary iterations.

📊 Impact: Expected performance improvement
Reduces computation by preventing the map/filter logic from executing on unrelated re-renders (like when `searchParams` changes but the active tab happens to remain the same).

🔬 Measurement: How to verify the improvement
Tests passing. Render cycles can be inspected using the React DevTools Profiler to ensure the inner calculations skip when permissions are identical.

---
*PR created automatically by Jules for task [10832897890749442299](https://jules.google.com/task/10832897890749442299) started by @PhBassin*