### PR TITLE
perf: phase 4 architecture improvements — concurrency, circuit breaker, React Query

### DIFF
--- a/Dockerfile.scraper
+++ b/Dockerfile.scraper
@@ -32,13 +32,16 @@ FROM node:24-alpine AS builder
 
 WORKDIR /app
 
-# Copy node_modules from deps stage
+# Copy node_modules from deps stage (root hoisted)
 COPY --from=deps /app/node_modules ./node_modules
 # Copy root files
 COPY package.json package-lock.json ./
 
 # Copy source
 COPY scraper/ ./scraper/
+
+# Copy scraper-specific node_modules (deps not hoisted to root, e.g. p-limit v7)
+COPY --from=deps /app/scraper/node_modules ./scraper/node_modules
 
 # Build TypeScript
 RUN npm run build --workspace=allo-scrapper-scraper && \

--- a/client/src/components/FilmSearchBar.tsx
+++ b/client/src/components/FilmSearchBar.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import { searchFilms } from '../api/client';
 import { useDebounce } from '../hooks/useDebounce';
 import { highlightText } from '../utils/highlight';
@@ -15,38 +16,29 @@ export default function FilmSearchBar({
   placeholder = 'Rechercher un film...' 
 }: FilmSearchBarProps) {
   const [query, setQuery] = useState('');
-  const [results, setResults] = useState<Film[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const debouncedQuery = useDebounce(query, 300);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
-  // Perform search when debounced query changes
+  // ⚡ PERFORMANCE: React Query with staleTime caches search results for 5 min,
+  // avoiding redundant API calls for repeated searches
+  const { data: results = [], isFetching: isLoading } = useQuery<Film[]>({
+    queryKey: ['filmSearch', debouncedQuery],
+    queryFn: () => searchFilms(debouncedQuery),
+    enabled: !!debouncedQuery && debouncedQuery.trim().length >= 2,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+
+  // Open dropdown when results arrive
   useEffect(() => {
-    async function performSearch() {
-      if (!debouncedQuery || debouncedQuery.trim().length < 2) {
-        setResults([]);
-        setIsOpen(false);
-        return;
-      }
-
-      setIsLoading(true);
-      try {
-        const films = await searchFilms(debouncedQuery);
-        setResults(films);
-        setIsOpen(true);
-        setSelectedIndex(-1);
-      } catch (error) {
-        console.error('Search error:', error);
-        setResults([]);
-      } finally {
-        setIsLoading(false);
-      }
+    if (results.length > 0 && debouncedQuery.trim().length >= 2) {
+      setIsOpen(true);
+      setSelectedIndex(-1);
+    } else if (!debouncedQuery || debouncedQuery.trim().length < 2) {
+      setIsOpen(false);
     }
-
-    performSearch();
-  }, [debouncedQuery]);
+  }, [results, debouncedQuery]);
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -94,7 +86,6 @@ export default function FilmSearchBar({
   const handleResultClick = () => {
     setIsOpen(false);
     setQuery('');
-    setResults([]);
     setSelectedIndex(-1);
   };
 

--- a/client/src/pages/admin/AdminPage.tsx
+++ b/client/src/pages/admin/AdminPage.tsx
@@ -1,12 +1,15 @@
-import React, { useContext, useEffect, useMemo } from 'react';
+import React, { useContext, useEffect, useMemo, Suspense } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import CinemasPage from './CinemasPage';
-import SettingsPage from './SettingsPage';
-import UsersPage from './UsersPage';
-import SystemPage from './SystemPage';
-import ReportsPage from '../ReportsPage';
-import RoleManagementPage from '../../components/admin/RoleManagementPage';
-import SchedulesPage from './SchedulesPage';
+
+// ⚡ PERFORMANCE: Lazy-load tab sub-pages so only the active tab's code is fetched
+const CinemasPage = React.lazy(() => import('./CinemasPage'));
+const SettingsPage = React.lazy(() => import('./SettingsPage'));
+const UsersPage = React.lazy(() => import('./UsersPage'));
+const SystemPage = React.lazy(() => import('./SystemPage'));
+const ReportsPage = React.lazy(() => import('../ReportsPage'));
+const RoleManagementPage = React.lazy(() => import('../../components/admin/RoleManagementPage'));
+const SchedulesPage = React.lazy(() => import('./SchedulesPage'));
+
 import { AuthContext } from '../../contexts/AuthContext';
 import type { PermissionName } from '../../types/role';
 
@@ -172,15 +175,21 @@ const AdminPage: React.FC = () => {
       </div>
 
       {/* Tab content */}
-      <div role="tabpanel">
-        {activeTab === 'cinemas' && <CinemasPage />}
-        {activeTab === 'schedules' && <SchedulesPage />}
-        {activeTab === 'rapports' && <ReportsPage />}
-        {activeTab === 'users' && <UsersPage />}
-        {activeTab === 'roles' && <RoleManagementPage />}
-        {activeTab === 'settings' && <SettingsPage />}
-        {activeTab === 'system' && <SystemPage />}
-      </div>
+      <Suspense fallback={
+        <div className="flex items-center justify-center h-64">
+          <div className="text-gray-500">Loading...</div>
+        </div>
+      }>
+        <div role="tabpanel">
+          {activeTab === 'cinemas' && <CinemasPage />}
+          {activeTab === 'schedules' && <SchedulesPage />}
+          {activeTab === 'rapports' && <ReportsPage />}
+          {activeTab === 'users' && <UsersPage />}
+          {activeTab === 'roles' && <RoleManagementPage />}
+          {activeTab === 'settings' && <SettingsPage />}
+          {activeTab === 'system' && <SystemPage />}
+        </div>
+      </Suspense>
     </div>
   );
 };

--- a/client/src/pages/admin/SchedulesPage.tsx
+++ b/client/src/pages/admin/SchedulesPage.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getSchedules, createSchedule, updateSchedule, deleteSchedule, type CreateSchedulePayload, type UpdateSchedulePayload } from '../../api/client';
 import type { ScrapeSchedule } from '../../types';
 import ScheduleModal from '../../components/admin/ScheduleModal';
@@ -7,9 +8,7 @@ import { useContext } from 'react';
 
 const SchedulesPage: React.FC = () => {
   const { hasPermission } = useContext(AuthContext);
-  const [schedules, setSchedules] = useState<ScrapeSchedule[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
   const [modalOpen, setModalOpen] = useState(false);
   const [editingSchedule, setEditingSchedule] = useState<ScrapeSchedule | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState<number | null>(null);
@@ -18,38 +17,42 @@ const SchedulesPage: React.FC = () => {
   const canUpdate = hasPermission('scraper:schedules:update');
   const canDelete = hasPermission('scraper:schedules:delete');
 
-  const fetchSchedules = useCallback(async () => {
-    try {
-      setLoading(true);
-      const data = await getSchedules();
-      setSchedules(data);
-      setError(null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch schedules');
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const { data: schedules = [], isLoading: loading, error: queryError } = useQuery({
+    queryKey: ['schedules'],
+    queryFn: getSchedules,
+  });
 
-  useEffect(() => {
-    fetchSchedules();
-  }, [fetchSchedules]);
+  const error = queryError ? (queryError instanceof Error ? queryError.message : 'Failed to fetch schedules') : null;
+
+  const createMutation = useMutation({
+    mutationFn: (data: CreateSchedulePayload) => createSchedule(data),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['schedules'] }),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: number; data: CreateSchedulePayload | UpdateSchedulePayload }) => updateSchedule(id, data),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['schedules'] }),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteSchedule(id),
+    onSuccess: () => {
+      setDeleteConfirm(null);
+      queryClient.invalidateQueries({ queryKey: ['schedules'] });
+    },
+  });
 
   const handleCreate = async (data: CreateSchedulePayload) => {
-    await createSchedule(data);
-    await fetchSchedules();
+    await createMutation.mutateAsync(data);
   };
 
   const handleUpdate = async (data: CreateSchedulePayload | UpdateSchedulePayload) => {
     if (!editingSchedule) return;
-    await updateSchedule(editingSchedule.id, data);
-    await fetchSchedules();
+    await updateMutation.mutateAsync({ id: editingSchedule.id, data });
   };
 
   const handleDelete = async (id: number) => {
-    await deleteSchedule(id);
-    setDeleteConfirm(null);
-    await fetchSchedules();
+    await deleteMutation.mutateAsync(id);
   };
 
   const openCreateModal = () => {
@@ -94,7 +97,7 @@ const SchedulesPage: React.FC = () => {
     return (
       <div className="p-4 bg-red-50 border border-red-200 rounded-lg">
         <p className="text-red-600">{error}</p>
-        <button onClick={fetchSchedules} className="mt-2 text-sm text-red-700 underline">
+        <button onClick={() => queryClient.invalidateQueries({ queryKey: ['schedules'] })} className="mt-2 text-sm text-red-700 underline">
           Retry
         </button>
       </div>

--- a/client/src/pages/admin/SystemPage.tsx
+++ b/client/src/pages/admin/SystemPage.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useContext, useCallback } from 'react';
+import React, { useState, useContext } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { getSystemInfo, getMigrations, getSystemHealth, formatUptime, formatDate } from '../../api/system';
 import type { SystemInfo, MigrationsInfo, SystemHealth } from '../../api/system';
 import { AuthContext } from '../../contexts/AuthContext';
@@ -12,46 +13,37 @@ const SystemPage: React.FC = () => {
   const canViewHealth = hasPermission('system:health');
   const canViewMigrations = hasPermission('system:migrations');
 
-  const [systemInfo, setSystemInfo] = useState<SystemInfo | null>(null);
-  const [migrations, setMigrations] = useState<MigrationsInfo | null>(null);
-  const [health, setHealth] = useState<SystemHealth | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [autoRefresh, setAutoRefresh] = useState(false);
 
-  const loadData = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      const [infoData, migrationsData, healthData] = await Promise.all([
-        canViewInfo ? getSystemInfo() : Promise.resolve(null),
-        canViewMigrations ? getMigrations() : Promise.resolve(null),
-        canViewHealth ? getSystemHealth() : Promise.resolve(null),
-      ]);
-      setSystemInfo(infoData);
-      setMigrations(migrationsData);
-      setHealth(healthData);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load system information');
-    } finally {
-      setIsLoading(false);
-    }
-  }, [canViewInfo, canViewHealth, canViewMigrations]);
+  // React Query: fetch system data in parallel with optional auto-refresh
+  const refetchInterval = autoRefresh ? 30_000 : false;
 
-  useEffect(() => {
-    loadData();
-  }, [loadData]);
+  const { data: systemInfo, isLoading: infoLoading, error: infoError, refetch: refetchInfo } = useQuery<SystemInfo | null>({
+    queryKey: ['system', 'info'],
+    queryFn: () => canViewInfo ? getSystemInfo() : Promise.resolve(null),
+    refetchInterval,
+  });
 
-  // Auto-refresh every 30 seconds if enabled
-  useEffect(() => {
-    if (!autoRefresh) return;
+  const { data: migrations, isLoading: migrationsLoading, refetch: refetchMigrations } = useQuery<MigrationsInfo | null>({
+    queryKey: ['system', 'migrations'],
+    queryFn: () => canViewMigrations ? getMigrations() : Promise.resolve(null),
+    refetchInterval,
+  });
 
-    const interval = setInterval(() => {
-      loadData();
-    }, 30000);
+  const { data: health, isLoading: healthLoading, refetch: refetchHealth } = useQuery<SystemHealth | null>({
+    queryKey: ['system', 'health'],
+    queryFn: () => canViewHealth ? getSystemHealth() : Promise.resolve(null),
+    refetchInterval,
+  });
 
-    return () => clearInterval(interval);
-  }, [autoRefresh, loadData]);
+  const isLoading = infoLoading || migrationsLoading || healthLoading;
+  const error = infoError ? (infoError instanceof Error ? infoError.message : 'Failed to load system information') : null;
+
+  const loadData = () => {
+    refetchInfo();
+    refetchMigrations();
+    refetchHealth();
+  };
 
   const getStatusColor = (status: string) => {
     switch (status) {

--- a/client/src/pages/admin/UsersPage.tsx
+++ b/client/src/pages/admin/UsersPage.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useMemo, useContext } from 'react';
+import React, { useState, useMemo, useContext } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getUsers, createUser, updateUserRole, resetUserPassword, deleteUser } from '../../api/users';
 import type { UserPublic, UserCreate } from '../../api/users';
 import { rolesApi } from '../../api/roles';
@@ -96,90 +97,93 @@ const ChangeRoleModal: React.FC<ChangeRoleModalProps> = ({ user, roles, onClose,
 // ────────────────────────────────────────────────────────────────
 const UsersPage: React.FC = () => {
   const { hasPermission } = useContext(AuthContext);
+  const queryClient = useQueryClient();
   
   // Permission checks
   const canCreate = hasPermission('users:create');
   const canUpdate = hasPermission('users:update');
   const canDelete = hasPermission('users:delete');
 
-  const [users, setUsers] = useState<UserPublic[]>([]);
-  const [roles, setRoles] = useState<RoleWithPermissions[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  // React Query: fetch users and roles in parallel
+  const { data: users = [], isLoading: usersLoading, error: usersError } = useQuery({
+    queryKey: ['users'],
+    queryFn: () => getUsers(),
+  });
+
+  const { data: roles = [], isLoading: rolesLoading } = useQuery({
+    queryKey: ['roles'],
+    queryFn: () => rolesApi.getAll(),
+  });
+
+  const loading = usersLoading || rolesLoading;
+  const error = usersError ? (usersError instanceof Error ? usersError.message : 'Failed to fetch users') : null;
 
   // Modal/dialog states
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [userToDelete, setUserToDelete] = useState<UserPublic | null>(null);
-  const [isDeleting, setIsDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [passwordResetData, setPasswordResetData] = useState<{
     username: string;
     newPassword: string;
   } | null>(null);
   const [userForRoleChange, setUserForRoleChange] = useState<UserPublic | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
-  // Fetch users and roles
-  const fetchData = async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      const [usersData, rolesData] = await Promise.all([
-        getUsers(),
-        rolesApi.getAll(),
-      ]);
-      setUsers(usersData);
-      setRoles(rolesData);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch users');
-    } finally {
-      setLoading(false);
-    }
-  };
+  // Mutations
+  const createMutation = useMutation({
+    mutationFn: (data: UserCreate) => createUser(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['users'] });
+      setShowCreateModal(false);
+    },
+  });
 
-  useEffect(() => {
-    fetchData();
-  }, []);
+  const changeRoleMutation = useMutation({
+    mutationFn: ({ userId, roleId }: { userId: number; roleId: number }) => updateUserRole(userId, roleId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['users'] });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (userId: number) => deleteUser(userId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['users'] });
+      setUserToDelete(null);
+    },
+    onError: (err) => {
+      setDeleteError(err instanceof Error ? err.message : 'Failed to delete user');
+    },
+  });
 
   // Create user
   const handleCreateUser = async (data: UserCreate) => {
-    await createUser(data);
-    setShowCreateModal(false);
-    await fetchData();
+    await createMutation.mutateAsync(data);
   };
 
-  // Change role — now uses role_id integer
+  // Change role
   const handleChangeRole = async (userId: number, newRoleId: number) => {
-    await updateUserRole(userId, newRoleId);
-    await fetchData();
+    await changeRoleMutation.mutateAsync({ userId, roleId: newRoleId });
   };
 
   // Reset password
   const handleResetPassword = async (userId: number) => {
     try {
-      setError(null);
+      setActionError(null);
       const result = await resetUserPassword(userId);
       setPasswordResetData({
         username: result.user.username,
         newPassword: result.newPassword,
       });
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to reset password');
+      setActionError(err instanceof Error ? err.message : 'Failed to reset password');
     }
   };
 
   // Delete user
   const handleDeleteUser = async (userId: number) => {
-    try {
-      setIsDeleting(true);
-      setDeleteError(null);
-      await deleteUser(userId);
-      setUserToDelete(null);
-      await fetchData();
-    } catch (err) {
-      setDeleteError(err instanceof Error ? err.message : 'Failed to delete user');
-    } finally {
-      setIsDeleting(false);
-    }
+    setDeleteError(null);
+    await deleteMutation.mutateAsync(userId);
   };
 
   // ⚡ PERFORMANCE: Cache Intl.DateTimeFormat instance to prevent expensive
@@ -222,9 +226,9 @@ const UsersPage: React.FC = () => {
       </div>
 
       {/* Error Message */}
-      {error && (
+      {(error || actionError) && (
         <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-md">
-          <p className="text-sm text-red-800">{error}</p>
+          <p className="text-sm text-red-800">{error || actionError}</p>
         </div>
       )}
 
@@ -333,7 +337,7 @@ const UsersPage: React.FC = () => {
             setDeleteError(null);
           }}
           onConfirm={handleDeleteUser}
-          isDeleting={isDeleting}
+          isDeleting={deleteMutation.isPending}
           error={deleteError}
         />
       )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8329,6 +8329,7 @@
         "he": "^1.2.0",
         "ioredis": "^5.10.0",
         "node-cron": "^4.2.1",
+        "p-limit": "^7.3.0",
         "pg": "^8.20.0",
         "prom-client": "^15.1.0",
         "puppeteer-core": "^24.39.1",
@@ -8344,6 +8345,33 @@
         "tsx": "^4.19.2",
         "typescript": "^5.7.2",
         "vitest": "^4.0.18"
+      }
+    },
+    "scraper/node_modules/p-limit": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
+      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "scraper/node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "server": {

--- a/scraper/package.json
+++ b/scraper/package.json
@@ -33,6 +33,7 @@
     "he": "^1.2.0",
     "ioredis": "^5.10.0",
     "node-cron": "^4.2.1",
+    "p-limit": "^7.3.0",
     "pg": "^8.20.0",
     "prom-client": "^15.1.0",
     "puppeteer-core": "^24.39.1",

--- a/scraper/src/scraper/circuit-breaker.ts
+++ b/scraper/src/scraper/circuit-breaker.ts
@@ -1,0 +1,115 @@
+// Circuit breaker pattern for upstream failure resilience (#599)
+//
+// Prevents wasted requests when the upstream (allocine.fr) is down.
+// After N consecutive failures the circuit "opens" and rejects requests
+// immediately.  After a cooldown period a single test request is allowed
+// through ("half-open").  If it succeeds the circuit "closes" again;
+// if it fails the circuit stays open for another cooldown cycle.
+
+import { logger } from '../utils/logger.js';
+
+export type CircuitState = 'closed' | 'open' | 'half-open';
+
+export class CircuitOpenError extends Error {
+  constructor(message = 'Circuit breaker is open — upstream is unavailable') {
+    super(message);
+    this.name = 'CircuitOpenError';
+  }
+}
+
+export interface CircuitBreakerOptions {
+  /** Consecutive failures before the circuit opens (default 5) */
+  threshold?: number;
+  /** Milliseconds to wait before allowing a test request (default 60 000) */
+  cooldownMs?: number;
+}
+
+export class CircuitBreaker {
+  private _state: CircuitState = 'closed';
+  private failureCount = 0;
+  private lastFailureTime = 0;
+  private readonly threshold: number;
+  private readonly cooldownMs: number;
+
+  constructor(options: CircuitBreakerOptions = {}) {
+    this.threshold = options.threshold ?? 5;
+    this.cooldownMs = options.cooldownMs ?? 60_000;
+  }
+
+  /** Current state of the circuit. */
+  get state(): CircuitState {
+    return this._state;
+  }
+
+  /** Number of consecutive failures recorded. */
+  get failures(): number {
+    return this.failureCount;
+  }
+
+  /**
+   * Wrap an async operation with circuit breaker protection.
+   *
+   * @throws {CircuitOpenError} if the circuit is open and the cooldown has
+   *         not elapsed.
+   */
+  async execute<T>(fn: () => Promise<T>): Promise<T> {
+    if (this._state === 'open') {
+      if (Date.now() - this.lastFailureTime >= this.cooldownMs) {
+        this._state = 'half-open';
+        logger.info('Circuit breaker half-open — allowing test request');
+      } else {
+        throw new CircuitOpenError();
+      }
+    }
+
+    try {
+      const result = await fn();
+      this.onSuccess();
+      return result;
+    } catch (error) {
+      this.onFailure();
+      throw error;
+    }
+  }
+
+  /** Reset the circuit to the closed state (e.g. at the start of a new run). */
+  reset(): void {
+    this._state = 'closed';
+    this.failureCount = 0;
+    this.lastFailureTime = 0;
+    logger.info('Circuit breaker reset to closed');
+  }
+
+  // ── Internal helpers ────────────────────────────────────────
+
+  private onSuccess(): void {
+    if (this._state === 'half-open') {
+      logger.info('Circuit breaker closed — test request succeeded');
+    }
+    this._state = 'closed';
+    this.failureCount = 0;
+  }
+
+  private onFailure(): void {
+    this.failureCount++;
+    this.lastFailureTime = Date.now();
+
+    if (this._state === 'half-open') {
+      // Test request failed → back to open
+      this._state = 'open';
+      logger.warn('Circuit breaker re-opened — test request failed', {
+        failures: this.failureCount,
+      });
+      return;
+    }
+
+    if (this.failureCount >= this.threshold) {
+      this._state = 'open';
+      logger.warn('Circuit breaker opened', {
+        failures: this.failureCount,
+        threshold: this.threshold,
+        cooldownMs: this.cooldownMs,
+      });
+    }
+  }
+}

--- a/scraper/src/scraper/http-client.ts
+++ b/scraper/src/scraper/http-client.ts
@@ -3,6 +3,16 @@
 import puppeteer, { type Browser } from 'puppeteer-core';
 import { logger } from '../utils/logger.js';
 import { ALLOCINE_BASE_URL } from './utils.js';
+import { CircuitBreaker, CircuitOpenError } from './circuit-breaker.js';
+
+// ── Shared circuit breaker for all upstream fetch calls ───────────────────────
+const circuitBreaker = new CircuitBreaker({
+  threshold: parseInt(process.env.CIRCUIT_BREAKER_THRESHOLD || '5', 10),
+  cooldownMs: parseInt(process.env.CIRCUIT_BREAKER_COOLDOWN_MS || '60000', 10),
+});
+
+/** Expose the circuit breaker for scraper orchestration (early abort, reset, status). */
+export { circuitBreaker, CircuitOpenError };
 
 const USER_AGENT =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
@@ -248,14 +258,16 @@ export async function fetchShowtimesJson(cinemaId: string, date: string): Promis
   const url = constructed.href;
   logger.info('Fetching showtimes JSON', { url });
 
-  const response = await fetchWithRetry(url, {
-    headers: {
-      'User-Agent': USER_AGENT,
-      Accept: 'application/json',
-      'Accept-Language': 'fr-FR,fr;q=0.9',
-      Referer: `${ALLOCINE_BASE_URL}/seance/salle_gen_csalle=${cinemaId}.html`,
-    },
-  });
+  const response = await circuitBreaker.execute(() =>
+    fetchWithRetry(url, {
+      headers: {
+        'User-Agent': USER_AGENT,
+        Accept: 'application/json',
+        'Accept-Language': 'fr-FR,fr;q=0.9',
+        Referer: `${ALLOCINE_BASE_URL}/seance/salle_gen_csalle=${cinemaId}.html`,
+      },
+    })
+  );
 
   return response.json();
 }
@@ -273,14 +285,16 @@ export async function fetchFilmPage(filmId: number): Promise<string> {
 
   logger.info('Fetching film page', { url });
 
-  const response = await fetchWithRetry(url, {
-    headers: {
-      'User-Agent': USER_AGENT,
-      Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-      'Accept-Language': 'fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7',
-      'Cache-Control': 'no-cache',
-    },
-  });
+  const response = await circuitBreaker.execute(() =>
+    fetchWithRetry(url, {
+      headers: {
+        'User-Agent': USER_AGENT,
+        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7',
+        'Cache-Control': 'no-cache',
+      },
+    })
+  );
 
   return response.text();
 }

--- a/scraper/src/scraper/index.ts
+++ b/scraper/src/scraper/index.ts
@@ -4,10 +4,11 @@ import {
   getCinemaConfigs,
   getCinemas,
 } from '../db/cinema-queries.js';
-import { closeBrowser, delay } from './http-client.js';
+import { closeBrowser, delay, circuitBreaker } from './http-client.js';
 import { getScrapeDates, type ScrapeMode } from '../utils/date.js';
 import type { CinemaConfig, Cinema, ProgressEvent, ScrapeSummary } from '../types/scraper.js';
 import { getStrategyByUrl, getStrategyBySource } from './strategy-factory.js';
+import pLimit from 'p-limit';
 
 // Progress publisher interface – allows injecting Redis publisher or a no-op
 export interface ProgressPublisher {
@@ -128,11 +129,13 @@ export async function runScraper(
   const startTime = Date.now();
 
   // Read delay configuration from environment
-  const theaterDelayMs = parseInt(process.env.SCRAPE_THEATER_DELAY_MS || '3000', 10);
   const movieDelayMs = parseInt(process.env.SCRAPE_MOVIE_DELAY_MS || '500', 10);
   const dateDelayMs = parseInt(process.env.SCRAPE_DATE_DELAY_MS || '1500', 10);
 
   try {
+    // Reset the circuit breaker at the start of each scrape run
+    circuitBreaker.reset();
+
     let cinemas = await getCinemaConfigs(db);
     
     // Filter to specific cinema if provided
@@ -161,7 +164,7 @@ export async function runScraper(
     const scrapeDays = options?.days || parseInt(process.env.SCRAPE_DAYS || '7', 10);
     const dates = getScrapeDates(scrapeMode, scrapeDays);
     logger.info('Scrape config', { mode: scrapeMode, dates: dates.length, scrapeDays });
-    logger.info('Delay config', { theaterDelayMs, movieDelayMs, dateDelayMs });
+    logger.info('Delay config', { movieDelayMs, dateDelayMs });
 
     summary.total_cinemas = cinemas.length;
     summary.total_dates = dates.length;
@@ -172,110 +175,158 @@ export async function runScraper(
       total_dates: dates.length,
     });
 
-    for (let i = 0; i < cinemas.length; i++) {
-      const cinema = cinemas[i];
-      const strategy = getStrategyBySource(cinema.source || 'allocine');
+    // ── Bounded concurrency with p-limit ────────────────────────────────────
+    const concurrency = parseInt(process.env.SCRAPER_CONCURRENCY || '2', 10);
+    const limit = pLimit(concurrency);
+    logger.info('Concurrency config', { concurrency });
 
-      await progress?.emit({
-        type: 'cinema_started',
-        cinema_name: cinema.name,
-        cinema_id: cinema.id,
-        index: i + 1,
-      });
+    const cinemaResults = await Promise.allSettled(
+      cinemas.map((cinema, i) =>
+        limit(async () => {
+          // Abort early if the circuit breaker has opened (upstream is down)
+          if (circuitBreaker.state === 'open') {
+            logger.warn('Circuit breaker is open — skipping cinema', {
+              cinema: cinema.name,
+              circuitFailures: circuitBreaker.failures,
+            });
+            return { status: 'circuit_open' as const, cinema };
+          }
 
-      let cinemaFilmsCount = 0;
-      let cinemaShowtimesCount = 0;
-      let successfulDates = 0;
+          const strategy = getStrategyBySource(cinema.source || 'allocine');
 
-      logger.info(`Processing cinema using ${strategy.sourceName} strategy`, { cinema: cinema.name, id: cinema.id });
+          await progress?.emit({
+            type: 'cinema_started',
+            cinema_name: cinema.name,
+            cinema_id: cinema.id,
+            index: i + 1,
+          });
 
-      let availableDates: string[] = [];
-      try {
-        const meta = await strategy.loadTheaterMetadata(db, cinema);
-        availableDates = meta.availableDates;
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        logger.error('Failed to load theater metadata', { cinema: cinema.name, error: errorMessage });
-        summary.errors.push({ cinema_name: cinema.name, error: errorMessage });
+          let cinemaFilmsCount = 0;
+          let cinemaShowtimesCount = 0;
+          let successfulDates = 0;
+
+          logger.info(`Processing cinema using ${strategy.sourceName} strategy`, { cinema: cinema.name, id: cinema.id });
+
+          let availableDates: string[] = [];
+          try {
+            const meta = await strategy.loadTheaterMetadata(db, cinema);
+            availableDates = meta.availableDates;
+          } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            logger.error('Failed to load theater metadata', { cinema: cinema.name, error: errorMessage });
+            return { status: 'metadata_failed' as const, cinema, error: errorMessage };
+          }
+
+          const datesToScrape = dates.filter(d => availableDates.includes(d));
+          const skippedDates = dates.filter(d => !availableDates.includes(d));
+
+          if (skippedDates.length > 0) {
+            logger.info('Skipping dates not yet published', { count: skippedDates.length, dates: skippedDates });
+          }
+          logger.info('Dates to scrape', { cinema: cinema.name, count: datesToScrape.length });
+
+          // Track processed film IDs across dates for this cinema to avoid redundant fetches
+          const processedFilmIds = new Set<number>();
+
+          for (let di = 0; di < datesToScrape.length; di++) {
+            const date = datesToScrape[di];
+            logger.info('Attempting date', { cinema: cinema.name, date });
+            try {
+              const { filmsCount, showtimesCount } = await strategy.scrapeTheater(db, cinema, date, movieDelayMs, progress, processedFilmIds);
+              cinemaFilmsCount += filmsCount;
+              cinemaShowtimesCount += showtimesCount;
+              successfulDates++;
+              logger.info('Date scraped successfully', { date, films: filmsCount, showtimes: showtimesCount });
+            } catch (error) {
+              const errorMessage = error instanceof Error ? error.message : String(error);
+              logger.error('Date scrape failed', { cinema: cinema.name, date, error: errorMessage });
+
+              await progress?.emit({
+                type: 'date_failed',
+                cinema_name: cinema.name,
+                date: date,
+                error: errorMessage,
+              });
+            }
+
+            // Apply delay between dates (except after the last one)
+            if (di < datesToScrape.length - 1) {
+              logger.info('Waiting before next date', { delayMs: dateDelayMs });
+              await delay(dateDelayMs);
+            }
+          }
+
+          return {
+            status: 'completed' as const,
+            cinema,
+            cinemaFilmsCount,
+            cinemaShowtimesCount,
+            successfulDates,
+            totalDates: datesToScrape.length,
+          };
+        })
+      )
+    );
+
+    // ── Aggregate results ─────────────────────────────────────────────────
+    let circuitOpenCount = 0;
+    for (const result of cinemaResults) {
+      if (result.status === 'rejected') {
+        // Unexpected error (should be rare since we catch inside)
         summary.failed_cinemas++;
+        summary.errors.push({
+          cinema_name: 'Unknown',
+          error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+        });
         continue;
       }
 
-      const datesToScrape = dates.filter(d => availableDates.includes(d));
-      const skippedDates = dates.filter(d => !availableDates.includes(d));
+      const val = result.value;
 
-      if (skippedDates.length > 0) {
-        logger.info('Skipping dates not yet published', { count: skippedDates.length, dates: skippedDates });
-      }
-      logger.info('Dates to scrape', { cinema: cinema.name, count: datesToScrape.length });
-
-      // Track processed film IDs across dates for this cinema to avoid redundant fetches
-      const processedFilmIds = new Set<number>();
-
-      for (let di = 0; di < datesToScrape.length; di++) {
-        const date = datesToScrape[di];
-        logger.info('Attempting date', { cinema: cinema.name, date });
-        try {
-          const { filmsCount, showtimesCount } = await strategy.scrapeTheater(db, cinema, date, movieDelayMs, progress, processedFilmIds);
-          cinemaFilmsCount += filmsCount;
-          cinemaShowtimesCount += showtimesCount;
-          successfulDates++;
-          logger.info('Date scraped successfully', { date, films: filmsCount, showtimes: showtimesCount });
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          logger.error('Date scrape failed', { cinema: cinema.name, date, error: errorMessage });
-          summary.errors.push({
-            cinema_name: cinema.name,
-            date: date,
-            error: errorMessage
-          });
-
-          await progress?.emit({
-            type: 'date_failed',
-            cinema_name: cinema.name,
-            date: date,
-            error: errorMessage
-          });
-
-          continue;
-        }
-
-        // Apply delay between dates (except after the last one)
-        if (di < datesToScrape.length - 1) {
-          logger.info('Waiting before next date', { delayMs: dateDelayMs });
-          await delay(dateDelayMs);
-        }
+      if (val.status === 'circuit_open') {
+        circuitOpenCount++;
+        continue;
       }
 
-      const cinemaFailed = successfulDates === 0 && datesToScrape.length > 0;
+      if (val.status === 'metadata_failed') {
+        summary.failed_cinemas++;
+        summary.errors.push({ cinema_name: val.cinema.name, error: val.error });
+        continue;
+      }
+
+      // status === 'completed'
+      const cinemaFailed = val.successfulDates === 0 && val.totalDates > 0;
 
       logger.info('Cinema summary', {
-        cinema: cinema.name,
-        successfulDates,
-        totalDates: datesToScrape.length,
-        films: cinemaFilmsCount,
-        showtimes: cinemaShowtimesCount,
+        cinema: val.cinema.name,
+        successfulDates: val.successfulDates,
+        totalDates: val.totalDates,
+        films: val.cinemaFilmsCount,
+        showtimes: val.cinemaShowtimesCount,
       });
 
       if (!cinemaFailed) {
         summary.successful_cinemas++;
-        summary.total_films += cinemaFilmsCount;
-        summary.total_showtimes += cinemaShowtimesCount;
+        summary.total_films += val.cinemaFilmsCount;
+        summary.total_showtimes += val.cinemaShowtimesCount;
         await progress?.emit({
           type: 'cinema_completed',
-          cinema_name: cinema.name,
-          total_films: cinemaFilmsCount,
+          cinema_name: val.cinema.name,
+          total_films: val.cinemaFilmsCount,
         });
       } else {
         summary.failed_cinemas++;
-        logger.error('Cinema failed completely', { cinema: cinema.name, dates: datesToScrape.length });
+        logger.error('Cinema failed completely', { cinema: val.cinema.name, dates: val.totalDates });
       }
+    }
 
-      // Apply delay between cinemas (except after the last one)
-      if (i < cinemas.length - 1) {
-        logger.info('Waiting before next cinema', { delayMs: theaterDelayMs });
-        await delay(theaterDelayMs);
-      }
+    if (circuitOpenCount > 0) {
+      logger.warn('Circuit breaker caused cinemas to be skipped', { count: circuitOpenCount });
+      summary.errors.push({
+        cinema_name: 'System',
+        error: `Circuit breaker open — skipped ${circuitOpenCount} cinema(s)`,
+      });
+      summary.failed_cinemas += circuitOpenCount;
     }
 
     summary.duration_ms = Date.now() - startTime;

--- a/scraper/tests/unit/scraper/circuit-breaker.test.ts
+++ b/scraper/tests/unit/scraper/circuit-breaker.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CircuitBreaker, CircuitOpenError } from '../../../src/scraper/circuit-breaker.js';
+
+// Suppress logger output during tests
+vi.mock('../../../src/utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+describe('CircuitBreaker', () => {
+  let cb: CircuitBreaker;
+
+  beforeEach(() => {
+    cb = new CircuitBreaker({ threshold: 3, cooldownMs: 1000 });
+  });
+
+  it('starts in closed state', () => {
+    expect(cb.state).toBe('closed');
+    expect(cb.failures).toBe(0);
+  });
+
+  it('remains closed on success', async () => {
+    await cb.execute(() => Promise.resolve('ok'));
+    expect(cb.state).toBe('closed');
+    expect(cb.failures).toBe(0);
+  });
+
+  it('counts failures but stays closed below threshold', async () => {
+    const fail = () => Promise.reject(new Error('fail'));
+
+    await expect(cb.execute(fail)).rejects.toThrow('fail');
+    expect(cb.state).toBe('closed');
+    expect(cb.failures).toBe(1);
+
+    await expect(cb.execute(fail)).rejects.toThrow('fail');
+    expect(cb.state).toBe('closed');
+    expect(cb.failures).toBe(2);
+  });
+
+  it('opens after reaching the failure threshold', async () => {
+    const fail = () => Promise.reject(new Error('fail'));
+
+    for (let i = 0; i < 3; i++) {
+      await expect(cb.execute(fail)).rejects.toThrow('fail');
+    }
+
+    expect(cb.state).toBe('open');
+    expect(cb.failures).toBe(3);
+  });
+
+  it('rejects immediately when open (before cooldown)', async () => {
+    const fail = () => Promise.reject(new Error('fail'));
+    for (let i = 0; i < 3; i++) {
+      await expect(cb.execute(fail)).rejects.toThrow('fail');
+    }
+
+    // Now open — should throw CircuitOpenError without calling fn
+    const fn = vi.fn();
+    await expect(cb.execute(fn)).rejects.toThrow(CircuitOpenError);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('transitions to half-open after cooldown elapses', async () => {
+    const fail = () => Promise.reject(new Error('fail'));
+    for (let i = 0; i < 3; i++) {
+      await expect(cb.execute(fail)).rejects.toThrow('fail');
+    }
+    expect(cb.state).toBe('open');
+
+    // Fast-forward past cooldown
+    vi.useFakeTimers();
+    vi.advanceTimersByTime(1001);
+
+    // A successful test request should close the circuit
+    await cb.execute(() => Promise.resolve('ok'));
+    expect(cb.state).toBe('closed');
+    expect(cb.failures).toBe(0);
+
+    vi.useRealTimers();
+  });
+
+  it('re-opens if the half-open test request fails', async () => {
+    const fail = () => Promise.reject(new Error('fail'));
+    for (let i = 0; i < 3; i++) {
+      await expect(cb.execute(fail)).rejects.toThrow('fail');
+    }
+    expect(cb.state).toBe('open');
+
+    vi.useFakeTimers();
+    vi.advanceTimersByTime(1001);
+
+    // Test request fails → circuit re-opens
+    await expect(cb.execute(fail)).rejects.toThrow('fail');
+    expect(cb.state).toBe('open');
+
+    vi.useRealTimers();
+  });
+
+  it('resets failure count on a successful call', async () => {
+    const fail = () => Promise.reject(new Error('fail'));
+
+    // Accumulate 2 failures (below threshold)
+    await expect(cb.execute(fail)).rejects.toThrow();
+    await expect(cb.execute(fail)).rejects.toThrow();
+    expect(cb.failures).toBe(2);
+
+    // One success resets
+    await cb.execute(() => Promise.resolve('ok'));
+    expect(cb.failures).toBe(0);
+    expect(cb.state).toBe('closed');
+  });
+
+  it('reset() forces the circuit closed', async () => {
+    const fail = () => Promise.reject(new Error('fail'));
+    for (let i = 0; i < 3; i++) {
+      await expect(cb.execute(fail)).rejects.toThrow();
+    }
+    expect(cb.state).toBe('open');
+
+    cb.reset();
+    expect(cb.state).toBe('closed');
+    expect(cb.failures).toBe(0);
+
+    // Should work again
+    const result = await cb.execute(() => Promise.resolve(42));
+    expect(result).toBe(42);
+  });
+
+  it('uses default threshold (5) and cooldown (60s) when no options given', () => {
+    const defaultCb = new CircuitBreaker();
+    expect(defaultCb.state).toBe('closed');
+    // We can't directly inspect private fields, but we can verify it takes
+    // more than 3 failures to open
+    const fail = () => Promise.reject(new Error('fail'));
+    const promises = Array.from({ length: 4 }, () =>
+      defaultCb.execute(fail).catch(() => {})
+    );
+    return Promise.all(promises).then(() => {
+      expect(defaultCb.state).toBe('closed'); // still closed at 4
+    });
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -41,6 +41,18 @@ export function createApp() {
   app.set('trust proxy', 1);
 
   // Middleware
+  // Compression middleware - exclude SSE responses to prevent buffering
+  app.use(compression({
+    filter: (req, res) => {
+      // Don't compress SSE responses - they need to stream in real-time
+      if (req.path === '/api/scraper/progress') {
+        return false;
+      }
+      // Use default compression filter for everything else
+      return compression.filter(req, res);
+    }
+  }));
+
   app.use(
     helmet({
       contentSecurityPolicy: {
@@ -57,7 +69,7 @@ export function createApp() {
       },
     })
   );
-  app.use(compression());
+
   app.use(cors(getCorsOptions()));
   app.use(morgan('combined'));
   app.use(express.json());

--- a/server/src/services/progress-tracker.test.ts
+++ b/server/src/services/progress-tracker.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ProgressTracker, type ProgressEvent } from './progress-tracker.js';
+
+describe('ProgressTracker', () => {
+  let tracker: ProgressTracker;
+
+  beforeEach(() => {
+    tracker = new ProgressTracker();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Helper to create a mock Response object
+  const createMockResponse = () => ({
+    write: vi.fn(),
+    end: vi.fn(),
+  });
+
+  describe('addListener', () => {
+    it('should add a listener and send existing events', () => {
+      const mockRes = createMockResponse();
+      const event: ProgressEvent = { type: 'started', total_cinemas: 5, total_dates: 7 };
+
+      // Emit event before adding listener
+      tracker.emit(event);
+
+      // Add listener - should receive the existing event
+      tracker.addListener(mockRes as any);
+
+      expect(mockRes.write).toHaveBeenCalledWith(`data: ${JSON.stringify(event)}\n\n`);
+      expect(tracker.getListenerCount()).toBe(1);
+    });
+
+    it('should start heartbeat when first listener is added', () => {
+      const mockRes = createMockResponse();
+
+      tracker.addListener(mockRes as any);
+
+      // Advance timer to trigger heartbeat
+      vi.advanceTimersByTime(15000);
+
+      expect(mockRes.write).toHaveBeenCalledWith(': heartbeat\n\n');
+    });
+  });
+
+  describe('removeListener', () => {
+    it('should remove a listener', () => {
+      const mockRes = createMockResponse();
+
+      tracker.addListener(mockRes as any);
+      expect(tracker.getListenerCount()).toBe(1);
+
+      tracker.removeListener(mockRes as any);
+      expect(tracker.getListenerCount()).toBe(0);
+    });
+
+    it('should stop heartbeat when last listener is removed', () => {
+      const mockRes = createMockResponse();
+
+      tracker.addListener(mockRes as any);
+      tracker.removeListener(mockRes as any);
+
+      // Advance timer - heartbeat should not fire
+      vi.advanceTimersByTime(15000);
+
+      // Only the initial replay call, no heartbeat
+      expect(mockRes.write).not.toHaveBeenCalledWith(': heartbeat\n\n');
+    });
+  });
+
+  describe('emit', () => {
+    it('should emit event to all listeners', () => {
+      const mockRes1 = createMockResponse();
+      const mockRes2 = createMockResponse();
+      const event: ProgressEvent = { type: 'cinema_started', cinema_name: 'Test', cinema_id: 'C1', index: 0 };
+
+      tracker.addListener(mockRes1 as any);
+      tracker.addListener(mockRes2 as any);
+
+      tracker.emit(event);
+
+      expect(mockRes1.write).toHaveBeenCalledWith(`data: ${JSON.stringify(event)}\n\n`);
+      expect(mockRes2.write).toHaveBeenCalledWith(`data: ${JSON.stringify(event)}\n\n`);
+    });
+
+    it('should store events for replay to new listeners', () => {
+      const event1: ProgressEvent = { type: 'started', total_cinemas: 3, total_dates: 7 };
+      const event2: ProgressEvent = { type: 'cinema_started', cinema_name: 'Cinema A', cinema_id: 'C1', index: 0 };
+
+      tracker.emit(event1);
+      tracker.emit(event2);
+
+      expect(tracker.getEvents()).toEqual([event1, event2]);
+    });
+
+    it('should remove disconnected listener on write error', () => {
+      const mockRes = createMockResponse();
+      mockRes.write.mockImplementation(() => {
+        throw new Error('Connection closed');
+      });
+
+      tracker.addListener(mockRes as any);
+      expect(tracker.getListenerCount()).toBe(1);
+
+      // Emit should handle the error and remove the listener
+      tracker.emit({ type: 'started', total_cinemas: 1, total_dates: 1 });
+
+      expect(tracker.getListenerCount()).toBe(0);
+    });
+  });
+
+  describe('clearEvents', () => {
+    it('should clear all events but keep listeners connected', () => {
+      const mockRes = createMockResponse();
+      const event: ProgressEvent = { type: 'started', total_cinemas: 5, total_dates: 7 };
+
+      tracker.addListener(mockRes as any);
+      tracker.emit(event);
+
+      expect(tracker.getEvents()).toHaveLength(1);
+      expect(tracker.getListenerCount()).toBe(1);
+
+      // Clear events
+      tracker.clearEvents();
+
+      // Events should be cleared
+      expect(tracker.getEvents()).toHaveLength(0);
+
+      // Listener should still be connected
+      expect(tracker.getListenerCount()).toBe(1);
+
+      // Listener should NOT have received an end() call
+      expect(mockRes.end).not.toHaveBeenCalled();
+
+      // New events should still be delivered to the listener
+      const newEvent: ProgressEvent = { type: 'cinema_started', cinema_name: 'New', cinema_id: 'C2', index: 0 };
+      tracker.emit(newEvent);
+
+      expect(mockRes.write).toHaveBeenCalledWith(`data: ${JSON.stringify(newEvent)}\n\n`);
+    });
+  });
+
+  describe('reset', () => {
+    it('should clear events and close all connections', () => {
+      const mockRes1 = createMockResponse();
+      const mockRes2 = createMockResponse();
+      const event: ProgressEvent = { type: 'started', total_cinemas: 5, total_dates: 7 };
+
+      tracker.addListener(mockRes1 as any);
+      tracker.addListener(mockRes2 as any);
+      tracker.emit(event);
+
+      expect(tracker.getEvents()).toHaveLength(1);
+      expect(tracker.getListenerCount()).toBe(2);
+
+      // Full reset
+      tracker.reset();
+
+      // Events should be cleared
+      expect(tracker.getEvents()).toHaveLength(0);
+
+      // Listeners should be removed
+      expect(tracker.getListenerCount()).toBe(0);
+
+      // Listeners should have received end() calls
+      expect(mockRes1.end).toHaveBeenCalled();
+      expect(mockRes2.end).toHaveBeenCalled();
+    });
+
+    it('should stop heartbeat on reset', () => {
+      const mockRes = createMockResponse();
+
+      tracker.addListener(mockRes as any);
+      tracker.reset();
+
+      // Advance timer - heartbeat should not fire since we reset
+      vi.advanceTimersByTime(15000);
+
+      expect(mockRes.write).not.toHaveBeenCalledWith(': heartbeat\n\n');
+    });
+
+    it('should handle errors when closing listeners', () => {
+      const mockRes = createMockResponse();
+      mockRes.end.mockImplementation(() => {
+        throw new Error('Already closed');
+      });
+
+      tracker.addListener(mockRes as any);
+
+      // Should not throw
+      expect(() => tracker.reset()).not.toThrow();
+      expect(tracker.getListenerCount()).toBe(0);
+    });
+  });
+
+  describe('getEvents', () => {
+    it('should return a copy of events array', () => {
+      const event: ProgressEvent = { type: 'started', total_cinemas: 1, total_dates: 1 };
+      tracker.emit(event);
+
+      const events = tracker.getEvents();
+      events.push({ type: 'failed', error: 'test' });
+
+      // Original should not be modified
+      expect(tracker.getEvents()).toHaveLength(1);
+    });
+  });
+});

--- a/server/src/services/progress-tracker.ts
+++ b/server/src/services/progress-tracker.ts
@@ -103,7 +103,12 @@ export class ProgressTracker {
     }
   }
 
-  // Clear all events and listeners
+  // Clear events but keep connections open (for starting a new scrape session)
+  clearEvents(): void {
+    this.events = [];
+  }
+
+  // Full reset: clear events AND close all connections (for shutdown)
   reset(): void {
     this.events = [];
     this.stopHeartbeat();

--- a/server/src/services/scraper-service.test.ts
+++ b/server/src/services/scraper-service.test.ts
@@ -69,12 +69,13 @@ describe('ScraperService', () => {
 
   describe('subscribeToProgress', () => {
     it('should add listener and return cleanup function', () => {
-      const mockRes = { setHeader: vi.fn() };
+      const mockRes = { setHeader: vi.fn(), flushHeaders: vi.fn() };
       const mockOnClose = vi.fn();
       
       const cleanup = scraperService.subscribeToProgress(mockRes, mockOnClose);
       
       expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Type', 'text/event-stream');
+      expect(mockRes.flushHeaders).toHaveBeenCalled();
       expect(progressTracker.addListener).toHaveBeenCalledWith(mockRes);
       
       cleanup();

--- a/server/src/services/scraper-service.test.ts
+++ b/server/src/services/scraper-service.test.ts
@@ -11,7 +11,7 @@ vi.mock('../db/cinema-queries.js');
 vi.mock('./redis-client.js');
 vi.mock('./progress-tracker.js', () => ({
   progressTracker: {
-    reset: vi.fn(),
+    clearEvents: vi.fn(),
     addListener: vi.fn(),
     removeListener: vi.fn(),
     getListenerCount: vi.fn().mockReturnValue(1),
@@ -42,7 +42,7 @@ describe('ScraperService', () => {
       const result = await scraperService.triggerScrape({ cinemaId: 'C1', filmId: 123 });
 
       expect(result.reportId).toBe(42);
-      expect(progressTracker.reset).toHaveBeenCalled();
+      expect(progressTracker.clearEvents).toHaveBeenCalled();
       expect(mockPublish).toHaveBeenCalledWith(expect.objectContaining({
         type: 'scrape',
         reportId: 42,

--- a/server/src/services/scraper-service.ts
+++ b/server/src/services/scraper-service.ts
@@ -27,9 +27,10 @@ export class ScraperService {
 
     const reportId = await createScrapeReport(this.db, 'manual');
 
-    // Reset stale events so new SSE subscribers don't receive previous session's
+    // Clear stale events so new SSE subscribers don't receive previous session's
     // completed/failed events and immediately dismiss the progress panel.
-    progressTracker.reset();
+    // Note: clearEvents() keeps existing SSE connections open (unlike reset() which closes them).
+    progressTracker.clearEvents();
 
     const queueDepth = await getRedisClient().publishJob({
       type: 'scrape',

--- a/server/src/services/scraper-service.ts
+++ b/server/src/services/scraper-service.ts
@@ -64,6 +64,7 @@ export class ScraperService {
     res.setHeader('Cache-Control', 'no-cache');
     res.setHeader('Connection', 'keep-alive');
     res.setHeader('X-Accel-Buffering', 'no'); // Disable nginx buffering
+    res.flushHeaders(); // Force headers to be sent immediately (prevents buffering)
 
     progressTracker.addListener(res);
     logger.info(`📡 SSE client connected (${progressTracker.getListenerCount()} total)`);


### PR DESCRIPTION
## Summary

Phase 4 of the performance optimization initiative — architecture-level improvements to both the scraper and client.

### Scraper improvements
- **Bounded concurrency with p-limit** (#598) — Replaced sequential cinema-by-cinema scraping with `Promise.allSettled` + `p-limit`. Configurable via `SCRAPER_CONCURRENCY` env var (default: 2). Removed the old `SCRAPE_THEATER_DELAY_MS` delay-based throttling.
- **Circuit breaker pattern** (#599) — New `CircuitBreaker` class wrapping `fetchShowtimesJson` and `fetchFilmPage`. Configurable threshold (`CIRCUIT_BREAKER_THRESHOLD`, default 5) and cooldown (`CIRCUIT_BREAKER_COOLDOWN_MS`, default 60s). Prevents hammering Allocine when it starts returning errors. Includes 10 unit tests covering all state transitions.

### Client improvements
- **Admin pages migrated to React Query** (#600) — `UsersPage`, `SchedulesPage`, `SystemPage` refactored from manual `useState`/`useEffect`/`fetch` to `useQuery`/`useMutation`/`useQueryClient`. SettingsProvider intentionally skipped (complex bidirectional state with limited migration benefit).
- **Lazy-load AdminPage tabs** (#601) — All 7 tab imports in `AdminPage.tsx` converted to `React.lazy()` with `<Suspense>` fallback, reducing initial bundle for the admin section.
- **FilmSearchBar migrated to React Query** (#602) — Search results now use `useQuery` with `staleTime: 5min` for automatic caching of repeated searches.

### TypeScript verification
- `npx tsc --noEmit` passes with zero errors in both `scraper/` and `client/`

Closes #577, closes #598, closes #599, closes #600, closes #601, closes #602