### PR TITLE
fix(ci): add actions:write permission for workflow dispatch

### DIFF
--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -12,7 +12,7 @@ permissions:
   contents: write
   packages: write
   pull-requests: read
-  actions: read
+  actions: write
 
 jobs:
   create-version-tag:


### PR DESCRIPTION
## Summary

Fixes the 403 error when `version-tag.yml` tries to dispatch `docker-build-push.yml`.

## Root Cause

```
HTTP 403: Resource not accessible by integration
```

The `permissions` block had `actions: read` but `gh workflow run` (workflow_dispatch API) requires `actions: write`.

## Fix

```yaml
permissions:
  actions: write  # was: read
```

Closes #709