### PR TITLE
Fix CI to dispatch Docker build after version tag push

### DIFF
--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -246,6 +246,18 @@ jobs:
           
           echo "Pushed commit and tag ${NEW_TAG}"
 
+      # GITHUB_TOKEN-pushed tags do not trigger other workflows (GitHub security restriction).
+      # We dispatch docker-build-push.yml explicitly via the API, which IS allowed with GITHUB_TOKEN.
+      - name: Trigger Docker build
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEW_TAG="${{ steps.new_version.outputs.tag }}"
+          
+          gh workflow run docker-build-push.yml --ref "${NEW_TAG}"
+          
+          echo "Triggered Docker build for ${NEW_TAG}"
+
       - name: Move stable tag to new release
         run: |
           NEW_TAG="${{ steps.new_version.outputs.tag }}"
@@ -377,4 +389,4 @@ jobs:
           echo "✅ Created git tag \`${NEW_TAG}\`" >> $GITHUB_STEP_SUMMARY
           echo "✅ Created GitHub release" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "🐋 Docker build will be triggered by the \`${NEW_TAG}\` tag push" >> $GITHUB_STEP_SUMMARY
+          echo "🐋 Docker build dispatched for tag \`${NEW_TAG}\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This pull request updates the release workflow to ensure that Docker builds are reliably triggered after a new version tag is created. The main improvement is to explicitly dispatch the Docker build workflow using the GitHub API, addressing a limitation where tags pushed with `GITHUB_TOKEN` do not trigger downstream workflows.

Workflow automation improvements:

* Added a new step to the `.github/workflows/version-tag.yml` workflow to explicitly trigger the `docker-build-push.yml` workflow using the `gh workflow run` command and the new tag, ensuring Docker builds are started even when tags are pushed with `GITHUB_TOKEN`.
* Updated the release summary message to reflect that the Docker build is now dispatched directly, rather than relying on the tag push to trigger it.