### PR TITLE
perf(scraper): phase 3 scraper overhaul — retry, throttling, deduplication, batching

### DIFF
--- a/scraper/src/db/film-queries.ts
+++ b/scraper/src/db/film-queries.ts
@@ -33,6 +33,30 @@ export async function getFilm(db: DB, filmId: number): Promise<Film | undefined>
   const row = result.rows[0];
   if (!row) return undefined;
 
+  return rowToFilm(row);
+}
+
+/**
+ * Batch-fetch multiple films by their IDs in a single query.
+ * Returns a Map of filmId -> Film for films that exist in the database.
+ */
+export async function getFilmsBatch(db: DB, filmIds: number[]): Promise<Map<number, Film>> {
+  const map = new Map<number, Film>();
+  if (filmIds.length === 0) return map;
+
+  const result = await db.query<FilmRow>(
+    'SELECT * FROM films WHERE id = ANY($1)',
+    [filmIds]
+  );
+
+  for (const row of result.rows) {
+    map.set(row.id, rowToFilm(row));
+  }
+
+  return map;
+}
+
+function rowToFilm(row: FilmRow): Film {
   return {
     id: row.id,
     title: row.title,
@@ -139,5 +163,73 @@ export async function upsertFilm(db: DB, film: Film): Promise<void> {
       sanitized.audience_rating ?? null,
       sanitized.source_url,
     ]
+  );
+}
+
+/**
+ * Batch upsert multiple films in a single query.
+ * Uses multi-row INSERT ... ON CONFLICT for efficiency.
+ */
+export async function upsertFilmsBatch(db: DB, films: Film[]): Promise<void> {
+  if (films.length === 0) return;
+
+  const values: any[] = [];
+  const valueSets: string[] = [];
+  let paramIndex = 1;
+
+  for (const film of films) {
+    const sanitized = sanitizeFilm(film);
+    valueSets.push(
+      `($${paramIndex}, $${paramIndex + 1}, $${paramIndex + 2}, $${paramIndex + 3}, $${paramIndex + 4}, ` +
+      `$${paramIndex + 5}, $${paramIndex + 6}, $${paramIndex + 7}, $${paramIndex + 8}, $${paramIndex + 9}, ` +
+      `$${paramIndex + 10}, $${paramIndex + 11}, $${paramIndex + 12}, $${paramIndex + 13}, $${paramIndex + 14}, $${paramIndex + 15})`
+    );
+    values.push(
+      sanitized.id,
+      sanitized.title,
+      sanitized.original_title ?? null,
+      sanitized.poster_url ?? null,
+      sanitized.duration_minutes ?? null,
+      sanitized.release_date ?? null,
+      sanitized.rerelease_date ?? null,
+      JSON.stringify(sanitized.genres),
+      sanitized.nationality ?? null,
+      sanitized.director ?? null,
+      JSON.stringify(sanitized.actors),
+      sanitized.synopsis ?? null,
+      sanitized.certificate ?? null,
+      sanitized.press_rating ?? null,
+      sanitized.audience_rating ?? null,
+      sanitized.source_url
+    );
+    paramIndex += 16;
+  }
+
+  await db.query(
+    `
+      INSERT INTO films (
+        id, title, original_title, poster_url, duration_minutes,
+        release_date, rerelease_date, genres, nationality, director,
+        actors, synopsis, certificate, press_rating, audience_rating, source_url
+      )
+      VALUES ${valueSets.join(', ')}
+      ON CONFLICT(id) DO UPDATE SET
+        title = EXCLUDED.title,
+        original_title = EXCLUDED.original_title,
+        poster_url = EXCLUDED.poster_url,
+        duration_minutes = COALESCE(EXCLUDED.duration_minutes, films.duration_minutes),
+        release_date = COALESCE(EXCLUDED.release_date, films.release_date),
+        rerelease_date = EXCLUDED.rerelease_date,
+        genres = EXCLUDED.genres,
+        nationality = EXCLUDED.nationality,
+        director = EXCLUDED.director,
+        actors = EXCLUDED.actors,
+        synopsis = EXCLUDED.synopsis,
+        certificate = EXCLUDED.certificate,
+        press_rating = EXCLUDED.press_rating,
+        audience_rating = EXCLUDED.audience_rating,
+        source_url = EXCLUDED.source_url
+    `,
+    values
   );
 }

--- a/scraper/src/scraper/http-client.ts
+++ b/scraper/src/scraper/http-client.ts
@@ -7,6 +7,126 @@ import { ALLOCINE_BASE_URL } from './utils.js';
 const USER_AGENT =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 
+// ── Retry configuration ──────────────────────────────────────────────────────
+
+const FETCH_TIMEOUT_MS = 30_000;
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 1000;
+const MAX_JITTER_MS = 500;
+
+/**
+ * Fetch with automatic retry, exponential backoff, Retry-After support, jitter,
+ * and AbortSignal.timeout.
+ *
+ * Retries on:
+ *  - HTTP 429 (Too Many Requests)
+ *  - HTTP 5xx (server errors)
+ *  - Network errors (TypeError from fetch)
+ *
+ * @param url     - The URL to fetch
+ * @param options - Standard RequestInit options (signal will be overridden)
+ * @returns       - The Response object
+ */
+export async function fetchWithRetry(
+  url: string,
+  options: RequestInit = {}
+): Promise<Response> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const response = await fetch(url, {
+        ...options,
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+
+      // Success — return immediately
+      if (response.ok) return response;
+
+      // Retryable HTTP status: 429 or 5xx
+      if (response.status === 429 || response.status >= 500) {
+        lastError = new Error(
+          `HTTP ${response.status} ${response.statusText} for ${url}`
+        );
+
+        if (attempt < MAX_RETRIES) {
+          const delayMs = computeRetryDelay(attempt, response);
+          logger.warn('Retryable HTTP error, backing off', {
+            url,
+            status: response.status,
+            attempt: attempt + 1,
+            maxRetries: MAX_RETRIES,
+            delayMs,
+          });
+          await delay(delayMs);
+          continue;
+        }
+      }
+
+      // Non-retryable HTTP error — throw immediately
+      throw new Error(
+        `Failed to fetch ${url}: ${response.status} ${response.statusText}`
+      );
+    } catch (error) {
+      lastError = error;
+
+      // AbortError / TimeoutError from AbortSignal.timeout — retryable
+      // Network errors (TypeError) — retryable
+      const isRetryable =
+        error instanceof TypeError ||
+        (error instanceof DOMException && error.name === 'TimeoutError') ||
+        (error instanceof DOMException && error.name === 'AbortError');
+
+      if (isRetryable && attempt < MAX_RETRIES) {
+        const delayMs = computeRetryDelay(attempt);
+        logger.warn('Network/timeout error, retrying', {
+          url,
+          error: error instanceof Error ? error.message : String(error),
+          attempt: attempt + 1,
+          maxRetries: MAX_RETRIES,
+          delayMs,
+        });
+        await delay(delayMs);
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  // Should never reach here, but just in case
+  throw lastError;
+}
+
+/**
+ * Compute retry delay with exponential backoff + jitter.
+ * Respects Retry-After header if present.
+ */
+function computeRetryDelay(attempt: number, response?: Response): number {
+  // Check Retry-After header (seconds or HTTP-date)
+  if (response) {
+    const retryAfter = response.headers.get('Retry-After');
+    if (retryAfter) {
+      const seconds = Number(retryAfter);
+      if (Number.isFinite(seconds) && seconds > 0) {
+        // Clamp to max 60 seconds to avoid absurdly long waits
+        return Math.min(seconds * 1000, 60_000);
+      }
+      // Try parsing as HTTP-date
+      const date = new Date(retryAfter);
+      if (!isNaN(date.getTime())) {
+        const ms = date.getTime() - Date.now();
+        if (ms > 0) return Math.min(ms, 60_000);
+      }
+    }
+  }
+
+  // Exponential backoff: 1s, 2s, 4s, ... + random jitter up to 500ms
+  const exponential = BASE_DELAY_MS * Math.pow(2, attempt);
+  const jitter = Math.random() * MAX_JITTER_MS;
+  return exponential + jitter;
+}
+
 /**
  * Validates cinema ID format (e.g., "C0072", "W7517")
  * @throws {Error} if format is invalid
@@ -85,7 +205,7 @@ export async function fetchTheaterPage(cinemaBaseUrl: string): Promise<TheaterIn
   try {
     await page.setUserAgent(USER_AGENT);
     logger.info('Loading theater page', { url: cinemaBaseUrl });
-    await page.goto(cinemaBaseUrl, { waitUntil: 'networkidle0', timeout: 60000 });
+    await page.goto(cinemaBaseUrl, { waitUntil: 'domcontentloaded', timeout: 60000 });
 
     const html = await page.content();
 
@@ -128,7 +248,7 @@ export async function fetchShowtimesJson(cinemaId: string, date: string): Promis
   const url = constructed.href;
   logger.info('Fetching showtimes JSON', { url });
 
-  const response = await fetch(url, {
+  const response = await fetchWithRetry(url, {
     headers: {
       'User-Agent': USER_AGENT,
       Accept: 'application/json',
@@ -136,10 +256,6 @@ export async function fetchShowtimesJson(cinemaId: string, date: string): Promis
       Referer: `${ALLOCINE_BASE_URL}/seance/salle_gen_csalle=${cinemaId}.html`,
     },
   });
-
-  if (!response.ok) {
-    throw new Error(`Failed to fetch showtimes JSON for ${cinemaId} on ${date}: ${response.status} ${response.statusText}`);
-  }
 
   return response.json();
 }
@@ -157,7 +273,7 @@ export async function fetchFilmPage(filmId: number): Promise<string> {
 
   logger.info('Fetching film page', { url });
 
-  const response = await fetch(url, {
+  const response = await fetchWithRetry(url, {
     headers: {
       'User-Agent': USER_AGENT,
       Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
@@ -165,12 +281,6 @@ export async function fetchFilmPage(filmId: number): Promise<string> {
       'Cache-Control': 'no-cache',
     },
   });
-
-  if (!response.ok) {
-    throw new Error(
-      `Failed to fetch film page ${filmId}: ${response.status} ${response.statusText}`
-    );
-  }
 
   return response.text();
 }

--- a/scraper/src/scraper/index.ts
+++ b/scraper/src/scraper/index.ts
@@ -39,10 +39,11 @@ export async function scrapeTheater(
   cinema: CinemaConfig,
   date: string,
   movieDelayMs: number,
-  progress?: ProgressPublisher
+  progress?: ProgressPublisher,
+  processedFilmIds?: Set<number>
 ): Promise<{ filmsCount: number; showtimesCount: number }> {
   const strategy = getStrategyBySource(cinema.source || 'allocine');
-  return strategy.scrapeTheater(db, cinema, date, movieDelayMs, progress);
+  return strategy.scrapeTheater(db, cinema, date, movieDelayMs, progress, processedFilmIds);
 }
 
 /**
@@ -74,13 +75,23 @@ export async function addCinemaAndScrape(
   const { availableDates, cinema } = await strategy.loadTheaterMetadata(db, tempConfig);
 
   const movieDelayMs = parseInt(process.env.SCRAPE_MOVIE_DELAY_MS || '500', 10);
+  const dateDelayMs = parseInt(process.env.SCRAPE_DATE_DELAY_MS || '1500', 10);
   logger.info(`Scraping ${availableDates.length} available date(s)...`, { cinema: cinema.name });
 
-  for (const date of availableDates) {
+  // Track processed film IDs across dates for this cinema to avoid redundant fetches
+  const processedFilmIds = new Set<number>();
+
+  for (let di = 0; di < availableDates.length; di++) {
+    const date = availableDates[di];
     try {
-      await strategy.scrapeTheater(db, tempConfig, date, movieDelayMs, progress);
+      await strategy.scrapeTheater(db, tempConfig, date, movieDelayMs, progress, processedFilmIds);
     } catch (error) {
       logger.error('Failed to scrape date', { date, cinema: cinema.name, error });
+    }
+
+    // Apply delay between dates (except after the last one)
+    if (di < availableDates.length - 1) {
+      await delay(dateDelayMs);
     }
   }
 
@@ -119,6 +130,7 @@ export async function runScraper(
   // Read delay configuration from environment
   const theaterDelayMs = parseInt(process.env.SCRAPE_THEATER_DELAY_MS || '3000', 10);
   const movieDelayMs = parseInt(process.env.SCRAPE_MOVIE_DELAY_MS || '500', 10);
+  const dateDelayMs = parseInt(process.env.SCRAPE_DATE_DELAY_MS || '1500', 10);
 
   try {
     let cinemas = await getCinemaConfigs(db);
@@ -149,7 +161,7 @@ export async function runScraper(
     const scrapeDays = options?.days || parseInt(process.env.SCRAPE_DAYS || '7', 10);
     const dates = getScrapeDates(scrapeMode, scrapeDays);
     logger.info('Scrape config', { mode: scrapeMode, dates: dates.length, scrapeDays });
-    logger.info('Delay config', { theaterDelayMs, movieDelayMs });
+    logger.info('Delay config', { theaterDelayMs, movieDelayMs, dateDelayMs });
 
     summary.total_cinemas = cinemas.length;
     summary.total_dates = dates.length;
@@ -197,10 +209,14 @@ export async function runScraper(
       }
       logger.info('Dates to scrape', { cinema: cinema.name, count: datesToScrape.length });
 
-      for (const date of datesToScrape) {
+      // Track processed film IDs across dates for this cinema to avoid redundant fetches
+      const processedFilmIds = new Set<number>();
+
+      for (let di = 0; di < datesToScrape.length; di++) {
+        const date = datesToScrape[di];
         logger.info('Attempting date', { cinema: cinema.name, date });
         try {
-          const { filmsCount, showtimesCount } = await strategy.scrapeTheater(db, cinema, date, movieDelayMs, progress);
+          const { filmsCount, showtimesCount } = await strategy.scrapeTheater(db, cinema, date, movieDelayMs, progress, processedFilmIds);
           cinemaFilmsCount += filmsCount;
           cinemaShowtimesCount += showtimesCount;
           successfulDates++;
@@ -222,6 +238,12 @@ export async function runScraper(
           });
 
           continue;
+        }
+
+        // Apply delay between dates (except after the last one)
+        if (di < datesToScrape.length - 1) {
+          logger.info('Waiting before next date', { delayMs: dateDelayMs });
+          await delay(dateDelayMs);
         }
       }
 

--- a/scraper/src/scraper/strategies/AllocineScraperStrategy.ts
+++ b/scraper/src/scraper/strategies/AllocineScraperStrategy.ts
@@ -6,6 +6,8 @@ import {
 import {
   upsertFilm,
   getFilm,
+  getFilmsBatch,
+  upsertFilmsBatch,
 } from '../../db/film-queries.js';
 import {
   upsertCinema,
@@ -59,7 +61,8 @@ export class AllocineScraperStrategy implements IScraperStrategy {
     cinema: CinemaConfig,
     date: string,
     movieDelayMs: number,
-    progress?: ProgressPublisher
+    progress?: ProgressPublisher,
+    processedFilmIds?: Set<number>
   ): Promise<{ filmsCount: number; showtimesCount: number }> {
     logger.info('Scraping cinema for date', { cinema: cinema.name, id: cinema.id, date });
 
@@ -74,7 +77,16 @@ export class AllocineScraperStrategy implements IScraperStrategy {
 
       logger.info('Films found for date', { count: filmShowtimesData.length, date });
 
+      // Batch-fetch existing films from DB to avoid N+1 queries (#595)
+      const filmIdsToLookup = filmShowtimesData
+        .map(fd => fd.film.id)
+        .filter(id => !(processedFilmIds?.has(id)));
+      const existingFilmsMap = filmIdsToLookup.length > 0
+        ? await getFilmsBatch(db, filmIdsToLookup)
+        : new Map<number, import('../../types/scraper.js').Film>();
+
       const weeklyPrograms: WeeklyProgram[] = [];
+      const filmsToUpsert: import('../../types/scraper.js').Film[] = [];
 
       for (const filmData of filmShowtimesData) {
         const film = filmData.film;
@@ -82,29 +94,53 @@ export class AllocineScraperStrategy implements IScraperStrategy {
         await progress?.emit({ type: 'film_started', film_title: film.title, film_id: film.id });
 
         try {
-          const existingFilm = await getFilm(db, film.id);
+          // Skip film detail fetch if already processed for this cinema run (#594)
+          const alreadyProcessed = processedFilmIds?.has(film.id) ?? false;
 
-          if (!existingFilm || !existingFilm.duration_minutes) {
-            logger.info('Fetching film details', { title: film.title, id: film.id });
+          if (!alreadyProcessed) {
+            // Check if JSON API already provided duration (#596) —
+            // if so, skip the expensive fetchFilmPage call
+            const hasRuntimeFromJson = film.duration_minutes !== undefined && film.duration_minutes > 0;
 
-            try {
-              const filmHtml = await fetchFilmPage(film.id);
-              const filmPageData = parseFilmPage(filmHtml);
+            if (!hasRuntimeFromJson) {
+              const existingFilm = existingFilmsMap.get(film.id);
 
-              if (filmPageData.duration_minutes) {
-                film.duration_minutes = filmPageData.duration_minutes;
+              if (!existingFilm || !existingFilm.duration_minutes) {
+                logger.info('Fetching film details', { title: film.title, id: film.id });
+
+                try {
+                  const filmHtml = await fetchFilmPage(film.id);
+                  const filmPageData = parseFilmPage(filmHtml);
+
+                  if (filmPageData.duration_minutes) {
+                    film.duration_minutes = filmPageData.duration_minutes;
+                  }
+
+                  await delay(movieDelayMs);
+                } catch (error) {
+                  logger.warn('Error fetching film page', { filmId: film.id, error });
+                }
+              } else {
+                film.duration_minutes = existingFilm.duration_minutes;
               }
-
-              await delay(movieDelayMs);
-            } catch (error) {
-              logger.warn('Error fetching film page', { filmId: film.id, error });
+            } else {
+              logger.info('Runtime already in JSON, skipping film page fetch', {
+                title: film.title,
+                id: film.id,
+                duration: film.duration_minutes,
+              });
             }
+
+            // Mark as processed for subsequent dates
+            processedFilmIds?.add(film.id);
           } else {
-            film.duration_minutes = existingFilm.duration_minutes;
+            logger.info('Film already processed, skipping detail fetch', {
+              title: film.title,
+              id: film.id,
+            });
           }
 
-          await upsertFilm(db, film);
-          logger.info('Film upserted', { title: film.title });
+          filmsToUpsert.push(film);
 
           await upsertShowtimes(db, filmData.showtimes);
           logger.info('Showtimes upserted', { count: filmData.showtimes.length });
@@ -130,6 +166,12 @@ export class AllocineScraperStrategy implements IScraperStrategy {
           logger.error('Error processing film', { title: film.title, error });
           await progress?.emit({ type: 'film_failed', film_title: film.title, error: errorMessage });
         }
+      }
+
+      // Batch upsert all films at once (#595)
+      if (filmsToUpsert.length > 0) {
+        await upsertFilmsBatch(db, filmsToUpsert);
+        logger.info('Films batch upserted', { count: filmsToUpsert.length });
       }
 
       if (weeklyPrograms.length > 0) {

--- a/scraper/src/scraper/strategies/IScraperStrategy.ts
+++ b/scraper/src/scraper/strategies/IScraperStrategy.ts
@@ -12,5 +12,12 @@ export interface IScraperStrategy {
 
   // Core scraping actions
   loadTheaterMetadata(db: DB, cinema: CinemaConfig): Promise<{ availableDates: string[]; cinema: Cinema }>;
-  scrapeTheater(db: DB, cinema: CinemaConfig, date: string, movieDelayMs: number, progress?: ProgressPublisher): Promise<{ filmsCount: number; showtimesCount: number }>;
+  scrapeTheater(
+    db: DB,
+    cinema: CinemaConfig,
+    date: string,
+    movieDelayMs: number,
+    progress?: ProgressPublisher,
+    processedFilmIds?: Set<number>
+  ): Promise<{ filmsCount: number; showtimesCount: number }>;
 }

--- a/scraper/tests/unit/scraper/http-client.test.ts
+++ b/scraper/tests/unit/scraper/http-client.test.ts
@@ -40,6 +40,7 @@ describe('http-client', () => {
   let fetchShowtimesJson: (cinemaId: string, date: string) => Promise<unknown>;
   let fetchFilmPage: (filmId: number) => Promise<string>;
   let fetchTheaterPage: (cinemaBaseUrl: string) => Promise<{ html: string; availableDates: string[] }>;
+  let fetchWithRetry: (url: string, options?: RequestInit) => Promise<Response>;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -55,10 +56,149 @@ describe('http-client', () => {
     fetchShowtimesJson = mod.fetchShowtimesJson;
     fetchFilmPage = mod.fetchFilmPage;
     fetchTheaterPage = mod.fetchTheaterPage;
+    fetchWithRetry = mod.fetchWithRetry;
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // fetchWithRetry
+  // -------------------------------------------------------------------------
+  describe('fetchWithRetry', () => {
+    it('should return response on successful fetch', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({ data: 'test' }),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
+      const response = await fetchWithRetry('https://example.com/api');
+      expect(response.ok).toBe(true);
+      expect(mockFetch).toHaveBeenCalledOnce();
+    });
+
+    it('should pass AbortSignal.timeout to fetch', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
+      await fetchWithRetry('https://example.com/api', {
+        headers: { Accept: 'application/json' },
+      });
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const calledOptions = mockFetch.mock.calls[0][1];
+      expect(calledOptions.signal).toBeDefined();
+    });
+
+    it('should retry on HTTP 429 and eventually succeed', async () => {
+      const mockFetch = vi.fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          statusText: 'Too Many Requests',
+          headers: new Headers(),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: vi.fn().mockResolvedValue({}),
+        });
+      vi.stubGlobal('fetch', mockFetch);
+
+      const response = await fetchWithRetry('https://example.com/api');
+      expect(response.ok).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should retry on HTTP 500 server errors', async () => {
+      const mockFetch = vi.fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error',
+          headers: new Headers(),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+        });
+      vi.stubGlobal('fetch', mockFetch);
+
+      const response = await fetchWithRetry('https://example.com/api');
+      expect(response.ok).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should throw immediately on non-retryable HTTP errors (e.g. 404)', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        headers: new Headers(),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
+      await expect(fetchWithRetry('https://example.com/api')).rejects.toThrow(/404/);
+      expect(mockFetch).toHaveBeenCalledOnce();
+    });
+
+    it('should throw after exhausting all retries on persistent 429', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 429,
+        statusText: 'Too Many Requests',
+        headers: new Headers(),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
+      await expect(fetchWithRetry('https://example.com/api')).rejects.toThrow(/429/);
+      // initial + 3 retries = 4 calls
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+    });
+
+    it('should respect Retry-After header (seconds)', async () => {
+      const headers = new Headers({ 'Retry-After': '2' });
+      const mockFetch = vi.fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          statusText: 'Too Many Requests',
+          headers,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+        });
+      vi.stubGlobal('fetch', mockFetch);
+
+      const start = Date.now();
+      await fetchWithRetry('https://example.com/api');
+      const elapsed = Date.now() - start;
+
+      // Should have waited approximately 2 seconds
+      expect(elapsed).toBeGreaterThanOrEqual(1800);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should retry on network errors (TypeError)', async () => {
+      const mockFetch = vi.fn()
+        .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+        });
+      vi.stubGlobal('fetch', mockFetch);
+
+      const response = await fetchWithRetry('https://example.com/api');
+      expect(response.ok).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -240,12 +380,12 @@ describe('http-client', () => {
       );
     });
 
-    it('should navigate with waitUntil networkidle0', async () => {
+    it('should navigate with waitUntil domcontentloaded', async () => {
       await fetchTheaterPage('https://www.allocine.fr/seance/salle_gen_csalle=C0072.html');
 
       expect(mockPage.goto).toHaveBeenCalledWith(
         'https://www.allocine.fr/seance/salle_gen_csalle=C0072.html',
-        expect.objectContaining({ waitUntil: 'networkidle0' })
+        expect.objectContaining({ waitUntil: 'domcontentloaded' })
       );
     });
 

--- a/scraper/tests/unit/scraper/index.test.ts
+++ b/scraper/tests/unit/scraper/index.test.ts
@@ -11,6 +11,8 @@ const mockParseShowtimesJson = vi.fn().mockReturnValue([]);
 vi.mock('../../../src/db/film-queries.js', () => ({
   upsertFilm: vi.fn(),
   getFilm: vi.fn(),
+  getFilmsBatch: vi.fn().mockResolvedValue(new Map()),
+  upsertFilmsBatch: vi.fn(),
 }));
 
 vi.mock('../../../src/db/showtime-queries.js', () => ({
@@ -28,6 +30,7 @@ vi.mock('../../../src/scraper/http-client.js', () => ({
   fetchTheaterPage: mockFetchTheaterPage,
   fetchShowtimesJson: mockFetchShowtimesJson,
   fetchFilmPage: vi.fn(),
+  fetchWithRetry: vi.fn(),
   delay: vi.fn(),
   closeBrowser: vi.fn(),
 }));


### PR DESCRIPTION
## Summary

Phase 3 of the optimization project — a comprehensive scraper performance overhaul addressing HTTP 429 errors from Allocine and reducing unnecessary network/DB calls.

### Changes

1. **Retry with exponential backoff** (#592) — `fetchWithRetry()` wrapper with exponential backoff (1s, 2s, 4s), `Retry-After` header support, jitter (0–500ms), max 3 retries. Retries on 429, 5xx, TypeError, TimeoutError.

2. **Fetch timeouts** (#593) — `AbortSignal.timeout(30_000)` on all `fetch()` calls via `fetchWithRetry`.

3. **Date iteration throttling** (#606) — `SCRAPE_DATE_DELAY_MS` env var (default 1500ms) adds delay between date iterations in both `runScraper()` and `addCinemaAndScrape()`.

4. **Film deduplication across dates** (#594) — In-memory `Set<number>` (`processedFilmIds`) passed across dates per cinema. Skips `fetchFilmPage` + DB lookups for already-processed films.

5. **Skip fetch when runtime already available** (#596) — Checks `film.duration_minutes` from JSON parser before attempting `fetchFilmPage`. If runtime already present from the JSON API, skips the HTTP call entirely.

6. **Batch DB operations** (#595) — `getFilmsBatch()` (`WHERE id = ANY($1)`) replaces N individual `getFilm()` calls. `upsertFilmsBatch()` (multi-row INSERT ON CONFLICT) replaces N individual `upsertFilm()` calls.

7. **Faster page loads** (#597) — Puppeteer `waitUntil` changed from `networkidle0` to `domcontentloaded`.

### Modified files

- `scraper/src/scraper/http-client.ts` — `fetchWithRetry()`, `computeRetryDelay()`, timeout, `domcontentloaded`
- `scraper/src/scraper/index.ts` — `SCRAPE_DATE_DELAY_MS`, date delay loops, `processedFilmIds` Set
- `scraper/src/scraper/strategies/AllocineScraperStrategy.ts` — film dedup, JSON runtime check, batch DB ops
- `scraper/src/scraper/strategies/IScraperStrategy.ts` — optional `processedFilmIds` param
- `scraper/src/db/film-queries.ts` — `getFilmsBatch()`, `upsertFilmsBatch()`, `rowToFilm()` helper
- `scraper/tests/unit/scraper/http-client.test.ts` — 7 new `fetchWithRetry` test cases
- `scraper/tests/unit/scraper/index.test.ts` — updated mocks

Closes #592, closes #593, closes #594, closes #595, closes #596, closes #597, closes #606
Refs #576