### PR TITLE
ci: bump version before docker build

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -3,7 +3,6 @@ name: Docker Build & Push
 on:
   push:
     branches:
-      - main
       - develop
     tags:
       - 'v*'
@@ -195,7 +194,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
             type=raw,value=stable,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Create and push multi-arch manifest

--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -1,11 +1,12 @@
 name: Version Tag & Release
 
-# Triggered after docker-build-push.yml completes successfully on main branch
+# Triggered on push to main — runs BEFORE Docker build so the image is built
+# with the correct bumped version in package.json.
+# The version-bump commit uses [skip ci] to avoid re-triggering this workflow.
 on:
-  workflow_run:
-    workflows: ["Docker Build & Push"]
-    types:
-      - completed
+  push:
+    branches:
+      - main
 
 permissions:
   contents: write
@@ -17,8 +18,8 @@ jobs:
   create-version-tag:
     name: Create Version Tag
     runs-on: ubuntu-latest
-    # Only run if Docker build succeeded AND triggered from main branch
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    # Skip the version-bump commit itself (it contains [skip ci])
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
 
     steps:
       - name: Checkout repository
@@ -46,9 +47,9 @@ jobs:
         id: pr
         run: |
           # Get the PR that was merged in the commit that triggered the workflow
-          PR_NUMBER=$(gh pr list --state merged --json number,mergeCommit --jq ".[] | select(.mergeCommit.oid==\"${{ github.event.workflow_run.head_sha }}\") | .number" | head -1)
+          PR_NUMBER=$(gh pr list --state merged --json number,mergeCommit --jq ".[] | select(.mergeCommit.oid==\"${{ github.sha }}\") | .number" | head -1)
           if [ -z "$PR_NUMBER" ]; then
-            echo "No merged PR found for commit ${{ github.event.workflow_run.head_sha }}"
+            echo "No merged PR found for commit ${{ github.sha }}"
             echo "number=" >> $GITHUB_OUTPUT
           else
             echo "number=${PR_NUMBER}" >> $GITHUB_OUTPUT
@@ -359,40 +360,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Retag Docker images with version
-        run: |
-          NEW_VERSION="${{ steps.new_version.outputs.version }}"
-          NEW_TAG="${{ steps.new_version.outputs.tag }}"
-          REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          
-          # Parse version components for semver tags
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$NEW_VERSION"
-          
-          # Retag both web and scraper images
-          for IMAGE in "ghcr.io/${REPO}" "ghcr.io/${REPO}-scraper"; do
-            echo "Retagging ${IMAGE}..."
-            
-            # Add semver tags to the existing 'main' manifest
-            docker buildx imagetools create \
-              --tag "${IMAGE}:${NEW_VERSION}" \
-              --tag "${IMAGE}:${MAJOR}.${MINOR}" \
-              --tag "${IMAGE}:${MAJOR}" \
-              --tag "${IMAGE}:${NEW_TAG}" \
-              "${IMAGE}:main"
-            
-            echo "Tagged ${IMAGE} with: ${NEW_TAG}, ${NEW_VERSION}, ${MAJOR}.${MINOR}, ${MAJOR}"
-          done
-
       - name: Summary
         run: |
           NEW_TAG="${{ steps.new_version.outputs.tag }}"
@@ -410,4 +377,4 @@ jobs:
           echo "✅ Created git tag \`${NEW_TAG}\`" >> $GITHUB_STEP_SUMMARY
           echo "✅ Created GitHub release" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "🐋 Docker images retagged with version tags" >> $GITHUB_STEP_SUMMARY
+          echo "🐋 Docker build will be triggered by the \`${NEW_TAG}\` tag push" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Closes #703

### Problem

On push to main, Docker images were built *before* the version bump, so the image contained the previous version number in `package.json`. The version-tag workflow then just retagged the already-built image without rebuilding it.

### New flow

```
push to main
  └→ version-tag.yml (runs FIRST)
       ├─ bumps package.json → v4.x.x
       ├─ commits [skip ci] + pushes
       └─ pushes git tag v4.x.x
             └→ docker-build-push.yml (triggered by tag)
                  └─ builds with CORRECT version in package.json
```

### Changes

**`version-tag.yml`**
- Trigger: `workflow_run: Docker Build & Push` → `push: branches: [main]`
- Added `if: !contains(github.event.head_commit.message, '[skip ci]')` guard (prevents infinite loop)
- Removed redundant "Retag Docker images with version" step

**`docker-build-push.yml`**
- Removed `main` from push branch triggers (release builds trigger via `v*` tag)
- Updated `:latest` tag to apply on `v*` tag pushes (was `is_default_branch` only)
