### PR TITLE
🛡️ Sentinel: [MEDIUM] Replace loose parseInt with strict parseStrictInt

### DIFF
--- a/server/src/routes/admin/rate-limits.ts
+++ b/server/src/routes/admin/rate-limits.ts
@@ -13,6 +13,7 @@ import { protectedLimiter } from '../../middleware/rate-limit.js';
 import { invalidateRateLimitCache } from '../../config/rate-limits.js';
 import type { ApiResponse } from '../../types/api.js';
 import { ValidationError } from '../../utils/errors.js';
+import { parseStrictInt } from '../../utils/number.js';
 
 const router = express.Router();
 
@@ -121,9 +122,12 @@ router.post('/reset', protectedLimiter, requireAuth, requirePermission('ratelimi
 router.get('/audit', protectedLimiter, requireAuth, requirePermission('ratelimits:audit'), async (req, res, next) => {
   try {
     const db: DB = req.app.get('db');
-    const limit = Math.min(parseInt(req.query.limit as string) || 50, 200);
-    const offset = parseInt(req.query.offset as string) || 0;
-    const userId = req.query.userId ? parseInt(req.query.userId as string) : undefined;
+    const parsedLimit = parseStrictInt(req.query.limit);
+    const limit = Math.min(isNaN(parsedLimit) ? 50 : parsedLimit, 200);
+    const parsedOffset = parseStrictInt(req.query.offset);
+    const offset = isNaN(parsedOffset) ? 0 : parsedOffset;
+    const parsedUserId = parseStrictInt(req.query.userId);
+    const userId = isNaN(parsedUserId) ? undefined : parsedUserId;
 
     const auditLog = await getRateLimitAuditLog(db, { limit, offset, userId });
 

--- a/server/src/routes/reports.ts
+++ b/server/src/routes/reports.ts
@@ -89,7 +89,7 @@ router.get('/:id', protectedLimiter, requireAuth, requirePermission('reports:vie
 router.get('/:id/details', protectedLimiter, requireAuth, requirePermission('reports:view'), async (req, res, next) => {
   try {
     const db: DB = req.app.get('db');
-    const reportId = parseInt(req.params.id as string);
+    const reportId = parseStrictInt(req.params.id);
 
     if (isNaN(reportId)) {
       return next(new ValidationError('Invalid report ID'));

--- a/server/src/routes/scraper.ts
+++ b/server/src/routes/scraper.ts
@@ -70,7 +70,7 @@ router.post('/resume/:reportId', scraperLimiter, requireAuth, async (req: AuthRe
   const scraperService = new ScraperService(dbConn);
 
   try {
-    const reportId = parseInt(req.params.reportId as string, 10);
+    const reportId = parseStrictInt(req.params.reportId);
     
     if (isNaN(reportId)) {
       return next(new ValidationError('Invalid report ID'));


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Loose integer parsing of IDs and query parameters using native `parseInt` which allows trailing non-numeric characters.
🎯 Impact: Permissive parsing can lead to unexpected behavior, logic flaws, or potential IDORs if IDs are loosely matched or interpreted.
🔧 Fix: Replaced `parseInt` with the custom `parseStrictInt` utility in API routes (`scraper.ts`, `reports.ts`, `admin/rate-limits.ts`) to strictly enforce a valid integer format.
✅ Verification: Ran `npm run test:run` in the `server` directory and executed the application build.

---
*PR created automatically by Jules for task [1754077494643075962](https://jules.google.com/task/1754077494643075962) started by @PhBassin*