### PR TITLE
feat(client): vertical stacked date buttons in DaySelector

### DIFF
--- a/client/src/components/DaySelector.tsx
+++ b/client/src/components/DaySelector.tsx
@@ -8,9 +8,14 @@ interface DaySelectorProps {
   isNowActive?: boolean;
 }
 
-// ⚡ PERFORMANCE: Cache Intl.DateTimeFormat instance to prevent expensive
+// ⚡ PERFORMANCE: Cache Intl.DateTimeFormat instances to prevent expensive
 // re-initialization during loops or frequent re-renders
-const formatterDay = new Intl.DateTimeFormat('fr-FR', { weekday: 'short', day: 'numeric' });
+const fmtWeekday = new Intl.DateTimeFormat('fr-FR', { weekday: 'short' });
+const fmtDay     = new Intl.DateTimeFormat('fr-FR', { day: 'numeric' });
+const fmtMonth   = new Intl.DateTimeFormat('fr-FR', { month: 'short' });
+
+// fr-FR abbreviates weekdays/months with a trailing period (e.g. "lun.", "mars.")
+const stripDot = (s: string) => s.replace(/\.$/, '');
 
 function DaySelector({ weekStart, selectedDate, onSelectDate, onNow, isNowActive = false }: DaySelectorProps) {
   const days = useMemo(() => {
@@ -26,7 +31,9 @@ function DaySelector({ weekStart, selectedDate, onSelectDate, onNow, isNowActive
       date.setDate(start.getDate() + i);
       result.push({
         date: date.toISOString().split('T')[0],
-        label: formatterDay.format(date)
+        weekday: stripDot(fmtWeekday.format(date)),
+        day:     fmtDay.format(date),
+        month:   stripDot(fmtMonth.format(date)),
       });
     }
     
@@ -46,44 +53,52 @@ function DaySelector({ weekStart, selectedDate, onSelectDate, onNow, isNowActive
 
   return (
     <div className="bg-white rounded-xl border border-gray-100 p-3 shadow-sm overflow-x-auto">
-      <div className="flex gap-2 min-w-max">
+      <div className="flex gap-2 min-w-max items-stretch">
         {/* Maintenant button — always first */}
         <button
           onClick={handleNowClick}
           disabled={!todayInWeek}
           data-now-active={isNowActive || undefined}
-          className={`px-3 py-1.5 text-sm rounded-lg transition font-semibold active:scale-95 ${
+          className={`px-3 py-2 text-sm rounded-lg transition font-semibold active:scale-95 flex flex-col items-center justify-center min-w-[68px] ${
             isNowActive
               ? 'bg-teal-500 text-white cursor-pointer'
               : 'bg-gray-50 text-gray-700 hover:bg-gray-100 cursor-pointer'
           } ${!todayInWeek ? 'opacity-50 cursor-not-allowed' : ''}`}
         >
-          ⏱ Maintenant
+          <span className="text-base leading-none">⏱</span>
+          <span className="text-[11px] font-bold mt-0.5">Maintenant</span>
         </button>
 
         <button
           onClick={() => onSelectDate(null)}
-          className={`px-3 py-1.5 text-sm rounded-lg transition font-semibold cursor-pointer active:scale-95 ${
+          className={`px-3 py-2 text-sm rounded-lg transition font-semibold cursor-pointer active:scale-95 flex flex-col items-center justify-center min-w-[68px] ${
             selectedDate === null && !isNowActive
               ? 'bg-primary text-black'
               : 'bg-gray-50 text-gray-700 hover:bg-gray-100'
           }`}
           data-testid="day-selector-all"
         >
-          Tous les jours
+          <span className="text-[11px] font-bold leading-tight text-center">Tous les jours</span>
         </button>
+
         {days.map((day) => (
           <button
             key={day.date}
             onClick={() => onSelectDate(day.date)}
-            className={`px-3 py-1.5 text-sm rounded-lg transition font-semibold capitalize cursor-pointer active:scale-95 ${
+            className={`px-2 py-2 rounded-lg transition cursor-pointer active:scale-95 flex flex-col items-center justify-center min-w-[52px] ${
               selectedDate === day.date && !isNowActive
                 ? 'bg-primary text-black'
                 : 'bg-gray-50 text-gray-700 hover:bg-gray-100'
             }`}
             data-testid={`day-selector-${day.date}`}
           >
-            {day.label}
+            <span className={`text-[10px] uppercase font-bold ${selectedDate === day.date && !isNowActive ? 'text-black' : 'text-gray-400'}`}>
+              {day.weekday}
+            </span>
+            <span className="text-base font-bold leading-none my-0.5">{day.day}</span>
+            <span className={`text-[10px] ${selectedDate === day.date && !isNowActive ? 'text-black' : 'text-gray-400'}`}>
+              {day.month}
+            </span>
           </button>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- Replace single-line `lun. 25` labels with a 3-row compact card layout
- Top: abbreviated weekday (e.g. **LUN**, uppercase, no trailing dot)
- Middle: day number (large bold, e.g. **25**)
- Bottom: month abbreviation (e.g. **mars**, no trailing dot)
- All 9 buttons (Maintenant + Tous les jours + 7 days) remain on one horizontal line
- Maintenant and Tous les jours buttons restyled to match stacked card height

Closes #713