### PR TITLE
chore(security): force path-to-regexp >=8.4.0 to fix CVE-2026-4926

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "allo-scrapper",
-  "version": "4.3.0",
+  "version": "4.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "allo-scrapper",
-      "version": "4.3.0",
+      "version": "4.6.7",
       "license": "MIT",
       "workspaces": [
         "client",
@@ -7591,9 +7591,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "flatted": "^3.4.2"
   },
   "overrides": {
-    "flatted": "^3.4.2"
+    "flatted": "^3.4.2",
+    "path-to-regexp": "^8.4.0"
   },
   "optionalDependencies": {
     "fsevents": "^2.3.3"


### PR DESCRIPTION
## Security Fix — Dependabot Alert #14

**CVE:** CVE-2026-4926 / GHSA-j3q9-mxjg-w52f  
**Severity:** High (CVSS 7.5)  
**Type:** DoS via sequential optional groups generating exponential regex

## Change
Added `path-to-regexp` to the npm `overrides` in root `package.json`:
```json
"overrides": {
  "flatted": "^3.4.2",
  "path-to-regexp": "^8.4.0"
}
```

## Before / After
- Before: `path-to-regexp@8.3.0` (vulnerable)
- After: `path-to-regexp@8.4.0` (patched)

## Chain
`express@5.2.1` → `router@2.2.0` → `path-to-regexp@^8.0.0` → was resolving `8.3.0`

Closes #718