### PR TITLE
Improve CI workflow for version bump and Docker build process

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -3,7 +3,6 @@ name: Docker Build & Push
 on:
   push:
     branches:
-      - main
       - develop
     tags:
       - 'v*'
@@ -195,7 +194,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
             type=raw,value=stable,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Create and push multi-arch manifest

--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -1,11 +1,12 @@
 name: Version Tag & Release
 
-# Triggered after docker-build-push.yml completes successfully on main branch
+# Triggered on push to main — runs BEFORE Docker build so the image is built
+# with the correct bumped version in package.json.
+# The version-bump commit uses [skip ci] to avoid re-triggering this workflow.
 on:
-  workflow_run:
-    workflows: ["Docker Build & Push"]
-    types:
-      - completed
+  push:
+    branches:
+      - main
 
 permissions:
   contents: write
@@ -17,8 +18,8 @@ jobs:
   create-version-tag:
     name: Create Version Tag
     runs-on: ubuntu-latest
-    # Only run if Docker build succeeded AND triggered from main branch
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    # Skip the version-bump commit itself (it contains [skip ci])
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
 
     steps:
       - name: Checkout repository
@@ -46,9 +47,9 @@ jobs:
         id: pr
         run: |
           # Get the PR that was merged in the commit that triggered the workflow
-          PR_NUMBER=$(gh pr list --state merged --json number,mergeCommit --jq ".[] | select(.mergeCommit.oid==\"${{ github.event.workflow_run.head_sha }}\") | .number" | head -1)
+          PR_NUMBER=$(gh pr list --state merged --json number,mergeCommit --jq ".[] | select(.mergeCommit.oid==\"${{ github.sha }}\") | .number" | head -1)
           if [ -z "$PR_NUMBER" ]; then
-            echo "No merged PR found for commit ${{ github.event.workflow_run.head_sha }}"
+            echo "No merged PR found for commit ${{ github.sha }}"
             echo "number=" >> $GITHUB_OUTPUT
           else
             echo "number=${PR_NUMBER}" >> $GITHUB_OUTPUT
@@ -359,40 +360,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Retag Docker images with version
-        run: |
-          NEW_VERSION="${{ steps.new_version.outputs.version }}"
-          NEW_TAG="${{ steps.new_version.outputs.tag }}"
-          REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          
-          # Parse version components for semver tags
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$NEW_VERSION"
-          
-          # Retag both web and scraper images
-          for IMAGE in "ghcr.io/${REPO}" "ghcr.io/${REPO}-scraper"; do
-            echo "Retagging ${IMAGE}..."
-            
-            # Add semver tags to the existing 'main' manifest
-            docker buildx imagetools create \
-              --tag "${IMAGE}:${NEW_VERSION}" \
-              --tag "${IMAGE}:${MAJOR}.${MINOR}" \
-              --tag "${IMAGE}:${MAJOR}" \
-              --tag "${IMAGE}:${NEW_TAG}" \
-              "${IMAGE}:main"
-            
-            echo "Tagged ${IMAGE} with: ${NEW_TAG}, ${NEW_VERSION}, ${MAJOR}.${MINOR}, ${MAJOR}"
-          done
-
       - name: Summary
         run: |
           NEW_TAG="${{ steps.new_version.outputs.tag }}"
@@ -410,4 +377,4 @@ jobs:
           echo "✅ Created git tag \`${NEW_TAG}\`" >> $GITHUB_STEP_SUMMARY
           echo "✅ Created GitHub release" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "🐋 Docker images retagged with version tags" >> $GITHUB_STEP_SUMMARY
+          echo "🐋 Docker build will be triggered by the \`${NEW_TAG}\` tag push" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This pull request updates the CI/CD workflow to improve the order and logic of version tagging and Docker image builds. The main change is that the version tagging workflow now runs before the Docker build, ensuring Docker images are built with the correct version from `package.json`. The Docker image retagging logic has been removed from the version tagging workflow, and Docker build/push steps have been updated to use more precise branch and tag checks.

**Workflow Trigger and Logic Changes**

* The `version-tag.yml` workflow now triggers on pushes to the `main` branch instead of after a successful Docker build, ensuring the version is bumped and tagged before building Docker images.
* The workflow now skips runs triggered by the version-bump commit itself (which contains `[skip ci]`), preventing infinite loops.

**Docker Build and Tagging Adjustments**

* The Docker build workflow (`docker-build-push.yml`) was updated to only trigger on pushes to `develop` and tags starting with `v`, no longer on `main`.
* The `latest` and `stable` Docker tags are now only enabled for builds from the `main` branch or version tags, ensuring correct tagging.

**Retagging and Summary Output**

* Removed Docker image retagging steps from the version tagging workflow, as images will now be built and tagged in the Docker build workflow after the version tag is created.
* Updated the workflow summary to reflect that Docker builds are now triggered by the version tag push, not by the version tagging workflow itself.

**Commit/PR Reference Fixes**

* Updated the logic for finding the merged PR number to use `${{ github.sha }}` instead of the previous event-based reference, ensuring correct PR association.