### PR TITLE
fix(ci): ensure release bump commit triggers Docker builds

### DIFF
--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -218,7 +218,7 @@ jobs:
           NEW_TAG="${{ steps.new_version.outputs.tag }}"
           
           git add package.json CHANGELOG.md
-          git commit -m "chore(release): bump version to ${NEW_TAG} [skip ci]"
+          git commit -m "chore(release): bump version to ${NEW_TAG}"
           
           echo "Committed version bump"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,7 +328,7 @@ If no version label is found, the workflow checks PR title:
    
 4. **Version bump commit**:
    - Updates `package.json` version field
-   - Commits changes: `chore(release): bump version to vX.Y.Z [skip ci]`
+   - Commits changes: `chore(release): bump version to vX.Y.Z`
    - Creates annotated git tag `vX.Y.Z`
    - Pushes to main
    


### PR DESCRIPTION
## Summary
- remove `[skip ci]` from the release bump commit message in `version-tag.yml`
- keep existing `chore(release)` workflow guard to prevent version-tag loops
- update `AGENTS.md` release flow docs to reflect the actual release commit format

Closes #692
