### PR TITLE
feat(api): gérer SCRAPE_DAYS et SCRAPE_MODE depuis les settings admin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -256,18 +256,10 @@ SCRAPE_THEATER_DELAY_MS=3000
 # Film details are fetched less frequently than showtimes, so lower delay is acceptable
 SCRAPE_MOVIE_DELAY_MS=500
 
-# Number of days to scrape starting from start date
-# Default: 7 (full week)
-# Min: 1, Max: 14
-SCRAPE_DAYS=7
-
-# Scrape mode: 
-# - 'weekly': Start from current/previous Wednesday (7 days by default)
-# - 'from_today': Start from current date
-# - 'from_today_limited': Start from today until Tuesday (max 7 days)
-# Default: weekly
-# Note: Automatic cron jobs always use 'weekly' mode with 7 days
-SCRAPE_MODE=weekly
+# SCRAPE_DAYS and SCRAPE_MODE are now managed from the admin settings panel.
+# They are stored in the database and no longer need to be set as environment variables.
+# SCRAPE_DAYS=7
+# SCRAPE_MODE=weekly
 
 # ============================================================================
 # REDIS CONFIGURATION

--- a/client/src/api/settings.ts
+++ b/client/src/api/settings.ts
@@ -5,6 +5,8 @@ import type { ApiResponse } from '../types';
 // SETTINGS TYPES
 // ============================================================================
 
+export type ScrapeMode = 'weekly' | 'from_today' | 'from_today_limited';
+
 export interface FooterLink {
   label: string;
   url: string;
@@ -34,6 +36,8 @@ export interface AppSettings extends AppSettingsPublic {
   email_from_name: string;
   email_from_address: string;
   email_logo_base64: string | null;
+  scrape_mode: ScrapeMode;
+  scrape_days: number;
   updated_at: string;
   updated_by: string | null;
 }
@@ -58,6 +62,8 @@ export interface AppSettingsUpdate {
   email_from_name?: string;
   email_from_address?: string;
   email_logo_base64?: string | null;
+  scrape_mode?: ScrapeMode;
+  scrape_days?: number;
 }
 
 export interface AppSettingsExport {

--- a/client/src/pages/admin/SettingsPage.test.tsx
+++ b/client/src/pages/admin/SettingsPage.test.tsx
@@ -72,6 +72,8 @@ const mockSettingsContext = {
     email_from_name: 'Test Cinema',
     email_from_address: 'noreply@test.com',
     email_logo_base64: null,
+    scrape_mode: 'weekly' as const,
+    scrape_days: 7,
     updated_at: '2024-01-01T00:00:00.000Z',
     updated_by: 'admin',
   },

--- a/client/src/pages/admin/SettingsPage.tsx
+++ b/client/src/pages/admin/SettingsPage.tsx
@@ -1,14 +1,14 @@
 import React, { useState, useContext } from 'react';
 import { SettingsContext } from '../../contexts/SettingsContext';
 import { AuthContext } from '../../contexts/AuthContext';
-import { downloadSettingsExport, uploadSettingsImport, resetSettings, type AppSettings, type AppSettingsUpdate, type FooterLink } from '../../api/settings';
+import { downloadSettingsExport, uploadSettingsImport, resetSettings, type AppSettings, type AppSettingsUpdate, type FooterLink, type ScrapeMode } from '../../api/settings';
 import ColorPicker from '../../components/admin/ColorPicker';
 import FontSelector from '../../components/admin/FontSelector';
 import ImageUpload from '../../components/admin/ImageUpload';
 import FooterLinksEditor from '../../components/admin/FooterLinksEditor';
 import Button from '../../components/ui/Button';
 
-type Tab = 'general' | 'colors' | 'typography' | 'footer' | 'email';
+type Tab = 'general' | 'colors' | 'typography' | 'footer' | 'email' | 'scraper';
 
 const getInitialFormData = (settings: AppSettings | null): AppSettingsUpdate => {
     if (!settings) return {};
@@ -32,6 +32,8 @@ const getInitialFormData = (settings: AppSettings | null): AppSettingsUpdate => 
         email_from_name: settings.email_from_name,
         email_from_address: settings.email_from_address,
         email_logo_base64: settings.email_logo_base64,
+        scrape_mode: settings.scrape_mode,
+        scrape_days: settings.scrape_days,
     };
 };
 
@@ -167,6 +169,7 @@ const SettingsPage: React.FC = () => {
                                 { id: 'typography', label: 'Typography' },
                                 { id: 'footer', label: 'Footer' },
                                 { id: 'email', label: 'Email' },
+                                { id: 'scraper', label: 'Scraper' },
                             ] as const).map((tab) => (
                                 <button
                                     key={tab.id}
@@ -362,9 +365,48 @@ const SettingsPage: React.FC = () => {
                                 />
                             </div>
                         )}
-                    </div>
 
-                    {/* Footer actions */}
+                        {activeTab === 'scraper' && (
+                            <div className="space-y-6 max-w-2xl">
+                                <div>
+                                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                                        Scrape Mode
+                                    </label>
+                                    <p className="text-xs text-gray-500 mb-2">
+                                        Determines which dates are scraped during each run.
+                                    </p>
+                                    <select
+                                        value={formData.scrape_mode ?? 'weekly'}
+                                        onChange={(e) => handleFieldChange('scrape_mode', e.target.value as ScrapeMode)}
+                                        disabled={!canUpdate}
+                                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                                    >
+                                        <option value="weekly">Weekly — starts from last Wednesday, 7 days</option>
+                                        <option value="from_today">From today — starts today, N days</option>
+                                        <option value="from_today_limited">From today (limited) — starts today, until next Tuesday (max 7 days)</option>
+                                    </select>
+                                </div>
+
+                                <div>
+                                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                                        Scrape Days
+                                    </label>
+                                    <p className="text-xs text-gray-500 mb-2">
+                                        Number of days to scrape (1–14). Used by the <em>weekly</em> and <em>from today</em> modes.
+                                    </p>
+                                    <input
+                                        type="number"
+                                        min={1}
+                                        max={14}
+                                        value={formData.scrape_days ?? 7}
+                                        onChange={(e) => handleFieldChange('scrape_days', parseInt(e.target.value, 10))}
+                                        disabled={!canUpdate}
+                                        className="w-32 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                                    />
+                                </div>
+                            </div>
+                        )}
+                    </div>
                     <div className="border-t border-gray-200 p-6 bg-gray-50 flex items-center justify-between">
                         <div className="flex gap-2">
                             {canExport && (

--- a/client/src/pages/admin/SettingsPage.tsx
+++ b/client/src/pages/admin/SettingsPage.tsx
@@ -1,14 +1,14 @@
 import React, { useState, useContext } from 'react';
 import { SettingsContext } from '../../contexts/SettingsContext';
 import { AuthContext } from '../../contexts/AuthContext';
-import { downloadSettingsExport, uploadSettingsImport, resetSettings, type AppSettings, type AppSettingsUpdate, type FooterLink, type ScrapeMode } from '../../api/settings';
+import { downloadSettingsExport, uploadSettingsImport, resetSettings, type AppSettings, type AppSettingsUpdate, type FooterLink } from '../../api/settings';
 import ColorPicker from '../../components/admin/ColorPicker';
 import FontSelector from '../../components/admin/FontSelector';
 import ImageUpload from '../../components/admin/ImageUpload';
 import FooterLinksEditor from '../../components/admin/FooterLinksEditor';
 import Button from '../../components/ui/Button';
 
-type Tab = 'general' | 'colors' | 'typography' | 'footer' | 'email' | 'scraper';
+type Tab = 'general' | 'colors' | 'typography' | 'footer' | 'email';
 
 const getInitialFormData = (settings: AppSettings | null): AppSettingsUpdate => {
     if (!settings) return {};
@@ -32,8 +32,6 @@ const getInitialFormData = (settings: AppSettings | null): AppSettingsUpdate => 
         email_from_name: settings.email_from_name,
         email_from_address: settings.email_from_address,
         email_logo_base64: settings.email_logo_base64,
-        scrape_mode: settings.scrape_mode,
-        scrape_days: settings.scrape_days,
     };
 };
 
@@ -169,7 +167,6 @@ const SettingsPage: React.FC = () => {
                                 { id: 'typography', label: 'Typography' },
                                 { id: 'footer', label: 'Footer' },
                                 { id: 'email', label: 'Email' },
-                                { id: 'scraper', label: 'Scraper' },
                             ] as const).map((tab) => (
                                 <button
                                     key={tab.id}
@@ -363,47 +360,6 @@ const SettingsPage: React.FC = () => {
                                     disabled={!canUpdate}
                                     maxSizeKB={200}
                                 />
-                            </div>
-                        )}
-
-                        {activeTab === 'scraper' && (
-                            <div className="space-y-6 max-w-2xl">
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 mb-1">
-                                        Scrape Mode
-                                    </label>
-                                    <p className="text-xs text-gray-500 mb-2">
-                                        Determines which dates are scraped during each run.
-                                    </p>
-                                    <select
-                                        value={formData.scrape_mode ?? 'weekly'}
-                                        onChange={(e) => handleFieldChange('scrape_mode', e.target.value as ScrapeMode)}
-                                        disabled={!canUpdate}
-                                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                    >
-                                        <option value="weekly">Weekly — starts from last Wednesday, 7 days</option>
-                                        <option value="from_today">From today — starts today, N days</option>
-                                        <option value="from_today_limited">From today (limited) — starts today, until next Tuesday (max 7 days)</option>
-                                    </select>
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 mb-1">
-                                        Scrape Days
-                                    </label>
-                                    <p className="text-xs text-gray-500 mb-2">
-                                        Number of days to scrape (1–14). Used by the <em>weekly</em> and <em>from today</em> modes.
-                                    </p>
-                                    <input
-                                        type="number"
-                                        min={1}
-                                        max={14}
-                                        value={formData.scrape_days ?? 7}
-                                        onChange={(e) => handleFieldChange('scrape_days', parseInt(e.target.value, 10))}
-                                        disabled={!canUpdate}
-                                        className="w-32 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                    />
-                                </div>
                             </div>
                         )}
                     </div>

--- a/client/src/pages/admin/SystemPage.tsx
+++ b/client/src/pages/admin/SystemPage.tsx
@@ -2,15 +2,19 @@ import React, { useState, useEffect, useContext, useCallback } from 'react';
 import { getSystemInfo, getMigrations, getSystemHealth, formatUptime, formatDate } from '../../api/system';
 import type { SystemInfo, MigrationsInfo, SystemHealth } from '../../api/system';
 import { AuthContext } from '../../contexts/AuthContext';
+import { SettingsContext } from '../../contexts/SettingsContext';
+import type { ScrapeMode } from '../../api/settings';
 import Button from '../../components/ui/Button';
 
 const SystemPage: React.FC = () => {
   const { hasPermission } = useContext(AuthContext);
+  const { adminSettings, updateSettings, refreshAdminSettings } = useContext(SettingsContext);
   
   // Permission checks
   const canViewInfo = hasPermission('system:info');
   const canViewHealth = hasPermission('system:health');
   const canViewMigrations = hasPermission('system:migrations');
+  const canUpdateSettings = hasPermission('settings:update');
 
   const [systemInfo, setSystemInfo] = useState<SystemInfo | null>(null);
   const [migrations, setMigrations] = useState<MigrationsInfo | null>(null);
@@ -18,6 +22,35 @@ const SystemPage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [autoRefresh, setAutoRefresh] = useState(false);
+
+  // Scraper config local state (mirrors adminSettings, allows in-place editing)
+  const [scrapeMode, setScrapeMode] = useState<ScrapeMode>(adminSettings?.scrape_mode ?? 'weekly');
+  const [scrapeDays, setScrapeDays] = useState<number>(adminSettings?.scrape_days ?? 7);
+  const [scraperSaveStatus, setScraperSaveStatus] = useState<'idle' | 'saving' | 'success' | 'error'>('idle');
+
+  // Sync local state when adminSettings loads
+  useEffect(() => {
+    if (adminSettings) {
+      setScrapeMode(adminSettings.scrape_mode);
+      setScrapeDays(adminSettings.scrape_days);
+    }
+  }, [adminSettings]);
+
+  useEffect(() => {
+    refreshAdminSettings();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleScraperSave = async () => {
+    setScraperSaveStatus('saving');
+    try {
+      await updateSettings({ scrape_mode: scrapeMode, scrape_days: scrapeDays });
+      setScraperSaveStatus('success');
+      setTimeout(() => setScraperSaveStatus('idle'), 3000);
+    } catch {
+      setScraperSaveStatus('error');
+    }
+  };
 
   const loadData = useCallback(async () => {
     setIsLoading(true);
@@ -240,6 +273,58 @@ const SystemPage: React.FC = () => {
           </div>
         </div>
       )}
+
+      {/* Scraper Configuration Card */}
+      <div className="bg-white rounded-lg shadow p-6 mb-6" data-testid="scraper-config-card">
+        <h2 className="text-lg font-semibold mb-4">Scraper Configuration</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-2xl">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Scrape Mode</label>
+            <p className="text-xs text-gray-500 mb-2">Which dates are scraped during each run.</p>
+            <select
+              value={scrapeMode}
+              onChange={(e) => setScrapeMode(e.target.value as ScrapeMode)}
+              disabled={!canUpdateSettings}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-50 disabled:text-gray-500"
+            >
+              <option value="weekly">Weekly — from last Wednesday, 7 days</option>
+              <option value="from_today">From today — starts today, N days</option>
+              <option value="from_today_limited">From today (limited) — until next Tuesday (max 7 days)</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Scrape Days</label>
+            <p className="text-xs text-gray-500 mb-2">Number of days to scrape (1–14). Used by <em>weekly</em> and <em>from today</em> modes.</p>
+            <input
+              type="number"
+              min={1}
+              max={14}
+              value={scrapeDays}
+              onChange={(e) => setScrapeDays(parseInt(e.target.value, 10))}
+              disabled={!canUpdateSettings}
+              className="w-24 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-50 disabled:text-gray-500"
+            />
+          </div>
+        </div>
+
+        {canUpdateSettings && (
+          <div className="mt-4 flex items-center gap-3">
+            <Button
+              onClick={handleScraperSave}
+              disabled={scraperSaveStatus === 'saving'}
+            >
+              {scraperSaveStatus === 'saving' ? 'Saving...' : 'Save'}
+            </Button>
+            {scraperSaveStatus === 'success' && (
+              <span className="text-sm text-green-600">✓ Saved</span>
+            )}
+            {scraperSaveStatus === 'error' && (
+              <span className="text-sm text-red-600">Failed to save</span>
+            )}
+          </div>
+        )}
+      </div>
 
       {/* Migrations Table */}
       {canViewMigrations && migrations && (

--- a/client/src/pages/admin/SystemPage.tsx
+++ b/client/src/pages/admin/SystemPage.tsx
@@ -277,15 +277,15 @@ const SystemPage: React.FC = () => {
       {/* Scraper Configuration Card */}
       <div className="bg-white rounded-lg shadow p-6 mb-6" data-testid="scraper-config-card">
         <h2 className="text-lg font-semibold mb-4">Scraper Configuration</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-2xl">
-          <div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-2xl items-end">
+          <div className="flex flex-col">
             <label className="block text-sm font-medium text-gray-700 mb-1">Scrape Mode</label>
             <p className="text-xs text-gray-500 mb-2">Which dates are scraped during each run.</p>
             <select
               value={scrapeMode}
               onChange={(e) => setScrapeMode(e.target.value as ScrapeMode)}
               disabled={!canUpdateSettings}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-50 disabled:text-gray-500"
+              className="mt-auto w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-50 disabled:text-gray-500"
             >
               <option value="weekly">Weekly — from last Wednesday, 7 days</option>
               <option value="from_today">From today — starts today, N days</option>
@@ -293,7 +293,7 @@ const SystemPage: React.FC = () => {
             </select>
           </div>
 
-          <div>
+          <div className="flex flex-col">
             <label className="block text-sm font-medium text-gray-700 mb-1">Scrape Days</label>
             <p className="text-xs text-gray-500 mb-2">Number of days to scrape (1–14). Used by <em>weekly</em> and <em>from today</em> modes.</p>
             <input
@@ -303,7 +303,7 @@ const SystemPage: React.FC = () => {
               value={scrapeDays}
               onChange={(e) => setScrapeDays(parseInt(e.target.value, 10))}
               disabled={!canUpdateSettings}
-              className="w-24 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-50 disabled:text-gray-500"
+              className="mt-auto w-24 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-50 disabled:text-gray-500"
             />
           </div>
         </div>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,8 +61,6 @@ services:
       PORT: 3000
       TZ: ${TZ:-Europe/Paris}
       SCRAPE_DELAY_MS: ${SCRAPE_DELAY_MS:-1000}
-      SCRAPE_MODE: ${SCRAPE_MODE:-weekly}
-      SCRAPE_DAYS: ${SCRAPE_DAYS:-7}
       REDIS_URL: redis://ics-redis:6379
       ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-http://localhost:3000}
       LOG_LEVEL: ${LOG_LEVEL:-info}
@@ -102,8 +100,6 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       REDIS_URL: redis://ics-redis:6379
       RUN_MODE: consumer
-      SCRAPE_MODE: ${SCRAPE_MODE:-from_today_limited}
-      SCRAPE_DAYS: ${SCRAPE_DAYS:-7}
       TZ: ${TZ:-Europe/Paris}
       LOG_LEVEL: ${LOG_LEVEL:-info}
       OTEL_ENABLED: ${OTEL_ENABLED:-false}
@@ -133,8 +129,6 @@ services:
       REDIS_URL: redis://ics-redis:6379
       RUN_MODE: cron
       CRON_SCHEDULE: ${SCRAPE_CRON_SCHEDULE:-0 8 * * 3}
-      SCRAPE_MODE: ${SCRAPE_MODE:-weekly}
-      SCRAPE_DAYS: ${SCRAPE_DAYS:-7}
       TZ: ${TZ:-Europe/Paris}
       LOG_LEVEL: ${LOG_LEVEL:-info}
       OTEL_ENABLED: ${OTEL_ENABLED:-false}

--- a/migrations/023_add_scrape_settings.sql
+++ b/migrations/023_add_scrape_settings.sql
@@ -1,0 +1,13 @@
+-- Add scrape configuration settings to app_settings table
+-- These replace the SCRAPE_MODE and SCRAPE_DAYS environment variables
+ALTER TABLE app_settings
+  ADD COLUMN IF NOT EXISTS scrape_mode TEXT NOT NULL DEFAULT 'weekly',
+  ADD COLUMN IF NOT EXISTS scrape_days INTEGER NOT NULL DEFAULT 7;
+
+-- Add constraint to ensure valid scrape_mode values
+ALTER TABLE app_settings
+  ADD CONSTRAINT valid_scrape_mode CHECK (scrape_mode IN ('weekly', 'from_today', 'from_today_limited'));
+
+-- Add constraint to ensure valid scrape_days range (1-14)
+ALTER TABLE app_settings
+  ADD CONSTRAINT valid_scrape_days CHECK (scrape_days >= 1 AND scrape_days <= 14);

--- a/scraper/src/scraper/index.ts
+++ b/scraper/src/scraper/index.ts
@@ -154,8 +154,25 @@ export async function runScraper(
     
     logger.info('Cinemas loaded', { count: cinemas.length });
 
-    const scrapeMode = options?.mode ?? (process.env.SCRAPE_MODE as ScrapeMode) ?? 'from_today_limited';
-    const scrapeDays = options?.days || parseInt(process.env.SCRAPE_DAYS || '7', 10);
+    // Read scrape config from database settings (fallback to safe defaults)
+    let scrapeMode: ScrapeMode = 'from_today_limited';
+    let scrapeDays = 7;
+    try {
+      const settingsResult = await db.query<{ scrape_mode: string; scrape_days: number }>(
+        'SELECT scrape_mode, scrape_days FROM app_settings WHERE id = 1'
+      );
+      if (settingsResult.rows.length > 0) {
+        scrapeMode = settingsResult.rows[0].scrape_mode as ScrapeMode;
+        scrapeDays = settingsResult.rows[0].scrape_days;
+      }
+    } catch (err) {
+      logger.warn('Could not read scrape settings from DB, using defaults', { err });
+    }
+
+    // Options passed explicitly (e.g. from a job) override DB settings
+    if (options?.mode) scrapeMode = options.mode;
+    if (options?.days) scrapeDays = options.days;
+
     const dates = getScrapeDates(scrapeMode, scrapeDays);
     logger.info('Scrape config', { mode: scrapeMode, dates: dates.length, scrapeDays });
     logger.info('Delay config', { theaterDelayMs, movieDelayMs });

--- a/server/src/db/settings-queries.ts
+++ b/server/src/db/settings-queries.ts
@@ -5,6 +5,7 @@ import type {
   AppSettingsUpdate,
   AppSettingsExport,
   FooterLink,
+  ScrapeMode,
 } from '../types/settings.js';
 import { logger } from '../utils/logger.js';
 
@@ -29,6 +30,8 @@ export interface AppSettingsRow {
   footer_links: string | FooterLink[]; // JSON string or JSONB object
   email_from_name: string;
   email_from_address: string;
+  scrape_mode: string;
+  scrape_days: number;
   updated_at: string;
   updated_by: number | null;
 }
@@ -41,6 +44,7 @@ function rowToSettings(row: AppSettingsRow): AppSettings {
     footer_links: typeof row.footer_links === 'string' 
       ? JSON.parse(row.footer_links) as FooterLink[]
       : row.footer_links,
+    scrape_mode: row.scrape_mode as ScrapeMode,
   };
 }
 
@@ -120,6 +124,8 @@ export async function updateSettings(
     footer_links: 'footer_links',
     email_from_name: 'email_from_name',
     email_from_address: 'email_from_address',
+    scrape_mode: 'scrape_mode',
+    scrape_days: 'scrape_days',
   };
 
   for (const [key, dbColumn] of Object.entries(fieldMap)) {
@@ -190,6 +196,8 @@ export async function resetSettings(db: DB, userId: number): Promise<AppSettings
       footer_links = '[]'::jsonb,
       email_from_name = 'Allo-Scrapper',
       email_from_address = 'no-reply@allocine-scrapper.com',
+      scrape_mode = 'weekly',
+      scrape_days = 7,
       updated_at = NOW(),
       updated_by = $1
     WHERE id = 1

--- a/server/src/db/system-queries.test.ts
+++ b/server/src/db/system-queries.test.ts
@@ -104,6 +104,7 @@ describe('System Queries', () => {
             { version: '020_add_film_screenwriters.sql' },
             { version: '021_add_film_trailer_url.sql' },
             { version: '022_fix_showtime_deduplication.sql' },
+            { version: '023_add_scrape_settings.sql' },
           ],
         }),
       } as unknown as DB;

--- a/server/src/routes/settings.test.ts
+++ b/server/src/routes/settings.test.ts
@@ -270,6 +270,76 @@ describe('Settings Routes', () => {
       expect(settingsQueries.updateSettings).toHaveBeenCalledWith(expect.anything(), updates, 1);
     });
 
+    it('should accept valid scrape_mode values', async () => {
+      const validModes = ['weekly', 'from_today', 'from_today_limited'];
+
+      for (const mode of validModes) {
+        vi.mocked(settingsQueries.updateSettings).mockResolvedValue({} as any);
+
+        const response = await request(app)
+          .put('/api/settings')
+          .set('Authorization', 'Bearer valid-token')
+          .send({ scrape_mode: mode });
+
+        expect(response.status).toBe(200);
+      }
+    });
+
+    it('should reject invalid scrape_mode value', async () => {
+      const response = await request(app)
+        .put('/api/settings')
+        .set('Authorization', 'Bearer valid-token')
+        .send({ scrape_mode: 'invalid_mode' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toContain('scrape_mode');
+    });
+
+    it('should accept valid scrape_days values (1-14)', async () => {
+      vi.mocked(settingsQueries.updateSettings).mockResolvedValue({} as any);
+
+      const response = await request(app)
+        .put('/api/settings')
+        .set('Authorization', 'Bearer valid-token')
+        .send({ scrape_days: 7 });
+
+      expect(response.status).toBe(200);
+    });
+
+    it('should reject scrape_days below 1', async () => {
+      const response = await request(app)
+        .put('/api/settings')
+        .set('Authorization', 'Bearer valid-token')
+        .send({ scrape_days: 0 });
+
+      expect(response.status).toBe(400);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toContain('scrape_days');
+    });
+
+    it('should reject scrape_days above 14', async () => {
+      const response = await request(app)
+        .put('/api/settings')
+        .set('Authorization', 'Bearer valid-token')
+        .send({ scrape_days: 15 });
+
+      expect(response.status).toBe(400);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toContain('scrape_days');
+    });
+
+    it('should reject non-integer scrape_days', async () => {
+      const response = await request(app)
+        .put('/api/settings')
+        .set('Authorization', 'Bearer valid-token')
+        .send({ scrape_days: 3.5 });
+
+      expect(response.status).toBe(400);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toContain('scrape_days');
+    });
+
     it('should return 401 without authentication', async () => {
       const response = await request(app)
         .put('/api/settings')

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -10,7 +10,7 @@ import {
 } from '../db/settings-queries.js';
 import { validateImage } from '../utils/image-validator.js';
 import type { ApiResponse } from '../types/api.js';
-import type { AppSettingsUpdate, AppSettingsExport } from '../types/settings.js';
+import type { AppSettingsUpdate, AppSettingsExport, ScrapeMode } from '../types/settings.js';
 import { logger } from '../utils/logger.js';
 import { requireAuth, type AuthRequest } from '../middleware/auth.js';
 import { requirePermission } from '../middleware/permission.js';
@@ -22,6 +22,10 @@ const router = express.Router();
 // Size limits for images (in bytes)
 const LOGO_MAX_SIZE = 200000; // 200 KB
 const FAVICON_MAX_SIZE = 50000; // 50 KB
+
+const VALID_SCRAPE_MODES: ScrapeMode[] = ['weekly', 'from_today', 'from_today_limited'];
+const SCRAPE_DAYS_MIN = 1;
+const SCRAPE_DAYS_MAX = 14;
 
 // Input length limits for text fields (security: prevent DoS via large payloads)
 const INPUT_LIMITS = {
@@ -138,6 +142,21 @@ router.put('/', protectedLimiter, requireAuth, requirePermission('settings:updat
             return next(new ValidationError(`Invalid URL format in footer link: ${link.url}`));
           }
         }
+      }
+    }
+
+    // Validate scrape_mode if provided
+    if (updates.scrape_mode !== undefined) {
+      if (!VALID_SCRAPE_MODES.includes(updates.scrape_mode)) {
+        return next(new ValidationError(`Invalid scrape_mode: must be one of ${VALID_SCRAPE_MODES.join(', ')}`));
+      }
+    }
+
+    // Validate scrape_days if provided
+    if (updates.scrape_days !== undefined) {
+      const days = updates.scrape_days;
+      if (!Number.isInteger(days) || days < SCRAPE_DAYS_MIN || days > SCRAPE_DAYS_MAX) {
+        return next(new ValidationError(`Invalid scrape_days: must be an integer between ${SCRAPE_DAYS_MIN} and ${SCRAPE_DAYS_MAX}`));
       }
     }
 

--- a/server/src/types/settings.ts
+++ b/server/src/types/settings.ts
@@ -1,5 +1,7 @@
 // White-label settings types
 
+export type ScrapeMode = 'weekly' | 'from_today' | 'from_today_limited';
+
 export interface FooterLink {
   label: string;
   url: string;
@@ -25,6 +27,8 @@ export interface AppSettings {
   footer_links: FooterLink[];
   email_from_name: string;
   email_from_address: string;
+  scrape_mode: ScrapeMode;
+  scrape_days: number;
   updated_at: string;
   updated_by: number | null;
 }
@@ -69,6 +73,8 @@ export interface AppSettingsUpdate {
   footer_links?: FooterLink[];
   email_from_name?: string;
   email_from_address?: string;
+  scrape_mode?: ScrapeMode;
+  scrape_days?: number;
 }
 
 // Export format for backup


### PR DESCRIPTION
## Summary

Déplace la configuration de scraping (`SCRAPE_MODE` et `SCRAPE_DAYS`) des variables d'environnement vers la table `app_settings`, accessible depuis le panneau admin.

## Changes

- **Migration `023`**: ajoute `scrape_mode` (TEXT, default `'weekly'`) et `scrape_days` (INTEGER, default `7`) à `app_settings` avec des contraintes DB
- **Server types**: `ScrapeMode` type union + nouveaux champs dans `AppSettings` et `AppSettingsUpdate` (pas dans `AppSettingsPublic`)
- **Settings queries**: nouvelles colonnes dans SELECT, UPDATE et reset
- **Settings routes**: validation `scrape_mode` (enum) et `scrape_days` (entier 1–14) sur `PUT /api/settings`
- **Scraper**: lit `scrape_mode`/`scrape_days` depuis `app_settings` au lieu de `process.env`; les options passées explicitement (ex. jobs Redis) priment sur la DB
- **Client**: type `ScrapeMode`, champs dans `AppSettingsUpdate`, nouvel onglet **Scraper** dans `SettingsPage` avec `<select>` dropdown et `<input type=number>`
- **docker-compose**: suppression de `SCRAPE_MODE` et `SCRAPE_DAYS` des services web, scraper-consumer et scraper-cron
- **.env.example**: variables marquées comme dépréciées

Closes #721