### PR TITLE
Implement deterministic showtime IDs to prevent duplication

### DIFF
--- a/migrations/022_fix_showtime_deduplication.sql
+++ b/migrations/022_fix_showtime_deduplication.sql
@@ -1,0 +1,49 @@
+-- Migration: Fix showtime deduplication
+-- Version: 4.7.0
+-- Date: 2026-03-30
+--
+-- PROBLEM: Showtime IDs were generated from Allociné's ephemeral internalId
+-- (data-showtime-id), which changes on every HTTP request. This caused a new
+-- row to be inserted for the same physical screening on each scrape run.
+--
+-- FIX: Showtime IDs are now deterministic:
+--   {cinema_id}_{film_id}_{date}_{time}_{version}_{format}
+-- This ensures ON CONFLICT(id) correctly deduplicates on re-scrapes.
+--
+-- This migration:
+--   1. Removes existing duplicate showtimes (keeps one per business key)
+--   2. Adds a UNIQUE constraint on (cinema_id, film_id, date, time, version, format)
+--      as an additional safety net
+--
+-- IMPORTANT: Backup your database before running!
+--   docker compose exec -T db pg_dump -U postgres its > backup_before_022.sql
+--
+-- Apply:
+--   docker compose exec -T db psql -U postgres -d its -f migrations/022_fix_showtime_deduplication.sql
+
+BEGIN;
+
+-- Step 1: Remove duplicate showtimes
+-- Keep the row with the lowest id (arbitrary but consistent) for each business key.
+-- A "duplicate" is defined as same (cinema_id, film_id, date, time, version, format).
+DELETE FROM showtimes
+WHERE id NOT IN (
+  SELECT MIN(id)
+  FROM showtimes
+  GROUP BY cinema_id, film_id, date, time, version, COALESCE(format, '')
+);
+
+-- Step 2: Add UNIQUE constraint on business key fields as a safety net.
+-- This prevents future duplicates even if a bug re-introduces non-deterministic IDs.
+ALTER TABLE showtimes
+  ADD CONSTRAINT uq_showtimes_business_key
+  UNIQUE (cinema_id, film_id, date, time, version, format);
+
+COMMIT;
+
+-- Post-migration verification
+-- SELECT COUNT(*) FROM showtimes;
+-- SELECT cinema_id, film_id, date, time, version, format, COUNT(*) as cnt
+--   FROM showtimes
+--   GROUP BY cinema_id, film_id, date, time, version, format
+--   HAVING COUNT(*) > 1;

--- a/scraper/src/scraper/theater-json-parser.ts
+++ b/scraper/src/scraper/theater-json-parser.ts
@@ -191,7 +191,7 @@ function mapShowtimes(
 
   const showtimes: Showtime[] = [];
   for (const { showtime, version } of allEntries) {
-    if (!showtime.startsAt || !showtime.internalId) continue;
+    if (!showtime.startsAt) continue;
 
     const actualDate = showtime.startsAt.split('T')[0] || date;
     const time = showtime.startsAt.split('T')[1]?.substring(0, 5) ?? '';
@@ -204,7 +204,7 @@ function mapShowtimes(
     const experiences: string[] = showtime.tags ?? [];
 
     showtimes.push({
-      id: `${showtime.internalId}-${actualDate}`,
+      id: `${cinemaId}_${filmId}_${actualDate}_${time}_${ver2}_${format ?? ''}`,
       film_id: filmId,
       cinema_id: cinemaId,
       date: actualDate,

--- a/scraper/src/scraper/theater-parser.ts
+++ b/scraper/src/scraper/theater-parser.ts
@@ -229,11 +229,10 @@ function parseShowtimes(
     $version.find('.showtimes-hour-item').each((_, hourItem) => {
       const $hour = $(hourItem);
 
-      const showtimeId = $hour.attr('data-showtime-id');
       const datetimeIso = $hour.attr('data-showtime-time');
       const experiencesStr = $hour.attr('data-experiences');
 
-      if (!showtimeId || !datetimeIso) return;
+      if (!datetimeIso) return;
 
       // Extraire l'heure
       const time = $hour.find('.showtimes-hour-item-value').text().trim();
@@ -264,7 +263,7 @@ function parseShowtimes(
       }
 
       showtimes.push({
-        id: `${showtimeId}-${showtimeDate}`,
+        id: `${cinemaId}_${filmId}_${showtimeDate}_${time}_${version}_${format ?? ''}`,
         film_id: filmId,
         cinema_id: cinemaId,
         date: showtimeDate,

--- a/scraper/tests/unit/scraper/theater-parser.test.ts
+++ b/scraper/tests/unit/scraper/theater-parser.test.ts
@@ -241,12 +241,13 @@ describe('parseTheaterPage - Edge Cases', () => {
 
 // Test Suite 5: Data Validation
 describe('parseTheaterPage - Data Validation', () => {
+  let c0089Html: string;
   let c0089Result: ReturnType<typeof parseTheaterPage>;
   let w7504Result: ReturnType<typeof parseTheaterPage>;
   let c0072Result: ReturnType<typeof parseTheaterPage>;
 
   beforeAll(() => {
-    const c0089Html = readFileSync(join(__dirname, '../../fixtures/cinema-c0089-page.html'), 'utf-8');
+    c0089Html = readFileSync(join(__dirname, '../../fixtures/cinema-c0089-page.html'), 'utf-8');
     const w7504Html = readFileSync(join(__dirname, '../../fixtures/cinema-w7504-page.html'), 'utf-8');
     const c0072Html = readFileSync(join(__dirname, '../../fixtures/cinema-c0072-page.html'), 'utf-8');
 
@@ -298,18 +299,45 @@ describe('parseTheaterPage - Data Validation', () => {
     });
   });
 
-  it('should generate unique showtime IDs that include the date', () => {
-    // Showtime IDs must include the date to be unique per day
-    // Format: <source_showtime_id>-<YYYY-MM-DD>
-    [c0089Result, w7504Result, c0072Result].forEach((result) => {
+  it('should generate deterministic showtime IDs based on stable business fields', () => {
+    // IDs must be deterministic: same cinema+film+date+time+version+format always → same ID
+    // Format: {cinema_id}_{film_id}_{date}_{time}_{version}_{format}
+    // This prevents duplicates when the same cinema is scraped multiple times in a week,
+    // since Allociné's internal internalId/data-showtime-id changes on each HTTP request.
+    const resultsByCinema = [
+      { result: c0089Result, cinemaId: 'C0089' },
+      { result: w7504Result, cinemaId: 'W7504' },
+      { result: c0072Result, cinemaId: 'C0072' },
+    ];
+
+    resultsByCinema.forEach(({ result, cinemaId }) => {
       result.films.forEach((filmData) => {
         filmData.showtimes.forEach((showtime) => {
-          // ID should contain the date to ensure uniqueness across days
+          // ID must contain the cinema ID to be scoped per cinema
+          expect(showtime.id).toContain(cinemaId);
+          // ID must contain the film ID
+          expect(showtime.id).toContain(String(filmData.film.id));
+          // ID must contain the date
           expect(showtime.id).toContain(showtime.date);
-          // ID format: <numeric_id>-<date>
-          expect(showtime.id).toMatch(/^\d+-\d{4}-\d{2}-\d{2}$/);
+          // ID must contain the time
+          expect(showtime.id).toContain(showtime.time);
+          // New format: {cinema_id}_{film_id}_{date}_{time}_{version}_{format}
+          expect(showtime.id).toMatch(/^[A-Z0-9]+_\d+_\d{4}-\d{2}-\d{2}_\d{2}:\d{2}_/);
         });
       });
     });
+  });
+
+  it('should generate the same showtime ID when parsing the same data twice (idempotent)', () => {
+    // Re-parsing the same HTML must produce identical IDs — no duplicates on repeated scrapes
+    const result1 = parseTheaterPage(c0089Html, 'C0089');
+    const result2 = parseTheaterPage(c0089Html, 'C0089');
+
+    const ids1 = result1.films.flatMap(f => f.showtimes.map(s => s.id)).sort();
+    const ids2 = result2.films.flatMap(f => f.showtimes.map(s => s.id)).sort();
+
+    expect(ids1).toEqual(ids2);
+    // All IDs must be unique within a single parse (no duplicates)
+    expect(ids1.length).toBe(new Set(ids1).size);
   });
 });

--- a/server/src/db/system-queries.test.ts
+++ b/server/src/db/system-queries.test.ts
@@ -103,6 +103,7 @@ describe('System Queries', () => {
             { version: '019_add_permission_category_labels.sql' },
             { version: '020_add_film_screenwriters.sql' },
             { version: '021_add_film_trailer_url.sql' },
+            { version: '022_fix_showtime_deduplication.sql' },
           ],
         }),
       } as unknown as DB;


### PR DESCRIPTION
This pull request addresses a critical issue with showtime deduplication by making showtime IDs deterministic and updating the database schema and scraper logic accordingly. The changes ensure that repeated scrapes do not create duplicate showtimes for the same physical screening, and that IDs remain stable across scrapes. The migration also removes existing duplicates and enforces uniqueness at the database level. Tests have been improved to verify the new deterministic ID logic and idempotency.

**Showtime ID Generation and Deduplication Improvements:**

* Showtime IDs are now generated deterministically using the format `{cinema_id}_{film_id}_{date}_{time}_{version}_{format}` instead of using Allociné's ephemeral `internalId`, ensuring stable IDs across scrapes and preventing duplicate entries. (`scraper/src/scraper/theater-json-parser.ts` [[1]](diffhunk://#diff-38d803fc1a596db902089018dec15c5ea8a44c38d72b6dc56b1e30b40669bcbdL194-R194) [[2]](diffhunk://#diff-38d803fc1a596db902089018dec15c5ea8a44c38d72b6dc56b1e30b40669bcbdL207-R207); `scraper/src/scraper/theater-parser.ts` [[3]](diffhunk://#diff-57f0843b5d7918e5658e013e2d90945472e7df4f4971f363f2f92e157fb9459cL232-R235) [[4]](diffhunk://#diff-57f0843b5d7918e5658e013e2d90945472e7df4f4971f363f2f92e157fb9459cL267-R266)

* The database migration removes existing duplicate showtimes (keeping only one per business key) and adds a unique constraint on `(cinema_id, film_id, date, time, version, format)` to enforce deduplication at the database level. (`migrations/022_fix_showtime_deduplication.sql` [migrations/022_fix_showtime_deduplication.sqlR1-R49](diffhunk://#diff-c161f4067390f4d6f3bafa922e1b57fc860d188e279d375bf86f5cb7c6b96036R1-R49))

**Testing Enhancements:**

* Unit tests have been updated to check that showtime IDs are deterministic, include all relevant business fields, and remain consistent across repeated parses. A new test ensures that parsing the same data twice produces identical IDs with no duplicates. (`scraper/tests/unit/scraper/theater-parser.test.ts` [[1]](diffhunk://#diff-56a21c197e8e0d0c72cf597593a26838b0631a7304b8a86d4d6862e2f94d8b72R244-R250) [[2]](diffhunk://#diff-56a21c197e8e0d0c72cf597593a26838b0631a7304b8a86d4d6862e2f94d8b72L301-R341)

**Maintenance and Metadata:**

* The new migration is registered in the system queries test to ensure it is tracked and applied in the correct order. (`server/src/db/system-queries.test.ts` [server/src/db/system-queries.test.tsR106](diffhunk://#diff-d158aaf04aaf33cc613d937c026043cccd4f86c9bb79f5d50051d71aaa2bb097R106))