### PR TITLE
Enhance CI with release order builds and version bump workflow

### DIFF
--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -218,7 +218,7 @@ jobs:
           NEW_TAG="${{ steps.new_version.outputs.tag }}"
           
           git add package.json CHANGELOG.md
-          git commit -m "chore(release): bump version to ${NEW_TAG} [skip ci]"
+          git commit -m "chore(release): bump version to ${NEW_TAG}"
           
           echo "Committed version bump"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,7 +328,7 @@ If no version label is found, the workflow checks PR title:
    
 4. **Version bump commit**:
    - Updates `package.json` version field
-   - Commits changes: `chore(release): bump version to vX.Y.Z [skip ci]`
+   - Commits changes: `chore(release): bump version to vX.Y.Z`
    - Creates annotated git tag `vX.Y.Z`
    - Pushes to main
    


### PR DESCRIPTION
This pull request removes the `[skip ci]` flag from the version bump commit messages in both the workflow configuration and the documentation. This means that CI workflows will now run for these commits, ensuring that all checks are performed after a version bump.

Most important changes:

**Workflow update:**
* [`.github/workflows/version-tag.yml`](diffhunk://#diff-89d280515581b51d5cbbc3a30b9397e7c7e7b229c497288a8ea36bac20ac8e15L221-R221): The commit message for version bumps no longer includes `[skip ci]`, so CI will not be skipped for these commits.

**Documentation update:**
* [`AGENTS.md`](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L331-R331): Updated the example version bump commit message to remove `[skip ci]`, reflecting the workflow change.