### PR TITLE
🛡️ Sentinel: [security improvement] Add length limit to film search query

### DIFF
--- a/server/src/routes/films.test.ts
+++ b/server/src/routes/films.test.ts
@@ -220,7 +220,19 @@ describe('Routes - Films', () => {
       expect(mockRes.status).toHaveBeenCalledWith(400);
       expect(mockRes.json).toHaveBeenCalledWith(expect.objectContaining({
         success: false,
-        error: expect.stringContaining('at least 2 characters')
+        error: expect.stringContaining('between 2 and 100 characters')
+      }));
+    });
+
+    it('should return 400 if query is too long', async () => {
+      mockReq = { query: { q: 'a'.repeat(101) }, app: mockApp };
+      const handler = getRouteHandler('/search', 'get');
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(mockRes.json).toHaveBeenCalledWith(expect.objectContaining({
+        success: false,
+        error: expect.stringContaining('between 2 and 100 characters')
       }));
     });
 
@@ -232,7 +244,7 @@ describe('Routes - Films', () => {
       expect(mockRes.status).toHaveBeenCalledWith(400);
       expect(mockRes.json).toHaveBeenCalledWith(expect.objectContaining({
         success: false,
-        error: expect.stringContaining('at least 2 characters')
+        error: expect.stringContaining('between 2 and 100 characters')
       }));
     });
 

--- a/server/src/routes/films.ts
+++ b/server/src/routes/films.ts
@@ -56,8 +56,8 @@ router.get('/search', publicLimiter, async (req, res, next) => {
     const query = req.query.q as string | undefined;
     
     // Validate query parameter
-    if (!query || query.trim().length < 2) {
-      return next(new ValidationError('Search query must be at least 2 characters'));
+    if (!query || query.trim().length < 2 || query.trim().length > 100) {
+      return next(new ValidationError('Search query must be between 2 and 100 characters'));
     }
     
     const films = await filmService.search(query.trim(), 10);


### PR DESCRIPTION
## 🛡️ Sentinel Security Improvement

**🚨 Severity:** MEDIUM (Security Enhancement)

**💡 Vulnerability:** Missing input length limits on search queries. The `GET /api/films/search` endpoint only enforced a minimum query length (2 characters) but did not enforce a maximum length.

**🎯 Impact:** A malicious user could submit extremely long strings in the `q` parameter. This could lead to a Denial of Service (DoS) by forcing the database to execute resource-intensive fuzzy matching (`similarity()`) and substring searches (`ILIKE`) on massive inputs, potentially exhausting CPU or memory resources and slowing down the API for legitimate users.

**🔧 Fix:** Added a validation check to strictly reject queries longer than 100 characters, returning a `400 Bad Request` with a clear validation error message. This safely bounds the input size before it reaches the database layer. Tests have been updated to assert this new 100-character boundary.

**✅ Verification:**
- Attempt to search for a query with 101+ characters on `/api/films/search`.
- The API will immediately reject the request with `Search query must be between 2 and 100 characters`.
- Test suite run validates that the endpoint accepts valid strings (2-100 characters) and rejects strings that are too short (<2 characters) or too long (>100 characters).

---
*PR created automatically by Jules for task [14690556113756625381](https://jules.google.com/task/14690556113756625381) started by @PhBassin*