### PR TITLE
fix(ci): dispatch docker build after version tag push

### DIFF
--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -246,6 +246,18 @@ jobs:
           
           echo "Pushed commit and tag ${NEW_TAG}"
 
+      # GITHUB_TOKEN-pushed tags do not trigger other workflows (GitHub security restriction).
+      # We dispatch docker-build-push.yml explicitly via the API, which IS allowed with GITHUB_TOKEN.
+      - name: Trigger Docker build
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEW_TAG="${{ steps.new_version.outputs.tag }}"
+          
+          gh workflow run docker-build-push.yml --ref "${NEW_TAG}"
+          
+          echo "Triggered Docker build for ${NEW_TAG}"
+
       - name: Move stable tag to new release
         run: |
           NEW_TAG="${{ steps.new_version.outputs.tag }}"
@@ -377,4 +389,4 @@ jobs:
           echo "✅ Created git tag \`${NEW_TAG}\`" >> $GITHUB_STEP_SUMMARY
           echo "✅ Created GitHub release" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "🐋 Docker build will be triggered by the \`${NEW_TAG}\` tag push" >> $GITHUB_STEP_SUMMARY
+          echo "🐋 Docker build dispatched for tag \`${NEW_TAG}\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Fixes the Docker build not starting after version bump on main.

## Root Cause

`GITHUB_TOKEN`-pushed git tags do **not** trigger other GitHub Actions workflows — this is a deliberate GitHub security restriction to prevent infinite loops. So when `version-tag.yml` pushes the `v*` tag, `docker-build-push.yml` (which listens on `tags: v*`) never fires.

## Fix

After pushing the tag, explicitly dispatch `docker-build-push.yml` via `gh workflow run` (workflow_dispatch API). The `workflow_dispatch` API **does** work with `GITHUB_TOKEN` — only git webhook events triggered by the token are blocked.

```yaml
- name: Trigger Docker build
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  run: |
    gh workflow run docker-build-push.yml --ref "${NEW_TAG}"
```

## New CI flow

```
push to main
  └→ version-tag.yml
       ├─ bumps package.json
       ├─ commits [skip ci] + pushes tag
       └─ dispatches docker-build-push.yml on vX.X.X tag  ← NEW
            └→ docker-build-push.yml (workflow_dispatch on vX.X.X)
                 └─ builds image with correct version ✅
```

Closes #706