### PR TITLE
Enhance CI with release order builds and version bump workflow

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -27,6 +27,10 @@ jobs:
   build:
     name: Build ${{ matrix.image }} (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
+    if: |
+      github.event_name != 'push' ||
+      github.ref != 'refs/heads/main' ||
+      startsWith(github.event.head_commit.message, 'chore(release): bump version to ')
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -1,11 +1,10 @@
 name: Version Tag & Release
 
-# Triggered after docker-build-push.yml completes successfully on main branch
+# Triggered on push to main to bump version before release builds
 on:
-  workflow_run:
-    workflows: ["Docker Build & Push"]
-    types:
-      - completed
+  push:
+    branches:
+      - main
 
 permissions:
   contents: write
@@ -17,8 +16,8 @@ jobs:
   create-version-tag:
     name: Create Version Tag
     runs-on: ubuntu-latest
-    # Only run if Docker build succeeded AND triggered from main branch
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    # Skip release bump commits to prevent workflow loops
+    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release)') }}
 
     steps:
       - name: Checkout repository
@@ -45,10 +44,10 @@ jobs:
       - name: Get merged PR number
         id: pr
         run: |
-          # Get the PR that was merged in the commit that triggered the workflow
-          PR_NUMBER=$(gh pr list --state merged --json number,mergeCommit --jq ".[] | select(.mergeCommit.oid==\"${{ github.event.workflow_run.head_sha }}\") | .number" | head -1)
+          # Get the PR merged in the commit that triggered this push
+          PR_NUMBER=$(gh pr list --state merged --json number,mergeCommit --jq ".[] | select(.mergeCommit.oid==\"${{ github.sha }}\") | .number" | head -1)
           if [ -z "$PR_NUMBER" ]; then
-            echo "No merged PR found for commit ${{ github.event.workflow_run.head_sha }}"
+            echo "No merged PR found for commit ${{ github.sha }}"
             echo "number=" >> $GITHUB_OUTPUT
           else
             echo "number=${PR_NUMBER}" >> $GITHUB_OUTPUT
@@ -359,40 +358,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Retag Docker images with version
-        run: |
-          NEW_VERSION="${{ steps.new_version.outputs.version }}"
-          NEW_TAG="${{ steps.new_version.outputs.tag }}"
-          REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          
-          # Parse version components for semver tags
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$NEW_VERSION"
-          
-          # Retag both web and scraper images
-          for IMAGE in "ghcr.io/${REPO}" "ghcr.io/${REPO}-scraper"; do
-            echo "Retagging ${IMAGE}..."
-            
-            # Add semver tags to the existing 'main' manifest
-            docker buildx imagetools create \
-              --tag "${IMAGE}:${NEW_VERSION}" \
-              --tag "${IMAGE}:${MAJOR}.${MINOR}" \
-              --tag "${IMAGE}:${MAJOR}" \
-              --tag "${IMAGE}:${NEW_TAG}" \
-              "${IMAGE}:main"
-            
-            echo "Tagged ${IMAGE} with: ${NEW_TAG}, ${NEW_VERSION}, ${MAJOR}.${MINOR}, ${MAJOR}"
-          done
-
       - name: Summary
         run: |
           NEW_TAG="${{ steps.new_version.outputs.tag }}"
@@ -410,4 +375,4 @@ jobs:
           echo "✅ Created git tag \`${NEW_TAG}\`" >> $GITHUB_STEP_SUMMARY
           echo "✅ Created GitHub release" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "🐋 Docker images retagged with version tags" >> $GITHUB_STEP_SUMMARY
+          echo "🐋 Docker builds are triggered from the release commit and tag" >> $GITHUB_STEP_SUMMARY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,10 +313,10 @@ If no version label is found, the workflow checks PR title:
 ### What Happens Automatically
 
 1. **On PR merge to main**:
-   - Docker Build & Push workflow runs
+   - Version Tag workflow runs first on `main`
    
-2. **After successful Docker build**:
-   - Version Tag workflow triggers automatically
+2. **After version bump + tag creation**:
+   - Docker Build & Push workflow runs from the release bump commit and tag
    - Reads last git tag (e.g., `v4.0.1`)
    - Determines bump type from PR label/title
    - Calculates new version (e.g., `v4.0.2`)
@@ -334,8 +334,13 @@ If no version label is found, the workflow checks PR title:
    
 5. **GitHub release**:
    - Creates release with generated changelog
-   - Docker build triggers again for the new tag
-   - Images tagged with version numbers
+   - Docker build triggered from the release bump commit and `vX.Y.Z` tag publishes `main`, `vX.Y.Z`, `vX.Y`, `vX`, `stable`, and `latest`
+
+### Version Consistency Guarantee
+
+- The app version displayed in System Information is read from root `package.json` at runtime.
+- Because version bump now happens before release image builds, image tags and displayed app version stay aligned.
+- Avoid manual image retagging from `main` for release tags, as it can reintroduce drift between image content and tag.
 
 ### Example Workflow
 


### PR DESCRIPTION
This pull request updates our GitHub Actions workflows to improve the release automation process, ensuring that version tags and Docker image tags stay consistent and aligned with the app version. The main changes are a reordering of workflow triggers, simplification of tagging logic, and updates to documentation to reflect the new process.

**Workflow trigger and logic changes:**

* The `version-tag.yml` workflow is now triggered directly on pushes to `main`, instead of after the Docker build workflow completes, to bump the version before release builds.
* The Docker Build & Push workflow (`docker-build-push.yml`) is updated to only run for non-release bump commits, preventing unnecessary builds and workflow loops. [[1]](diffhunk://#diff-b7dce24085c1061be7542e1f68edac2c9002799454a47708546d1e7e6fbf2a10R30-R33) [[2]](diffhunk://#diff-89d280515581b51d5cbbc3a30b9397e7c7e7b229c497288a8ea36bac20ac8e15L20-R20)
* The logic for finding the merged PR number in `version-tag.yml` is updated to use the commit SHA from the push event, ensuring correct PR association.

**Docker image tagging and release process:**

* The steps for retagging Docker images with version tags in `version-tag.yml` have been removed; Docker builds are now triggered from the release commit and tag, ensuring image tags and content are always in sync. [[1]](diffhunk://#diff-89d280515581b51d5cbbc3a30b9397e7c7e7b229c497288a8ea36bac20ac8e15L362-L395) [[2]](diffhunk://#diff-89d280515581b51d5cbbc3a30b9397e7c7e7b229c497288a8ea36bac20ac8e15L413-R378)

**Documentation updates:**

* The release process in `AGENTS.md` is updated to reflect the new workflow order and to explain how version consistency is guaranteed between the app and Docker images. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L316-R319) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L337-R343)