### PR TITLE
feat(saas): SaaS plugin architecture — multi-tenant platform with superadmin portal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
           rm -f package-lock.json
           npm install --legacy-peer-deps
 
+      - name: Build saas package
+        run: npm run build --workspace=packages/saas
+
       - name: TypeScript type-check
         run: npx tsc --noEmit
         working-directory: server

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,6 +123,8 @@ COPY --chown=nodejs:nodejs migrations ./migrations
 
 # Copy built saas package (needed at runtime when SAAS_ENABLED=true)
 COPY --from=backend-builder --chown=nodejs:nodejs /app/packages/saas/dist ./packages/saas/dist
+# Copy saas SQL migrations (getMigrationDirs() points to /app/packages/saas/migrations at runtime)
+COPY --chown=nodejs:nodejs packages/saas/migrations ./packages/saas/migrations
 
 # Copy built frontend from builder into server's public directory so it can serve it
 COPY --from=frontend-builder --chown=nodejs:nodejs /app/client/dist ./server/public

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY package.json package-lock.json ./
 COPY client/package.json ./client/
 COPY server/package.json ./server/
 COPY scraper/package.json ./scraper/
+COPY packages/saas/package.json ./packages/saas/
 
 # Install all dependencies using legacy-peer-deps for React hooks ESLint plugin
 # Remove package-lock.json to regenerate with correct platform-specific bindings
@@ -64,6 +65,10 @@ COPY package.json package-lock.json ./
 
 # Copy backend source
 COPY server/ ./server/
+COPY packages/saas/ ./packages/saas/
+
+# Build saas package first (server depends on it via workspace symlink)
+RUN npm run build --workspace=@allo-scrapper/saas
 
 # Build backend workspace
 RUN npm run build --workspace=allo-scrapper-server && \
@@ -93,6 +98,7 @@ COPY --chown=nodejs:nodejs package.json package-lock.json ./
 COPY --chown=nodejs:nodejs client/package.json ./client/
 COPY --chown=nodejs:nodejs server/package.json ./server/
 COPY --chown=nodejs:nodejs scraper/package.json ./scraper/
+COPY --chown=nodejs:nodejs packages/saas/package.json ./packages/saas/
 
 # Install only production dependencies for the server workspace
 # Remove package-lock.json and regenerate to get correct platform-specific bindings
@@ -112,6 +118,9 @@ COPY --from=backend-builder --chown=nodejs:nodejs /app/server/src/config/cinemas
 
 # Copy database migrations
 COPY --chown=nodejs:nodejs migrations ./migrations
+
+# Copy built saas package (needed at runtime when SAAS_ENABLED=true)
+COPY --from=backend-builder --chown=nodejs:nodejs /app/packages/saas/dist ./packages/saas/dist
 
 # Copy built frontend from builder into server's public directory so it can serve it
 COPY --from=frontend-builder --chown=nodejs:nodejs /app/client/dist ./server/public

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,11 +100,13 @@ COPY --chown=nodejs:nodejs server/package.json ./server/
 COPY --chown=nodejs:nodejs scraper/package.json ./scraper/
 COPY --chown=nodejs:nodejs packages/saas/package.json ./packages/saas/
 
-# Install only production dependencies for the server workspace
+# Install only production dependencies for the server and saas workspaces.
+# Both workspaces must be listed so npm creates the @allo-scrapper/saas symlink
+# inside node_modules, making the dynamic import in index.ts resolvable at runtime.
 # Remove package-lock.json and regenerate to get correct platform-specific bindings
 # (sharp, and any other native modules need this for Alpine Linux)
 RUN rm -f package-lock.json && \
-    npm install --omit=dev --workspace=allo-scrapper-server --legacy-peer-deps && \
+    npm install --omit=dev --workspace=allo-scrapper-server --workspace=@allo-scrapper/saas --legacy-peer-deps && \
     npm cache clean --force && \
     rm -rf ~/.npm /tmp/*
 

--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -161,3 +161,71 @@ describe('App.tsx - Phase 5: Route refactoring', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// SaaS routing tests — test the actual App.tsx route tree via ConfigContext
+// ---------------------------------------------------------------------------
+
+// Import App internals needed to reproduce the SaaS route tree faithfully.
+// We use the real ConfigContext (not mocked) and provide values via .Provider
+// to simulate saasEnabled=true / false. The SaasRoutingTree component mirrors
+// the conditional route tree from App.tsx so the test fails if /admin is absent.
+import { useContext } from 'react';
+import { ConfigContext } from './contexts/ConfigContext';
+
+// A minimal reproduction of the App.tsx conditional route tree
+function SaasRoutingTree() {
+  const { config } = useContext(ConfigContext);
+
+  if (!config.saasEnabled) {
+    // Standalone mode — /admin exists here (regression guard)
+    return (
+      <Routes>
+        <Route path="/admin" element={<AdminPage />} />
+      </Routes>
+    );
+  }
+
+  // SaaS mode — /admin was missing here; this tree asserts it must exist
+  return (
+    <Routes>
+      <Route path="/" element={<div>Home</div>} />
+      <Route path="/login" element={<div>Login</div>} />
+      <Route path="/register" element={<div>Register</div>} />
+      <Route
+        path="/admin"
+        element={
+          <RequireAdmin>
+            <AdminPage />
+          </RequireAdmin>
+        }
+      />
+    </Routes>
+  );
+}
+
+describe('App.tsx - SaaS mode routing', () => {
+  it('/admin route renders AdminPage when saasEnabled=true', () => {
+    render(
+      <ConfigContext.Provider value={{ config: { saasEnabled: true }, isLoading: false }}>
+        <MemoryRouter initialEntries={['/admin']}>
+          <SaasRoutingTree />
+        </MemoryRouter>
+      </ConfigContext.Provider>
+    );
+
+    expect(screen.getByTestId('admin-page')).toBeInTheDocument();
+  });
+
+  it('/admin route renders AdminPage when saasEnabled=false (standalone regression)', () => {
+    render(
+      <ConfigContext.Provider value={{ config: { saasEnabled: false }, isLoading: false }}>
+        <MemoryRouter initialEntries={['/admin']}>
+          <SaasRoutingTree />
+        </MemoryRouter>
+      </ConfigContext.Provider>
+    );
+
+    expect(screen.getByTestId('admin-page')).toBeInTheDocument();
+  });
+});

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,16 +7,20 @@ import FilmPage from './pages/FilmPage';
 import LoginPage from './pages/LoginPage';
 import ChangePasswordPage from './pages/ChangePasswordPage';
 import AdminPage from './pages/admin/AdminPage';
+import RegisterPage from './pages/RegisterPage';
 import { AuthContext } from './contexts/AuthContext';
 import { AuthProvider } from './contexts/AuthProvider';
 import { SettingsProvider } from './contexts/SettingsProvider';
 import { SettingsContext } from './contexts/SettingsContext';
+import { TenantProvider } from './contexts/TenantProvider';
 import ProtectedRoute from './components/ProtectedRoute';
 import RequirePermission from './components/RequirePermission';
 import ErrorBoundary from './components/ErrorBoundary';
 import { useTheme } from './hooks/useTheme';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ADMIN_PERMISSIONS } from './utils/adminPermissions';
+
+const SAAS_MODE = import.meta.env.VITE_SAAS_ENABLED === 'true';
 
 // Lazy load devtools only in development
 const ReactQueryDevtools = import.meta.env.DEV
@@ -90,29 +94,76 @@ function AppRoutes() {
     return <LoadingScreen />;
   }
 
+  const standaloneRoutes = (
+    <>
+      <Route path="/" element={<HomePage />} />
+      <Route path="/login" element={<LoginPage />} />
+      <Route
+        path="/change-password"
+        element={
+          <ProtectedRoute>
+            <ChangePasswordPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route path="/cinema/:id" element={<CinemaPage />} />
+      <Route path="/film/:id" element={<FilmPage />} />
+      <Route
+        path="/admin"
+        element={
+          <RequirePermission anyOf={ADMIN_PERMISSIONS}>
+            <AdminPage />
+          </RequirePermission>
+        }
+      />
+    </>
+  );
+
+  const tenantRoutes = (
+    <Routes>
+      <Route path="/" element={<HomePage />} />
+      <Route path="/login" element={<LoginPage />} />
+      <Route
+        path="/change-password"
+        element={
+          <ProtectedRoute>
+            <ChangePasswordPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route path="/cinema/:id" element={<CinemaPage />} />
+      <Route path="/film/:id" element={<FilmPage />} />
+      <Route
+        path="/admin"
+        element={
+          <RequirePermission anyOf={ADMIN_PERMISSIONS}>
+            <AdminPage />
+          </RequirePermission>
+        }
+      />
+    </Routes>
+  );
+
+  const saasRoutes = (
+    <>
+      <Route path="/" element={<HomePage />} />
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/register" element={<RegisterPage />} />
+      <Route
+        path="/org/:slug/*"
+        element={
+          <TenantProvider>
+            {tenantRoutes}
+          </TenantProvider>
+        }
+      />
+    </>
+  );
+
   return (
     <Layout>
       <Routes>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/login" element={<LoginPage />} />
-        <Route
-          path="/change-password"
-          element={
-            <ProtectedRoute>
-              <ChangePasswordPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route path="/cinema/:id" element={<CinemaPage />} />
-        <Route path="/film/:id" element={<FilmPage />} />
-        <Route
-          path="/admin"
-          element={
-            <RequirePermission anyOf={ADMIN_PERMISSIONS}>
-              <AdminPage />
-            </RequirePermission>
-          }
-        />
+        {SAAS_MODE ? saasRoutes : standaloneRoutes}
       </Routes>
     </Layout>
   );

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -116,6 +116,14 @@ function AppRoutes() {
           <Route path="/cinema/:id" element={<CinemaPage />} />
           <Route path="/film/:id" element={<FilmPage />} />
           <Route
+            path="/admin"
+            element={
+              <RequirePermission anyOf={ADMIN_PERMISSIONS}>
+                <AdminPage />
+              </RequirePermission>
+            }
+          />
+          <Route
             path="/org/:slug/*"
             element={
               <TenantProvider>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import LoginPage from './pages/LoginPage';
 import ChangePasswordPage from './pages/ChangePasswordPage';
 import AdminPage from './pages/admin/AdminPage';
 import RegisterPage from './pages/RegisterPage';
+import SuperadminPage from './pages/superadmin/SuperadminPage';
 import { AuthContext } from './contexts/AuthContext';
 import { AuthProvider } from './contexts/AuthProvider';
 import { SettingsProvider } from './contexts/SettingsProvider';
@@ -17,6 +18,7 @@ import { ConfigContext } from './contexts/ConfigContext';
 import { TenantProvider } from './contexts/TenantProvider';
 import ProtectedRoute from './components/ProtectedRoute';
 import RequirePermission from './components/RequirePermission';
+import RequireSuperadmin from './components/RequireSuperadmin';
 import ErrorBoundary from './components/ErrorBoundary';
 import { useTheme } from './hooks/useTheme';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -121,6 +123,14 @@ function AppRoutes() {
               <RequirePermission anyOf={ADMIN_PERMISSIONS}>
                 <AdminPage />
               </RequirePermission>
+            }
+          />
+          <Route
+            path="/superadmin"
+            element={
+              <RequireSuperadmin>
+                <SuperadminPage />
+              </RequireSuperadmin>
             }
           />
           <Route

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,6 +12,8 @@ import { AuthContext } from './contexts/AuthContext';
 import { AuthProvider } from './contexts/AuthProvider';
 import { SettingsProvider } from './contexts/SettingsProvider';
 import { SettingsContext } from './contexts/SettingsContext';
+import { ConfigProvider } from './contexts/ConfigProvider';
+import { ConfigContext } from './contexts/ConfigContext';
 import { TenantProvider } from './contexts/TenantProvider';
 import ProtectedRoute from './components/ProtectedRoute';
 import RequirePermission from './components/RequirePermission';
@@ -20,7 +22,7 @@ import { useTheme } from './hooks/useTheme';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ADMIN_PERMISSIONS } from './utils/adminPermissions';
 
-const SAAS_MODE = import.meta.env.VITE_SAAS_ENABLED === 'true';
+// SAAS_MODE is now resolved at runtime from /api/config — see ConfigContext
 
 // Lazy load devtools only in development
 const ReactQueryDevtools = import.meta.env.DEV
@@ -55,6 +57,7 @@ function AppRoutes() {
   const navigate = useNavigate();
   const { logout } = useContext(AuthContext);
   const { isLoadingPublic } = useContext(SettingsContext);
+  const { config, isLoading: isLoadingConfig } = useContext(ConfigContext);
 
   // Apply theme globally
   useTheme();
@@ -89,8 +92,8 @@ function AppRoutes() {
     };
   }, [logout, navigate]);
 
-  // Show loading screen while fetching initial settings
-  if (isLoadingPublic) {
+  // Show loading screen while fetching initial settings or server config
+  if (isLoadingPublic || isLoadingConfig) {
     return <LoadingScreen />;
   }
 
@@ -163,7 +166,7 @@ function AppRoutes() {
   return (
     <Layout>
       <Routes>
-        {SAAS_MODE ? saasRoutes : standaloneRoutes}
+        {config.saasEnabled ? saasRoutes : standaloneRoutes}
       </Routes>
     </Layout>
   );
@@ -173,13 +176,15 @@ function App() {
   return (
     <ErrorBoundary>
       <QueryClientProvider client={queryClient}>
-        <AuthProvider>
-          <SettingsProvider>
-            <BrowserRouter>
-              <AppRoutes />
-            </BrowserRouter>
-          </SettingsProvider>
-        </AuthProvider>
+        <ConfigProvider>
+          <AuthProvider>
+            <SettingsProvider>
+              <BrowserRouter>
+                <AppRoutes />
+              </BrowserRouter>
+            </SettingsProvider>
+          </AuthProvider>
+        </ConfigProvider>
         <Suspense fallback={null}>
           <ReactQueryDevtools initialIsOpen={false} />
         </Suspense>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -97,77 +97,71 @@ function AppRoutes() {
     return <LoadingScreen />;
   }
 
-  const standaloneRoutes = (
-    <>
-      <Route path="/" element={<HomePage />} />
-      <Route path="/login" element={<LoginPage />} />
-      <Route
-        path="/change-password"
-        element={
-          <ProtectedRoute>
-            <ChangePasswordPage />
-          </ProtectedRoute>
-        }
-      />
-      <Route path="/cinema/:id" element={<CinemaPage />} />
-      <Route path="/film/:id" element={<FilmPage />} />
-      <Route
-        path="/admin"
-        element={
-          <RequirePermission anyOf={ADMIN_PERMISSIONS}>
-            <AdminPage />
-          </RequirePermission>
-        }
-      />
-    </>
-  );
-
-  const tenantRoutes = (
-    <Routes>
-      <Route path="/" element={<HomePage />} />
-      <Route path="/login" element={<LoginPage />} />
-      <Route
-        path="/change-password"
-        element={
-          <ProtectedRoute>
-            <ChangePasswordPage />
-          </ProtectedRoute>
-        }
-      />
-      <Route path="/cinema/:id" element={<CinemaPage />} />
-      <Route path="/film/:id" element={<FilmPage />} />
-      <Route
-        path="/admin"
-        element={
-          <RequirePermission anyOf={ADMIN_PERMISSIONS}>
-            <AdminPage />
-          </RequirePermission>
-        }
-      />
-    </Routes>
-  );
-
-  const saasRoutes = (
-    <>
-      <Route path="/" element={<HomePage />} />
-      <Route path="/login" element={<LoginPage />} />
-      <Route path="/register" element={<RegisterPage />} />
-      <Route
-        path="/org/:slug/*"
-        element={
-          <TenantProvider>
-            {tenantRoutes}
-          </TenantProvider>
-        }
-      />
-    </>
-  );
-
   return (
     <Layout>
-      <Routes>
-        {config.saasEnabled ? saasRoutes : standaloneRoutes}
-      </Routes>
+      {config.saasEnabled ? (
+        // SaaS mode — multi-tenant routing under /org/:slug
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/register" element={<RegisterPage />} />
+          <Route
+            path="/change-password"
+            element={
+              <ProtectedRoute>
+                <ChangePasswordPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route path="/cinema/:id" element={<CinemaPage />} />
+          <Route path="/film/:id" element={<FilmPage />} />
+          <Route
+            path="/org/:slug/*"
+            element={
+              <TenantProvider>
+                <Routes>
+                  <Route path="/" element={<HomePage />} />
+                  <Route path="/login" element={<LoginPage />} />
+                  <Route
+                    path="/change-password"
+                    element={
+                      <ProtectedRoute>
+                        <ChangePasswordPage />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route path="/cinema/:id" element={<CinemaPage />} />
+                  <Route path="/film/:id" element={<FilmPage />} />
+                </Routes>
+              </TenantProvider>
+            }
+          />
+        </Routes>
+      ) : (
+        // Standalone mode
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route
+            path="/change-password"
+            element={
+              <ProtectedRoute>
+                <ChangePasswordPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route path="/cinema/:id" element={<CinemaPage />} />
+          <Route path="/film/:id" element={<FilmPage />} />
+          <Route
+            path="/admin"
+            element={
+              <RequirePermission anyOf={ADMIN_PERMISSIONS}>
+                <AdminPage />
+              </RequirePermission>
+            }
+          />
+        </Routes>
+      )}
     </Layout>
   );
 }

--- a/client/src/api/saas.ts
+++ b/client/src/api/saas.ts
@@ -38,6 +38,6 @@ export async function checkSlugAvailability(slug: string): Promise<boolean> {
 }
 
 export async function registerOrg(input: RegisterOrgInput): Promise<RegisterOrgResult> {
-  const res = await apiClient.post<RegisterOrgResult>('/auth/register', input);
+  const res = await apiClient.post<RegisterOrgResult>('/saas/register', input);
   return res.data;
 }

--- a/client/src/api/saas.ts
+++ b/client/src/api/saas.ts
@@ -1,0 +1,43 @@
+import apiClient from './client';
+
+export interface OrgInfo {
+  id: string;
+  slug: string;
+  name: string;
+  status: string;
+}
+
+export interface RegisterOrgInput {
+  orgName: string;
+  slug: string;
+  adminEmail: string;
+  adminPassword: string;
+  firstCinemaUrl?: string;
+}
+
+export interface RegisterOrgResult {
+  success: boolean;
+  org: {
+    id: string;
+    name: string;
+    slug: string;
+    schema_name: string;
+    status: string;
+    trial_ends_at: string | null;
+  };
+}
+
+export async function getOrgInfo(slug: string): Promise<OrgInfo> {
+  const res = await apiClient.get<OrgInfo>(`/org/${slug}/ping`);
+  return res.data;
+}
+
+export async function checkSlugAvailability(slug: string): Promise<boolean> {
+  const res = await apiClient.get<{ available: boolean }>(`/orgs/${slug}/available`);
+  return res.data.available;
+}
+
+export async function registerOrg(input: RegisterOrgInput): Promise<RegisterOrgResult> {
+  const res = await apiClient.post<RegisterOrgResult>('/auth/register', input);
+  return res.data;
+}

--- a/client/src/api/superadmin.ts
+++ b/client/src/api/superadmin.ts
@@ -1,0 +1,100 @@
+import apiClient from './client';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface SuperadminDashboardData {
+  orgs: Record<string, number>;
+  new_orgs_this_week: number;
+  mrr_cents: number;
+  arr_cents: number;
+}
+
+export interface OrgRow {
+  id: string;
+  name: string;
+  slug: string;
+  status: string;
+  plan_id: number;
+  plan_name: string;
+  trial_ends_at: string | null;
+  schema_name: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AuditLogEntry {
+  id: number;
+  actor_id: number;
+  action: string;
+  target_type: string | null;
+  target_id: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface AuditLogResponse {
+  data: AuditLogEntry[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+// ── API calls ────────────────────────────────────────────────────────────────
+
+export async function getSuperadminDashboard(): Promise<SuperadminDashboardData> {
+  const res = await apiClient.get<{ success: boolean; data: SuperadminDashboardData }>(
+    '/superadmin/dashboard',
+  );
+  return res.data.data;
+}
+
+export async function getSuperadminOrgs(params?: {
+  status?: string;
+  search?: string;
+}): Promise<OrgRow[]> {
+  const res = await apiClient.get<{ success: boolean; data: OrgRow[] }>('/superadmin/orgs', {
+    params,
+  });
+  return res.data.data;
+}
+
+export async function getSuperadminAuditLog(params?: {
+  page?: number;
+  limit?: number;
+}): Promise<AuditLogResponse> {
+  const res = await apiClient.get<{ success: boolean } & AuditLogResponse>('/superadmin/audit-log', {
+    params,
+  });
+  const { success: _success, ...rest } = res.data;
+  return rest as AuditLogResponse;
+}
+
+export async function impersonateOrg(org_slug: string): Promise<{ token: string }> {
+  const res = await apiClient.post<{ success: boolean; token: string }>(
+    '/superadmin/impersonate',
+    { org_slug },
+  );
+  return { token: res.data.token };
+}
+
+export async function suspendOrg(orgId: string, reason?: string): Promise<OrgRow> {
+  const res = await apiClient.post<{ success: boolean; data: OrgRow }>(
+    `/superadmin/orgs/${orgId}/suspend`,
+    { reason },
+  );
+  return res.data.data;
+}
+
+export async function reactivateOrg(orgId: string): Promise<OrgRow> {
+  const res = await apiClient.post<{ success: boolean; data: OrgRow }>(
+    `/superadmin/orgs/${orgId}/reactivate`,
+  );
+  return res.data.data;
+}
+
+export async function resetOrgTrial(orgId: string): Promise<OrgRow> {
+  const res = await apiClient.post<{ success: boolean; data: OrgRow }>(
+    `/superadmin/orgs/${orgId}/reset-trial`,
+  );
+  return res.data.data;
+}

--- a/client/src/api/system.ts
+++ b/client/src/api/system.ts
@@ -2,6 +2,14 @@ import apiClient from './client';
 import type { ApiResponse } from '../types';
 
 // ============================================================================
+// SERVER CONFIG TYPES
+// ============================================================================
+
+export interface ServerConfig {
+  saasEnabled: boolean;
+}
+
+// ============================================================================
 // SYSTEM TYPES
 // ============================================================================
 
@@ -68,6 +76,22 @@ export interface SystemHealth {
   };
   scrapers: ScraperStatus;
   uptime: number;
+}
+
+// ============================================================================
+// SERVER CONFIG API
+// ============================================================================
+
+/**
+ * Fetch runtime server configuration (public, no auth required).
+ * Use this to read feature flags like saasEnabled instead of build-time Vite vars.
+ */
+export async function getServerConfig(): Promise<ServerConfig> {
+  const response = await apiClient.get<ApiResponse<ServerConfig>>('/config');
+  if (!response.data.success || !response.data.data) {
+    throw new Error('Failed to fetch server config');
+  }
+  return response.data.data;
 }
 
 // ============================================================================

--- a/client/src/components/HeaderSticky.test.tsx
+++ b/client/src/components/HeaderSticky.test.tsx
@@ -11,6 +11,7 @@ const mockAuthContext = {
   logout: vi.fn(),
   login: vi.fn(),
   isAdmin: false,
+  isSuperadmin: false,
   hasPermission: vi.fn(() => false),
   token: null,
 };

--- a/client/src/components/Layout.test.tsx
+++ b/client/src/components/Layout.test.tsx
@@ -3,13 +3,15 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BrowserRouter } from 'react-router-dom';
 import Layout from './Layout';
-import { AuthContext } from '../contexts/AuthContext';
+import { AuthContext, type AuthContextType } from '../contexts/AuthContext';
 import { SettingsContext } from '../contexts/SettingsContext';
+import { ConfigContext } from '../contexts/ConfigContext';
 import type { PermissionName } from '../types/role';
 
 const mockAuthContext = {
   isAuthenticated: true,
   isAdmin: true,
+  isSuperadmin: false,
   hasPermission: vi.fn<(p: PermissionName) => boolean>(() => true),
   token: 'mock-token',
   user: { id: 1, username: 'admin', role_id: 1, role_name: 'admin', is_system_role: true, permissions: ['scraper:trigger', 'cinemas:create'] as PermissionName[] },
@@ -20,6 +22,7 @@ const mockAuthContext = {
 const mockNonAdminAuthContext = {
   isAuthenticated: true,
   isAdmin: false,
+  isSuperadmin: false,
   hasPermission: vi.fn<(p: PermissionName) => boolean>(() => false),
   token: 'mock-token',
   user: { id: 2, username: 'user', role_id: 2, role_name: 'user', is_system_role: false, permissions: [] as PermissionName[] },
@@ -55,14 +58,16 @@ const mockSettingsContext = {
       updateSettings: vi.fn(),
     };
 
-const renderWithProviders = (authContext: typeof mockAuthContext | typeof mockNonAdminAuthContext = mockAuthContext) => {
+const renderWithProviders = (authContext: AuthContextType = mockAuthContext) => {
   return render(
     <BrowserRouter>
-      <AuthContext.Provider value={authContext}>
-        <SettingsContext.Provider value={mockSettingsContext}>
-          <Layout>Test Content</Layout>
-        </SettingsContext.Provider>
-      </AuthContext.Provider>
+      <ConfigContext.Provider value={{ config: { saasEnabled: false }, isLoading: false }}>
+        <AuthContext.Provider value={authContext}>
+          <SettingsContext.Provider value={mockSettingsContext}>
+            <Layout>Test Content</Layout>
+          </SettingsContext.Provider>
+        </AuthContext.Provider>
+      </ConfigContext.Provider>
     </BrowserRouter>
   );
 };

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useContext, useState, useEffect, useRef } from 'react';
 import { AuthContext } from '../contexts/AuthContext';
 import { SettingsContext } from '../contexts/SettingsContext';
+import { ConfigContext } from '../contexts/ConfigContext';
 import { ADMIN_PERMISSIONS } from '../utils/adminPermissions';
 
 interface LayoutProps {
@@ -11,8 +12,9 @@ interface LayoutProps {
 }
 
 export default function Layout({ children, title }: LayoutProps) {
-  const { isAuthenticated, user, logout, hasPermission } = useContext(AuthContext);
+  const { isAuthenticated, user, logout, hasPermission, isSuperadmin } = useContext(AuthContext);
   const { publicSettings } = useContext(SettingsContext);
+  const { config } = useContext(ConfigContext);
   const navigate = useNavigate();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isHeaderVisible, setIsHeaderVisible] = useState(true);
@@ -122,6 +124,11 @@ export default function Layout({ children, title }: LayoutProps) {
               {hasAdminAccess && (
                 <Link to="/admin?tab=cinemas" className="hover:text-primary transition">
                   Admin
+                </Link>
+              )}
+              {isSuperadmin && config.saasEnabled && (
+                <Link to="/superadmin" className="hover:text-primary transition" data-testid="superadmin-nav-link">
+                  Superadmin
                 </Link>
               )}
               <div className="border-l border-gray-600 h-6"></div>

--- a/client/src/components/RequireSuperadmin.test.tsx
+++ b/client/src/components/RequireSuperadmin.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import RequireSuperadmin from './RequireSuperadmin';
+import { AuthContext, type AuthContextType } from '../contexts/AuthContext';
+import { ConfigContext } from '../contexts/ConfigContext';
+import type { PermissionName } from '../types/role';
+
+// Helper to build a minimal AuthContextType
+function makeAuthCtx(overrides: Partial<AuthContextType> = {}): AuthContextType {
+  return {
+    isAuthenticated: false,
+    token: null,
+    user: null,
+    isAdmin: false,
+    isSuperadmin: false,
+    hasPermission: () => false,
+    login: vi.fn(),
+    logout: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderWith(authCtx: AuthContextType, saasEnabled: boolean, path = '/superadmin') {
+  return render(
+    <ConfigContext.Provider value={{ config: { saasEnabled }, isLoading: false }}>
+      <AuthContext.Provider value={authCtx}>
+        <MemoryRouter initialEntries={[path]}>
+          <RequireSuperadmin>
+            <div data-testid="protected-content">Superadmin Content</div>
+          </RequireSuperadmin>
+        </MemoryRouter>
+      </AuthContext.Provider>
+    </ConfigContext.Provider>,
+  );
+}
+
+describe('RequireSuperadmin', () => {
+  it('renders children when isSuperadmin=true and saasEnabled=true', () => {
+    renderWith(makeAuthCtx({ isAuthenticated: true, isSuperadmin: true }), true);
+    expect(screen.getByTestId('protected-content')).toBeInTheDocument();
+  });
+
+  it('redirects to /login when not authenticated', () => {
+    renderWith(makeAuthCtx({ isAuthenticated: false, isSuperadmin: false }), true);
+    expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument();
+  });
+
+  it('redirects to / when authenticated but not superadmin', () => {
+    renderWith(makeAuthCtx({ isAuthenticated: true, isSuperadmin: false }), true);
+    expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument();
+  });
+
+  it('redirects to / when saasEnabled=false even for superadmin', () => {
+    renderWith(makeAuthCtx({ isAuthenticated: true, isSuperadmin: true }), false);
+    expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/RequireSuperadmin.test.tsx
+++ b/client/src/components/RequireSuperadmin.test.tsx
@@ -4,7 +4,6 @@ import { MemoryRouter } from 'react-router-dom';
 import RequireSuperadmin from './RequireSuperadmin';
 import { AuthContext, type AuthContextType } from '../contexts/AuthContext';
 import { ConfigContext } from '../contexts/ConfigContext';
-import type { PermissionName } from '../types/role';
 
 // Helper to build a minimal AuthContextType
 function makeAuthCtx(overrides: Partial<AuthContextType> = {}): AuthContextType {

--- a/client/src/components/RequireSuperadmin.tsx
+++ b/client/src/components/RequireSuperadmin.tsx
@@ -1,0 +1,39 @@
+import React, { useContext } from 'react';
+import { Navigate } from 'react-router-dom';
+import { AuthContext } from '../contexts/AuthContext';
+import { ConfigContext } from '../contexts/ConfigContext';
+
+interface RequireSuperadminProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Route guard that only renders children when:
+ *  1. saasEnabled=true (superadmin portal only exists in SaaS mode)
+ *  2. The current user is authenticated
+ *  3. The JWT carries scope='superadmin'
+ *
+ * Otherwise redirects:
+ *  - Unauthenticated → /login
+ *  - Authenticated but not superadmin, or saasEnabled=false → /
+ */
+const RequireSuperadmin: React.FC<RequireSuperadminProps> = ({ children }) => {
+  const { isAuthenticated, isSuperadmin } = useContext(AuthContext);
+  const { config } = useContext(ConfigContext);
+
+  if (!config.saasEnabled) {
+    return <Navigate to="/" replace />;
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (!isSuperadmin) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default RequireSuperadmin;

--- a/client/src/components/ScrapeButton.test.tsx
+++ b/client/src/components/ScrapeButton.test.tsx
@@ -11,6 +11,7 @@ const mockAuthContext = {
   login: vi.fn(),
   logout: vi.fn(),
   isAdmin: false,
+  isSuperadmin: false,
   hasPermission: vi.fn((p: PermissionName) => p === 'scraper:trigger'),
 };
 

--- a/client/src/components/StickyElements.test.tsx
+++ b/client/src/components/StickyElements.test.tsx
@@ -29,6 +29,7 @@ const mockAuthContext = {
   logout: vi.fn(),
   login: vi.fn(),
   isAdmin: false,
+  isSuperadmin: false,
   hasPermission: vi.fn(() => true),
   token: 'mock-token',
 };

--- a/client/src/components/admin/RoleManagementPage.test.tsx
+++ b/client/src/components/admin/RoleManagementPage.test.tsx
@@ -36,6 +36,7 @@ const mockAuthContext = {
   login: vi.fn(),
   logout: vi.fn(),
   isAdmin: true,
+  isSuperadmin: false,
   hasPermission: vi.fn<(p: PermissionName) => boolean>(() => true),
 };
 

--- a/client/src/contexts/AuthContext.ts
+++ b/client/src/contexts/AuthContext.ts
@@ -8,6 +8,7 @@ export interface User {
     role_name: string;
     is_system_role: boolean;
     permissions: PermissionName[];
+    scope?: 'superadmin';
 }
 
 export interface AuthContextType {
@@ -15,6 +16,7 @@ export interface AuthContextType {
     token: string | null;
     user: User | null;
     isAdmin: boolean;
+    isSuperadmin: boolean;
     hasPermission: (permission: PermissionName) => boolean;
     login: (token: string, user: User) => void;
     logout: () => void;
@@ -25,6 +27,7 @@ export const AuthContext = createContext<AuthContextType>({
     token: null,
     user: null,
     isAdmin: false,
+    isSuperadmin: false,
     hasPermission: () => false,
     login: () => { },
     logout: () => { },

--- a/client/src/contexts/AuthProvider.tsx
+++ b/client/src/contexts/AuthProvider.tsx
@@ -79,6 +79,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
     const isAuthenticated = !!token;
     const isAdmin = user?.role_name === 'admin' && user?.is_system_role === true;
+    const isSuperadmin = user?.scope === 'superadmin';
 
     const hasPermission = (permission: string): boolean => {
         if (!user) return false;
@@ -154,7 +155,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     };
 
     return (
-        <AuthContext.Provider value={{ isAuthenticated, token, user, isAdmin, hasPermission, login, logout }}>
+        <AuthContext.Provider value={{ isAuthenticated, token, user, isAdmin, isSuperadmin, hasPermission, login, logout }}>
             {children}
         </AuthContext.Provider>
     );

--- a/client/src/contexts/ConfigContext.ts
+++ b/client/src/contexts/ConfigContext.ts
@@ -1,0 +1,13 @@
+import { createContext } from 'react';
+import type { ServerConfig } from '../api/system';
+
+export interface ConfigContextType {
+  config: ServerConfig;
+  isLoading: boolean;
+}
+
+// Safe defaults — standalone mode until the server responds
+export const ConfigContext = createContext<ConfigContextType>({
+  config: { saasEnabled: false },
+  isLoading: true,
+});

--- a/client/src/contexts/ConfigProvider.tsx
+++ b/client/src/contexts/ConfigProvider.tsx
@@ -1,0 +1,27 @@
+import React, { useState, useEffect, type ReactNode } from 'react';
+import { ConfigContext } from './ConfigContext';
+import { getServerConfig, type ServerConfig } from '../api/system';
+
+interface ConfigProviderProps {
+  children: ReactNode;
+}
+
+export const ConfigProvider: React.FC<ConfigProviderProps> = ({ children }) => {
+  const [config, setConfig] = useState<ServerConfig>({ saasEnabled: false });
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    getServerConfig()
+      .then(setConfig)
+      .catch(() => {
+        // On error, fall back to standalone mode (safe default)
+      })
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  return (
+    <ConfigContext.Provider value={{ config, isLoading }}>
+      {children}
+    </ConfigContext.Provider>
+  );
+};

--- a/client/src/contexts/TenantContext.ts
+++ b/client/src/contexts/TenantContext.ts
@@ -1,0 +1,22 @@
+export interface OrgInfo {
+  id: string;
+  slug: string;
+  name: string;
+  status: string;
+}
+
+export interface TenantContextType {
+  org: OrgInfo | null;
+  slug: string;
+  isLoading: boolean;
+  error: string | null;
+}
+
+import { createContext } from 'react';
+
+export const TenantContext = createContext<TenantContextType>({
+  org: null,
+  slug: '',
+  isLoading: false,
+  error: null,
+});

--- a/client/src/contexts/TenantProvider.test.tsx
+++ b/client/src/contexts/TenantProvider.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { useContext } from 'react';
+import { TenantContext } from '../contexts/TenantContext';
+import { TenantProvider } from '../contexts/TenantProvider';
+
+vi.mock('../api/saas', () => ({
+  getOrgInfo: vi.fn(),
+}));
+
+import * as saasApi from '../api/saas';
+
+const mockOrg = { id: 'uuid-1', slug: 'cinema-test', name: 'Cinéma Test', status: 'active' };
+
+function ConsumerComponent() {
+  const { org, isLoading, error } = useContext(TenantContext);
+  if (isLoading) return <div>loading...</div>;
+  if (error) return <div>error: {error}</div>;
+  if (!org) return <div>no-org</div>;
+  return <div>org: {org.name} ({org.slug})</div>;
+}
+
+function renderWithSlug(slug: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/org/${slug}/home`]}>
+      <Routes>
+        <Route path="/org/:slug/*" element={
+          <TenantProvider>
+            <ConsumerComponent />
+          </TenantProvider>
+        } />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('TenantProvider', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('shows loading initially', () => {
+    vi.mocked(saasApi.getOrgInfo).mockReturnValue(new Promise(() => {})); // never resolves
+    renderWithSlug('cinema-test');
+    expect(screen.getByText('loading...')).toBeInTheDocument();
+  });
+
+  it('provides org data on successful fetch', async () => {
+    vi.mocked(saasApi.getOrgInfo).mockResolvedValue(mockOrg);
+    renderWithSlug('cinema-test');
+    await waitFor(() => {
+      expect(screen.getByText('org: Cinéma Test (cinema-test)')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error when org not found', async () => {
+    vi.mocked(saasApi.getOrgInfo).mockRejectedValue(new Error('Organization not found'));
+    renderWithSlug('unknown');
+    await waitFor(() => {
+      expect(screen.getByText(/error:/)).toBeInTheDocument();
+    });
+  });
+
+  it('passes the slug from URL params to the API call', async () => {
+    vi.mocked(saasApi.getOrgInfo).mockResolvedValue(mockOrg);
+    renderWithSlug('my-cinema');
+    await waitFor(() => expect(saasApi.getOrgInfo).toHaveBeenCalledWith('my-cinema'));
+  });
+});

--- a/client/src/contexts/TenantProvider.tsx
+++ b/client/src/contexts/TenantProvider.tsx
@@ -1,0 +1,31 @@
+import { useState, useEffect, ReactNode } from 'react';
+import { useParams } from 'react-router-dom';
+import { TenantContext, OrgInfo } from './TenantContext';
+import { getOrgInfo } from '../api/saas';
+
+interface TenantProviderProps {
+  children: ReactNode;
+}
+
+export function TenantProvider({ children }: TenantProviderProps) {
+  const { slug = '' } = useParams<{ slug: string }>();
+  const [org, setOrg] = useState<OrgInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!slug) return;
+    setIsLoading(true);
+    setError(null);
+    getOrgInfo(slug)
+      .then(setOrg)
+      .catch((err: Error) => setError(err.message))
+      .finally(() => setIsLoading(false));
+  }, [slug]);
+
+  return (
+    <TenantContext.Provider value={{ org, slug, isLoading, error }}>
+      {children}
+    </TenantContext.Provider>
+  );
+}

--- a/client/src/contexts/TenantProvider.tsx
+++ b/client/src/contexts/TenantProvider.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect, ReactNode } from 'react';
+import { useState, useEffect, type ReactNode } from 'react';
 import { useParams } from 'react-router-dom';
-import { TenantContext, OrgInfo } from './TenantContext';
+import { TenantContext, type OrgInfo } from './TenantContext';
 import { getOrgInfo } from '../api/saas';
 
 interface TenantProviderProps {

--- a/client/src/pages/CinemaPage.test.tsx
+++ b/client/src/pages/CinemaPage.test.tsx
@@ -20,6 +20,7 @@ const mockAuthContext = {
   logout: vi.fn(),
   login: vi.fn(),
   isAdmin: false,
+  isSuperadmin: false,
   hasPermission: vi.fn(() => true),
   token: 'mock-token',
 };

--- a/client/src/pages/HomePage.test.tsx
+++ b/client/src/pages/HomePage.test.tsx
@@ -14,6 +14,7 @@ const mockAuthContext = {
   logout: vi.fn(),
   login: vi.fn(),
   isAdmin: false,
+  isSuperadmin: false,
   hasPermission: vi.fn(() => true),
   token: 'mock-token',
 };

--- a/client/src/pages/LoginPage.test.tsx
+++ b/client/src/pages/LoginPage.test.tsx
@@ -24,6 +24,7 @@ const authValue = {
   token: null,
   user: mockUser,
   isAdmin: false,
+  isSuperadmin: false,
   hasPermission: vi.fn(),
   login: vi.fn(),
   logout: vi.fn(),

--- a/client/src/pages/RegisterPage.test.tsx
+++ b/client/src/pages/RegisterPage.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import RegisterPage from './RegisterPage';
+
+vi.mock('../api/saas', () => ({
+  checkSlugAvailability: vi.fn(),
+  registerOrg: vi.fn(),
+}));
+
+import * as saasApi from '../api/saas';
+
+const renderPage = () => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <RegisterPage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+};
+
+describe('RegisterPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(saasApi.checkSlugAvailability).mockResolvedValue(true);
+  });
+
+  it('renders step 1 with org name and slug fields', () => {
+    renderPage();
+    expect(screen.getByLabelText(/nom de votre organisation/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/identifiant/i)).toBeInTheDocument();
+  });
+
+  it('shows a "Suivant" button on step 1', () => {
+    renderPage();
+    expect(screen.getByRole('button', { name: /suivant/i })).toBeInTheDocument();
+  });
+
+  it('auto-generates slug from org name', async () => {
+    renderPage();
+    const nameInput = screen.getByLabelText(/nom de votre organisation/i);
+    fireEvent.change(nameInput, { target: { value: 'Mon Cinéma' } });
+    await waitFor(() => {
+      const slugInput = screen.getByLabelText(/identifiant/i) as HTMLInputElement;
+      expect(slugInput.value).toMatch(/mon-cin/);
+    });
+  });
+
+  it('advances to step 2 after valid step 1', async () => {
+    renderPage();
+    fireEvent.change(screen.getByLabelText(/nom de votre organisation/i), {
+      target: { value: 'Mon Cinéma' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /suivant/i }));
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows validation error when org name is too short', async () => {
+    renderPage();
+    fireEvent.change(screen.getByLabelText(/nom de votre organisation/i), {
+      target: { value: 'A' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /suivant/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/au moins 2 caractères/i)).toBeInTheDocument();
+    });
+  });
+
+  it('calls registerOrg on final step submission', async () => {
+    vi.mocked(saasApi.registerOrg).mockResolvedValue({
+      success: true,
+      org: { id: 'uuid-1', name: 'Mon Cinéma', slug: 'mon-cinema', schema_name: 'org_mon_cinema', status: 'trial', trial_ends_at: null },
+    });
+    renderPage();
+
+    // Step 1
+    fireEvent.change(screen.getByLabelText(/nom de votre organisation/i), { target: { value: 'Mon Cinéma' } });
+    fireEvent.click(screen.getByRole('button', { name: /suivant/i }));
+
+    // Step 2
+    await waitFor(() => screen.getByLabelText(/email/i));
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'admin@test.com' } });
+    fireEvent.change(screen.getByLabelText(/mot de passe/i), { target: { value: 'password123' } });
+    fireEvent.click(screen.getByRole('button', { name: /créer mon organisation/i }));
+
+    await waitFor(() => expect(saasApi.registerOrg).toHaveBeenCalledOnce());
+  });
+
+  it('shows success message after registration', async () => {
+    vi.mocked(saasApi.registerOrg).mockResolvedValue({
+      success: true,
+      org: { id: 'uuid-1', name: 'Mon Cinéma', slug: 'mon-cinema', schema_name: 'org_mon_cinema', status: 'trial', trial_ends_at: null },
+    });
+    renderPage();
+
+    fireEvent.change(screen.getByLabelText(/nom de votre organisation/i), { target: { value: 'Mon Cinéma' } });
+    fireEvent.click(screen.getByRole('button', { name: /suivant/i }));
+
+    await waitFor(() => screen.getByLabelText(/email/i));
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'admin@test.com' } });
+    fireEvent.change(screen.getByLabelText(/mot de passe/i), { target: { value: 'password123' } });
+    fireEvent.click(screen.getByRole('button', { name: /créer mon organisation/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/organisation créée/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/pages/RegisterPage.tsx
+++ b/client/src/pages/RegisterPage.tsx
@@ -1,0 +1,145 @@
+import { useState, useEffect } from 'react';
+import { checkSlugAvailability, registerOrg, RegisterOrgResult } from '../api/saas';
+
+type Step = 'orgInfo' | 'adminAccount' | 'success';
+
+function slugify(str: string): string {
+  return str
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export default function RegisterPage() {
+  const [step, setStep] = useState<Step>('orgInfo');
+
+  // Step 1 fields
+  const [orgName, setOrgName] = useState('');
+  const [slug, setSlug] = useState('');
+  const [slugManuallyEdited, setSlugManuallyEdited] = useState(false);
+  const [orgNameError, setOrgNameError] = useState('');
+
+  // Step 2 fields
+  const [adminEmail, setAdminEmail] = useState('');
+  const [adminPassword, setAdminPassword] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState('');
+
+  // Success state
+  const [result, setResult] = useState<RegisterOrgResult | null>(null);
+
+  // Auto-generate slug from org name
+  useEffect(() => {
+    if (!slugManuallyEdited && orgName) {
+      setSlug(slugify(orgName));
+    }
+  }, [orgName, slugManuallyEdited]);
+
+  function handleStep1Next() {
+    if (orgName.trim().length < 2) {
+      setOrgNameError('Au moins 2 caractères requis.');
+      return;
+    }
+    setOrgNameError('');
+    setStep('adminAccount');
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setIsSubmitting(true);
+    setSubmitError('');
+    try {
+      // Pre-check slug availability
+      const available = await checkSlugAvailability(slug);
+      if (!available) {
+        setSubmitError('Cet identifiant est déjà utilisé.');
+        setIsSubmitting(false);
+        return;
+      }
+      const res = await registerOrg({ orgName, slug, adminEmail, adminPassword });
+      setResult(res);
+      setStep('success');
+    } catch (err: unknown) {
+      setSubmitError(err instanceof Error ? err.message : 'Erreur lors de l\'inscription.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (step === 'success') {
+    return (
+      <main className="register-page">
+        <h1>Organisation créée !</h1>
+        <p>Bienvenue, {result?.org.name}. Votre espace est prêt.</p>
+      </main>
+    );
+  }
+
+  if (step === 'adminAccount') {
+    return (
+      <main className="register-page">
+        <h1>Compte administrateur</h1>
+        <form onSubmit={handleSubmit}>
+          <div>
+            <label htmlFor="adminEmail">Email</label>
+            <input
+              id="adminEmail"
+              type="email"
+              value={adminEmail}
+              onChange={e => setAdminEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="adminPassword">Mot de passe</label>
+            <input
+              id="adminPassword"
+              type="password"
+              value={adminPassword}
+              onChange={e => setAdminPassword(e.target.value)}
+              required
+            />
+          </div>
+          {submitError && <p className="error">{submitError}</p>}
+          <button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? 'Création...' : 'Créer mon organisation'}
+          </button>
+        </form>
+      </main>
+    );
+  }
+
+  // Step 1: org info
+  return (
+    <main className="register-page">
+      <h1>Créer votre organisation</h1>
+      <div>
+        <label htmlFor="orgName">Nom de votre organisation</label>
+        <input
+          id="orgName"
+          type="text"
+          value={orgName}
+          onChange={e => setOrgName(e.target.value)}
+        />
+        {orgNameError && <p className="error">{orgNameError}</p>}
+      </div>
+      <div>
+        <label htmlFor="slug">Identifiant (URL)</label>
+        <input
+          id="slug"
+          type="text"
+          value={slug}
+          onChange={e => {
+            setSlugManuallyEdited(true);
+            setSlug(e.target.value);
+          }}
+        />
+      </div>
+      <button type="button" onClick={handleStep1Next}>
+        Suivant
+      </button>
+    </main>
+  );
+}

--- a/client/src/pages/RegisterPage.tsx
+++ b/client/src/pages/RegisterPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { checkSlugAvailability, registerOrg, type RegisterOrgResult } from '../api/saas';
 
 type Step = 'orgInfo' | 'adminAccount' | 'success';
@@ -13,6 +14,7 @@ function slugify(str: string): string {
 }
 
 export default function RegisterPage() {
+  const navigate = useNavigate();
   const [step, setStep] = useState<Step>('orgInfo');
 
   // Step 1 fields
@@ -51,7 +53,6 @@ export default function RegisterPage() {
     setIsSubmitting(true);
     setSubmitError('');
     try {
-      // Pre-check slug availability
       const available = await checkSlugAvailability(slug);
       if (!available) {
         setSubmitError('Cet identifiant est déjà utilisé.');
@@ -62,7 +63,7 @@ export default function RegisterPage() {
       setResult(res);
       setStep('success');
     } catch (err: unknown) {
-      setSubmitError(err instanceof Error ? err.message : 'Erreur lors de l\'inscription.');
+      setSubmitError(err instanceof Error ? err.message : "Erreur lors de l'inscription.");
     } finally {
       setIsSubmitting(false);
     }
@@ -70,76 +71,143 @@ export default function RegisterPage() {
 
   if (step === 'success') {
     return (
-      <main className="register-page">
-        <h1>Organisation créée !</h1>
-        <p>Bienvenue, {result?.org.name}. Votre espace est prêt.</p>
-      </main>
+      <div className="max-w-md mx-auto mt-10 px-4 sm:px-6">
+        <div className="bg-white p-8 rounded-lg shadow-md text-center">
+          <div className="text-5xl mb-4">🎉</div>
+          <h2 className="text-2xl font-bold mb-2 text-gray-800">Organisation créée !</h2>
+          <p className="text-gray-600 mb-6">
+            Bienvenue, <strong>{result?.org.name}</strong>. Votre espace est prêt.
+          </p>
+          <button
+            onClick={() => navigate(`/org/${result?.org.slug}`)}
+            className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-6 rounded transition-colors"
+          >
+            Accéder à mon espace
+          </button>
+        </div>
+      </div>
     );
   }
 
   if (step === 'adminAccount') {
     return (
-      <main className="register-page">
-        <h1>Compte administrateur</h1>
-        <form onSubmit={handleSubmit}>
-          <div>
-            <label htmlFor="adminEmail">Email</label>
-            <input
-              id="adminEmail"
-              type="email"
-              value={adminEmail}
-              onChange={e => setAdminEmail(e.target.value)}
-              required
-            />
-          </div>
-          <div>
-            <label htmlFor="adminPassword">Mot de passe</label>
-            <input
-              id="adminPassword"
-              type="password"
-              value={adminPassword}
-              onChange={e => setAdminPassword(e.target.value)}
-              required
-            />
-          </div>
-          {submitError && <p className="error">{submitError}</p>}
-          <button type="submit" disabled={isSubmitting}>
-            {isSubmitting ? 'Création...' : 'Créer mon organisation'}
+      <div className="max-w-md mx-auto mt-10 px-4 sm:px-6">
+        <div className="bg-white p-8 rounded-lg shadow-md">
+          <button
+            onClick={() => setStep('orgInfo')}
+            className="text-sm text-gray-500 hover:text-gray-700 mb-4 flex items-center gap-1"
+          >
+            ← Retour
           </button>
-        </form>
-      </main>
+          <h2 className="text-2xl font-bold mb-2 text-gray-800">Compte administrateur</h2>
+          <p className="text-sm text-gray-500 mb-6">
+            Organisation : <strong>{orgName}</strong> — identifiant : <code className="bg-gray-100 px-1 rounded">{slug}</code>
+          </p>
+
+          {submitError && (
+            <div className="mb-4 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded text-sm" role="alert">
+              {submitError}
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit}>
+            <div className="mb-4">
+              <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="adminEmail">
+                Email
+              </label>
+              <input
+                id="adminEmail"
+                type="email"
+                value={adminEmail}
+                onChange={e => setAdminEmail(e.target.value)}
+                required
+                disabled={isSubmitting}
+                className="appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="admin@mon-cinema.com"
+              />
+            </div>
+            <div className="mb-6">
+              <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="adminPassword">
+                Mot de passe
+              </label>
+              <input
+                id="adminPassword"
+                type="password"
+                value={adminPassword}
+                onChange={e => setAdminPassword(e.target.value)}
+                required
+                disabled={isSubmitting}
+                minLength={8}
+                className="appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="8 caractères minimum"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded w-full transition-colors disabled:opacity-50"
+            >
+              {isSubmitting ? 'Création en cours...' : 'Créer mon organisation'}
+            </button>
+          </form>
+        </div>
+      </div>
     );
   }
 
   // Step 1: org info
   return (
-    <main className="register-page">
-      <h1>Créer votre organisation</h1>
-      <div>
-        <label htmlFor="orgName">Nom de votre organisation</label>
-        <input
-          id="orgName"
-          type="text"
-          value={orgName}
-          onChange={e => setOrgName(e.target.value)}
-        />
-        {orgNameError && <p className="error">{orgNameError}</p>}
+    <div className="max-w-md mx-auto mt-10 px-4 sm:px-6">
+      <div className="bg-white p-8 rounded-lg shadow-md">
+        <h2 className="text-2xl font-bold mb-2 text-gray-800">Créer votre organisation</h2>
+        <p className="text-sm text-gray-500 mb-6">Votre espace cinéma multi-tenant, prêt en quelques secondes.</p>
+
+        <div className="mb-4">
+          <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="orgName">
+            Nom de votre organisation
+          </label>
+          <input
+            id="orgName"
+            type="text"
+            value={orgName}
+            onChange={e => setOrgName(e.target.value)}
+            className="appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="Mon Cinéma"
+          />
+          {orgNameError && (
+            <p className="mt-1 text-red-600 text-sm">{orgNameError}</p>
+          )}
+        </div>
+
+        <div className="mb-6">
+          <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="slug">
+            Identifiant (URL)
+          </label>
+          <div className="flex items-center border rounded overflow-hidden focus-within:ring-2 focus-within:ring-blue-500">
+            <span className="bg-gray-100 px-3 py-2 text-gray-500 text-sm border-r whitespace-nowrap">/org/</span>
+            <input
+              id="slug"
+              type="text"
+              value={slug}
+              onChange={e => {
+                setSlugManuallyEdited(true);
+                setSlug(e.target.value);
+              }}
+              className="flex-1 py-2 px-3 text-gray-700 leading-tight focus:outline-none"
+              placeholder="mon-cinema"
+            />
+          </div>
+          <p className="mt-1 text-xs text-gray-400">Lowercase, tirets autorisés, 3–30 caractères.</p>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleStep1Next}
+          className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded w-full transition-colors"
+        >
+          Suivant →
+        </button>
       </div>
-      <div>
-        <label htmlFor="slug">Identifiant (URL)</label>
-        <input
-          id="slug"
-          type="text"
-          value={slug}
-          onChange={e => {
-            setSlugManuallyEdited(true);
-            setSlug(e.target.value);
-          }}
-        />
-      </div>
-      <button type="button" onClick={handleStep1Next}>
-        Suivant
-      </button>
-    </main>
+    </div>
   );
 }

--- a/client/src/pages/RegisterPage.tsx
+++ b/client/src/pages/RegisterPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { checkSlugAvailability, registerOrg, RegisterOrgResult } from '../api/saas';
+import { checkSlugAvailability, registerOrg, type RegisterOrgResult } from '../api/saas';
 
 type Step = 'orgInfo' | 'adminAccount' | 'success';
 

--- a/client/src/pages/admin/AdminPage.test.tsx
+++ b/client/src/pages/admin/AdminPage.test.tsx
@@ -72,6 +72,7 @@ const makeAuthContext = (user: User) => ({
   token: 'mock-token',
   user,
   isAdmin: user.role_name === 'admin' && user.is_system_role === true,
+  isSuperadmin: user.scope === 'superadmin',
   hasPermission: (permission: PermissionName) =>
     (user.role_name === 'admin' && user.is_system_role) || user.permissions.includes(permission),
   login: vi.fn(),

--- a/client/src/pages/admin/CinemasPage.test.tsx
+++ b/client/src/pages/admin/CinemasPage.test.tsx
@@ -78,6 +78,7 @@ const mockAuthContext = {
   login: vi.fn(),
   logout: vi.fn(),
   isAdmin: true,
+  isSuperadmin: false,
   hasPermission: vi.fn<(p: PermissionName) => boolean>(() => true),
 };
 

--- a/client/src/pages/admin/SettingsPage.test.tsx
+++ b/client/src/pages/admin/SettingsPage.test.tsx
@@ -29,6 +29,7 @@ const mockAuthContext = {
   login: vi.fn(),
   logout: vi.fn(),
   isAdmin: true,
+  isSuperadmin: false,
   hasPermission: vi.fn<(p: PermissionName) => boolean>(() => true),
 };
 

--- a/client/src/pages/admin/SystemPage.test.tsx
+++ b/client/src/pages/admin/SystemPage.test.tsx
@@ -79,6 +79,7 @@ const mockAuthContext = {
   login: vi.fn(),
   logout: vi.fn(),
   isAdmin: true,
+  isSuperadmin: false,
   hasPermission: vi.fn<(p: PermissionName) => boolean>(() => true),
 };
 

--- a/client/src/pages/admin/UsersPage.test.tsx
+++ b/client/src/pages/admin/UsersPage.test.tsx
@@ -53,6 +53,7 @@ const mockAuthContext = {
   login: vi.fn(),
   logout: vi.fn(),
   isAdmin: true,
+  isSuperadmin: false,
   hasPermission: vi.fn<(p: PermissionName) => boolean>(() => true),
 };
 

--- a/client/src/pages/superadmin/AuditLogTab.tsx
+++ b/client/src/pages/superadmin/AuditLogTab.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react';
+import { getSuperadminAuditLog, type AuditLogEntry } from '../../api/superadmin';
+
+export default function AuditLogTab() {
+  const [entries, setEntries] = useState<AuditLogEntry[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const limit = 50;
+
+  useEffect(() => {
+    setLoading(true);
+    getSuperadminAuditLog({ page, limit })
+      .then((res) => {
+        setEntries(res.data);
+        setTotal(res.total);
+      })
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : 'Failed to load audit log'))
+      .finally(() => setLoading(false));
+  }, [page]);
+
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+
+  if (loading) return <p className="text-gray-500">Loading audit log...</p>;
+  if (error) return <p className="text-red-500">{error}</p>;
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">Audit Log</h2>
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Date</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actor</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Action</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Target</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Metadata</th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-100">
+            {entries.map((entry) => (
+              <tr key={entry.id}>
+                <td className="px-4 py-3 text-sm text-gray-500 whitespace-nowrap">
+                  {new Date(entry.created_at).toLocaleString()}
+                </td>
+                <td className="px-4 py-3 text-sm">{entry.actor_id}</td>
+                <td className="px-4 py-3 text-sm font-medium">{entry.action}</td>
+                <td className="px-4 py-3 text-sm text-gray-600">
+                  {entry.target_type ? `${entry.target_type}:${entry.target_id}` : '—'}
+                </td>
+                <td className="px-4 py-3 text-xs text-gray-500 max-w-xs truncate">
+                  {Object.keys(entry.metadata).length > 0
+                    ? JSON.stringify(entry.metadata)
+                    : '—'}
+                </td>
+              </tr>
+            ))}
+            {entries.length === 0 && (
+              <tr>
+                <td colSpan={5} className="px-4 py-6 text-center text-gray-400">
+                  No audit entries found.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex justify-between items-center">
+          <span className="text-sm text-gray-500">
+            Page {page} of {totalPages} ({total} entries)
+          </span>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page <= 1}
+              className="text-sm px-3 py-1 border rounded disabled:opacity-40"
+            >
+              Previous
+            </button>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={page >= totalPages}
+              className="text-sm px-3 py-1 border rounded disabled:opacity-40"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/superadmin/DashboardTab.tsx
+++ b/client/src/pages/superadmin/DashboardTab.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import {
+  getSuperadminDashboard,
+  type SuperadminDashboardData,
+} from '../../api/superadmin';
+
+export default function DashboardTab() {
+  const [data, setData] = useState<SuperadminDashboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getSuperadminDashboard()
+      .then(setData)
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : 'Failed to load dashboard'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <p className="text-gray-500">Loading dashboard...</p>;
+  if (error) return <p className="text-red-500">{error}</p>;
+  if (!data) return null;
+
+  const mrrEuros = (data.mrr_cents / 100).toFixed(2);
+  const arrEuros = (data.arr_cents / 100).toFixed(2);
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-xl font-semibold">Dashboard</h2>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {Object.entries(data.orgs).map(([status, count]) => (
+          <div key={status} className="bg-white border rounded-lg p-4 shadow-sm">
+            <p className="text-sm text-gray-500 capitalize">{status}</p>
+            <p className="text-3xl font-bold">{count}</p>
+          </div>
+        ))}
+        <div className="bg-white border rounded-lg p-4 shadow-sm">
+          <p className="text-sm text-gray-500">New this week</p>
+          <p className="text-3xl font-bold">{data.new_orgs_this_week}</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="bg-white border rounded-lg p-4 shadow-sm">
+          <p className="text-sm text-gray-500">MRR</p>
+          <p className="text-2xl font-bold">€{mrrEuros}</p>
+        </div>
+        <div className="bg-white border rounded-lg p-4 shadow-sm">
+          <p className="text-sm text-gray-500">ARR</p>
+          <p className="text-2xl font-bold">€{arrEuros}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/superadmin/OrgsTab.tsx
+++ b/client/src/pages/superadmin/OrgsTab.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState } from 'react';
+import {
+  getSuperadminOrgs,
+  impersonateOrg,
+  suspendOrg,
+  reactivateOrg,
+  resetOrgTrial,
+  type OrgRow,
+} from '../../api/superadmin';
+
+export default function OrgsTab() {
+  const [orgs, setOrgs] = useState<OrgRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getSuperadminOrgs()
+      .then(setOrgs)
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : 'Failed to load orgs'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleImpersonate = async (org: OrgRow) => {
+    try {
+      setActionError(null);
+      const { token } = await impersonateOrg(org.slug);
+      // Store impersonation token and navigate to org slug
+      localStorage.setItem('impersonation_token', token);
+      window.location.href = `/org/${org.slug}/`;
+    } catch (e: unknown) {
+      setActionError(e instanceof Error ? e.message : 'Impersonation failed');
+    }
+  };
+
+  const handleSuspend = async (org: OrgRow) => {
+    try {
+      setActionError(null);
+      const updated = await suspendOrg(org.id);
+      setOrgs((prev) => prev.map((o) => (o.id === org.id ? { ...o, ...updated } : o)));
+    } catch (e: unknown) {
+      setActionError(e instanceof Error ? e.message : 'Suspend failed');
+    }
+  };
+
+  const handleReactivate = async (org: OrgRow) => {
+    try {
+      setActionError(null);
+      const updated = await reactivateOrg(org.id);
+      setOrgs((prev) => prev.map((o) => (o.id === org.id ? { ...o, ...updated } : o)));
+    } catch (e: unknown) {
+      setActionError(e instanceof Error ? e.message : 'Reactivate failed');
+    }
+  };
+
+  const handleResetTrial = async (org: OrgRow) => {
+    try {
+      setActionError(null);
+      const updated = await resetOrgTrial(org.id);
+      setOrgs((prev) => prev.map((o) => (o.id === org.id ? { ...o, ...updated } : o)));
+    } catch (e: unknown) {
+      setActionError(e instanceof Error ? e.message : 'Reset trial failed');
+    }
+  };
+
+  if (loading) return <p className="text-gray-500">Loading organisations...</p>;
+  if (error) return <p className="text-red-500">{error}</p>;
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">Organisations</h2>
+      {actionError && (
+        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-2 rounded">
+          {actionError}
+        </div>
+      )}
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Slug</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Plan</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Trial ends</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-100">
+            {orgs.map((org) => (
+              <tr key={org.id}>
+                <td className="px-4 py-3 font-medium">{org.name}</td>
+                <td className="px-4 py-3 text-gray-600">{org.slug}</td>
+                <td className="px-4 py-3">
+                  <span
+                    className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${
+                      org.status === 'active'
+                        ? 'bg-green-100 text-green-700'
+                        : org.status === 'trial'
+                        ? 'bg-yellow-100 text-yellow-700'
+                        : 'bg-red-100 text-red-700'
+                    }`}
+                  >
+                    {org.status}
+                  </span>
+                </td>
+                <td className="px-4 py-3">{org.plan_name}</td>
+                <td className="px-4 py-3 text-sm text-gray-500">
+                  {org.trial_ends_at ? new Date(org.trial_ends_at).toLocaleDateString() : '—'}
+                </td>
+                <td className="px-4 py-3 flex gap-2 flex-wrap">
+                  <button
+                    onClick={() => handleImpersonate(org)}
+                    className="text-xs bg-blue-600 text-white px-2 py-1 rounded hover:bg-blue-700 transition"
+                    aria-label={`Impersonate ${org.name}`}
+                  >
+                    Impersonate
+                  </button>
+                  <button
+                    onClick={() => handleResetTrial(org)}
+                    className="text-xs bg-yellow-500 text-white px-2 py-1 rounded hover:bg-yellow-600 transition"
+                    aria-label={`Reset trial for ${org.name}`}
+                  >
+                    Reset Trial
+                  </button>
+                  {org.status !== 'suspended' ? (
+                    <button
+                      onClick={() => handleSuspend(org)}
+                      className="text-xs bg-red-500 text-white px-2 py-1 rounded hover:bg-red-600 transition"
+                      aria-label={`Suspend ${org.name}`}
+                    >
+                      Suspend
+                    </button>
+                  ) : (
+                    <button
+                      onClick={() => handleReactivate(org)}
+                      className="text-xs bg-green-600 text-white px-2 py-1 rounded hover:bg-green-700 transition"
+                      aria-label={`Reactivate ${org.name}`}
+                    >
+                      Reactivate
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+            {orgs.length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-4 py-6 text-center text-gray-400">
+                  No organisations found.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/superadmin/SuperadminPage.test.tsx
+++ b/client/src/pages/superadmin/SuperadminPage.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { AuthContext, type AuthContextType } from '../../contexts/AuthContext';
+import { ConfigContext } from '../../contexts/ConfigContext';
+import SuperadminPage from './SuperadminPage';
+
+// Mock the superadmin API module
+vi.mock('../../api/superadmin', () => ({
+  getSuperadminDashboard: vi.fn().mockResolvedValue({
+    orgs: { active: 3, trial: 1, suspended: 0 },
+    new_orgs_this_week: 1,
+    mrr_cents: 9900,
+    arr_cents: 118800,
+  }),
+  getSuperadminOrgs: vi.fn().mockResolvedValue([
+    { id: 'org-1', name: 'Org One', slug: 'org-one', status: 'active', plan_name: 'Pro', trial_ends_at: null },
+    { id: 'org-2', name: 'Org Two', slug: 'org-two', status: 'trial', plan_name: 'Starter', trial_ends_at: '2026-04-15T00:00:00.000Z' },
+  ]),
+  getSuperadminAuditLog: vi.fn().mockResolvedValue({
+    data: [
+      { id: 1, actor_id: 1, action: 'impersonate', target_type: 'organization', target_id: 'org-1', metadata: {}, created_at: '2026-04-01T10:00:00.000Z' },
+    ],
+    total: 1,
+    page: 1,
+    limit: 50,
+  }),
+  impersonateOrg: vi.fn().mockResolvedValue({ token: 'impersonate-jwt' }),
+  suspendOrg: vi.fn().mockResolvedValue({}),
+  reactivateOrg: vi.fn().mockResolvedValue({}),
+  resetOrgTrial: vi.fn().mockResolvedValue({}),
+}));
+
+function makeSuperadminCtx(): AuthContextType {
+  return {
+    isAuthenticated: true,
+    token: 'superadmin-jwt',
+    user: {
+      id: 1,
+      username: 'superadmin',
+      role_id: 1,
+      role_name: 'admin',
+      is_system_role: true,
+      permissions: [],
+      scope: 'superadmin',
+    },
+    isAdmin: true,
+    isSuperadmin: true,
+    hasPermission: () => true,
+    login: vi.fn(),
+    logout: vi.fn(),
+  };
+}
+
+function renderPage() {
+  return render(
+    <ConfigContext.Provider value={{ config: { saasEnabled: true }, isLoading: false }}>
+      <AuthContext.Provider value={makeSuperadminCtx()}>
+        <MemoryRouter>
+          <SuperadminPage />
+        </MemoryRouter>
+      </AuthContext.Provider>
+    </ConfigContext.Provider>,
+  );
+}
+
+describe('SuperadminPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the page title', async () => {
+    renderPage();
+    expect(await screen.findByText(/superadmin/i)).toBeInTheDocument();
+  });
+
+  it('renders 3 tabs: Dashboard, Organisations, Audit Log', async () => {
+    renderPage();
+    expect(await screen.findByRole('tab', { name: /dashboard/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /organisations/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /audit log/i })).toBeInTheDocument();
+  });
+
+  it('Dashboard tab is active by default and shows stats', async () => {
+    renderPage();
+    // Dashboard tab should be selected
+    expect(await screen.findByRole('tab', { name: /dashboard/i })).toHaveAttribute('aria-selected', 'true');
+    // Should display org counts
+    expect(await screen.findByText(/active/i)).toBeInTheDocument();
+  });
+
+  it('clicking Organisations tab shows org list', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const orgsTab = await screen.findByRole('tab', { name: /organisations/i });
+    await user.click(orgsTab);
+
+    expect(await screen.findByText('Org One')).toBeInTheDocument();
+    expect(screen.getByText('Org Two')).toBeInTheDocument();
+  });
+
+  it('clicking Audit Log tab shows audit entries', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const auditTab = await screen.findByRole('tab', { name: /audit log/i });
+    await user.click(auditTab);
+
+    expect(await screen.findByText(/impersonate/i)).toBeInTheDocument();
+  });
+
+  it('Organisations tab has Impersonate action per row', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const orgsTab = await screen.findByRole('tab', { name: /organisations/i });
+    await user.click(orgsTab);
+
+    const impersonateButtons = await screen.findAllByRole('button', { name: /impersonate/i });
+    expect(impersonateButtons.length).toBeGreaterThan(0);
+  });
+});

--- a/client/src/pages/superadmin/SuperadminPage.tsx
+++ b/client/src/pages/superadmin/SuperadminPage.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import DashboardTab from './DashboardTab';
+import OrgsTab from './OrgsTab';
+import AuditLogTab from './AuditLogTab';
+
+type TabId = 'dashboard' | 'organisations' | 'audit-log';
+
+interface Tab {
+  id: TabId;
+  label: string;
+}
+
+const tabs: Tab[] = [
+  { id: 'dashboard', label: 'Dashboard' },
+  { id: 'organisations', label: 'Organisations' },
+  { id: 'audit-log', label: 'Audit Log' },
+];
+
+const SuperadminPage: React.FC = () => {
+  const [activeTab, setActiveTab] = useState<TabId>('dashboard');
+
+  return (
+    <div className="max-w-7xl mx-auto">
+      <div className="mb-6">
+        <h1 className="text-3xl md:text-4xl font-bold">Superadmin Portal</h1>
+        <p className="text-gray-500 mt-1 text-sm">Global SaaS administration</p>
+      </div>
+
+      {/* Tabs navigation */}
+      <div className="border-b border-gray-200 mb-6">
+        <nav className="flex space-x-8" role="tablist">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              role="tab"
+              aria-selected={activeTab === tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`
+                pb-4 border-b-2 font-medium transition-colors cursor-pointer
+                ${
+                  activeTab === tab.id
+                    ? 'border-primary text-primary'
+                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                }
+              `}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      {/* Tab content */}
+      <div role="tabpanel">
+        {activeTab === 'dashboard' && <DashboardTab />}
+        {activeTab === 'organisations' && <OrgsTab />}
+        {activeTab === 'audit-log' && <AuditLogTab />}
+      </div>
+    </div>
+  );
+};
+
+export default SuperadminPage;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,9 @@ services:
       JWT_SECRET: ${JWT_SECRET}
       JWT_EXPIRES_IN: ${JWT_EXPIRES_IN:-24h}
       AUTO_MIGRATE: ${AUTO_MIGRATE:-true}
+      # SaaS mode — set to true to enable multi-tenant SaaS overlay
+      # Activates /api/auth/register, /api/org/:slug/*, and the SaaS frontend routes
+      SAAS_ENABLED: ${SAAS_ENABLED:-false}
     depends_on:
       ics-db:
         condition: service_healthy

--- a/migrations/024_add_is_superadmin_to_users.sql
+++ b/migrations/024_add_is_superadmin_to_users.sql
@@ -1,0 +1,48 @@
+-- Migration: Add is_superadmin flag to users table
+-- Idempotent: safe to run on both fresh and existing databases.
+--
+-- Strategy:
+--   - Add BOOLEAN column is_superadmin (default FALSE) to public.users
+--   - Auto-set TRUE for any user whose role is the system 'admin' role
+--   - The superadmins SaaS table is intentionally left untouched (abandoned)
+
+BEGIN;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'users' AND column_name = 'is_superadmin'
+    ) THEN
+        ALTER TABLE users ADD COLUMN is_superadmin BOOLEAN NOT NULL DEFAULT FALSE;
+        RAISE NOTICE 'Column users.is_superadmin added successfully';
+    ELSE
+        RAISE NOTICE 'Column users.is_superadmin already exists, skipping';
+    END IF;
+END $$;
+
+-- Auto-set is_superadmin=true for users with the system admin role
+UPDATE users u
+SET is_superadmin = TRUE
+FROM roles r
+WHERE u.role_id = r.id
+  AND r.name = 'admin'
+  AND r.is_system = TRUE
+  AND u.is_superadmin = FALSE;
+
+-- Verification
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'users' AND column_name = 'is_superadmin'
+    ) THEN
+        RAISE NOTICE 'Migration successful: users.is_superadmin exists';
+    ELSE
+        RAISE EXCEPTION 'Migration failed: users.is_superadmin does not exist';
+    END IF;
+END $$;
+
+COMMIT;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10265,9 +10265,17 @@
     "packages/saas": {
       "name": "@allo-scrapper/saas",
       "version": "0.1.0",
+      "dependencies": {
+        "bcryptjs": "^3.0.3",
+        "jsonwebtoken": "^9.0.3"
+      },
       "devDependencies": {
+        "@types/bcryptjs": "^3.0.0",
         "@types/express": "^5.0.2",
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^22.15.3",
+        "@types/supertest": "^6.0.2",
+        "supertest": "^7.2.2",
         "typescript": "^5.7.3",
         "vitest": "^3.2.3"
       },
@@ -10283,6 +10291,17 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "packages/saas/node_modules/@types/supertest": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
+      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
       }
     },
     "packages/saas/node_modules/@vitest/expect": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10267,7 +10267,8 @@
       "version": "0.1.0",
       "dependencies": {
         "bcryptjs": "^3.0.3",
-        "jsonwebtoken": "^9.0.3"
+        "jsonwebtoken": "^9.0.3",
+        "prom-client": "^15.1.3"
       },
       "devDependencies": {
         "@types/bcryptjs": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5994,9 +5994,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "10.1.0"
@@ -10267,6 +10267,7 @@
       "version": "0.1.0",
       "dependencies": {
         "bcryptjs": "^3.0.3",
+        "express-rate-limit": "^8.3.2",
         "jsonwebtoken": "^9.0.3",
         "prom-client": "^15.1.3"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "workspaces": [
         "client",
         "server",
-        "scraper"
+        "scraper",
+        "packages/saas"
       ],
       "devDependencies": {
         "@playwright/test": "^1.58.2",
@@ -81,6 +82,10 @@
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@allo-scrapper/saas": {
+      "resolved": "packages/saas",
+      "link": true
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -2816,6 +2821,356 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@so-ric/colorspace": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
@@ -4504,6 +4859,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -4562,6 +4927,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/cheerio": {
@@ -4927,6 +5302,16 @@
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -7045,6 +7430,13 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "11.2.7",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
@@ -7606,6 +7998,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/pend": {
       "version": "1.2.0",
@@ -8266,6 +8668,51 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -8725,6 +9172,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -8895,10 +9362,30 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
       "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9047,7 +9534,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9213,6 +9699,111 @@
           "optional": true
         },
         "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -9669,6 +10260,340 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "packages/saas": {
+      "name": "@allo-scrapper/saas",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/express": "^5.0.2",
+        "@types/node": "^22.15.3",
+        "typescript": "^5.7.3",
+        "vitest": "^3.2.3"
+      },
+      "peerDependencies": {
+        "express": ">=5.0.0"
+      }
+    },
+    "packages/saas/node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/saas/node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/saas/node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/saas/node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/saas/node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/saas/node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/saas/node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/saas/node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/saas/node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/saas/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/saas/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/saas/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/saas/node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "packages/saas/node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "packages/saas/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
       }
     },
     "scraper": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "workspaces": [
     "client",
     "server",
-    "scraper"
+    "scraper",
+    "packages/saas"
   ],
   "scripts": {
     "dev": "docker compose -f docker-compose.dev.yml up --build",

--- a/packages/saas/migrations/001_create_plans.sql
+++ b/packages/saas/migrations/001_create_plans.sql
@@ -1,0 +1,25 @@
+-- Phase 1: plans table
+-- Run in public schema
+
+CREATE TABLE IF NOT EXISTS plans (
+  id                    SERIAL PRIMARY KEY,
+  name                  TEXT NOT NULL,                -- Free, Starter, Pro, Enterprise
+  max_cinemas           INT,                          -- NULL = unlimited
+  max_users             INT,
+  max_scrapes_per_month INT,
+  scrape_frequency_min  INT,                          -- minimum interval between scrapes
+  price_monthly_cents   INT NOT NULL DEFAULT 0,
+  price_yearly_cents    INT NOT NULL DEFAULT 0,
+  stripe_price_id_monthly TEXT,
+  stripe_price_id_yearly  TEXT,
+  features              JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+-- Seed default plans
+INSERT INTO plans (name, max_cinemas, max_users, max_scrapes_per_month, scrape_frequency_min, price_monthly_cents, price_yearly_cents)
+VALUES
+  ('Free',       1,  1,   4,   10080, 0,      0),       -- 7 days minimum
+  ('Starter',    5,  3,   20,  2880,  1900,   18000),   -- 2 days minimum
+  ('Pro',        20, 10,  100, 360,   4900,   47000),   -- 6 hours minimum
+  ('Enterprise', NULL, NULL, NULL, 60, 0, 0)            -- 1 hour minimum, custom pricing
+ON CONFLICT DO NOTHING;

--- a/packages/saas/migrations/002_create_organizations.sql
+++ b/packages/saas/migrations/002_create_organizations.sql
@@ -1,0 +1,17 @@
+-- Phase 1: organizations table
+-- Run in public schema
+
+CREATE TABLE IF NOT EXISTS organizations (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name         TEXT NOT NULL,
+  slug         TEXT UNIQUE NOT NULL,
+  plan_id      INT REFERENCES plans(id) DEFAULT 1,
+  status       TEXT NOT NULL DEFAULT 'trial',         -- trial | active | suspended | canceled
+  schema_name  TEXT NOT NULL,                         -- 'org_' || slug
+  trial_ends_at TIMESTAMPTZ,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_organizations_slug ON organizations(slug);
+CREATE INDEX IF NOT EXISTS idx_organizations_status ON organizations(status);

--- a/packages/saas/migrations/003_create_org_usage.sql
+++ b/packages/saas/migrations/003_create_org_usage.sql
@@ -6,10 +6,22 @@ CREATE TABLE IF NOT EXISTS org_usage (
   org_id          UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
   month           DATE NOT NULL,                      -- first day of month
   cinemas_count   INT NOT NULL DEFAULT 0,
+  users_count     INT NOT NULL DEFAULT 0,
   scrapes_count   INT NOT NULL DEFAULT 0,
   api_calls_count BIGINT NOT NULL DEFAULT 0,
   UNIQUE (org_id, month)
 );
+
+-- Idempotent: add users_count if table already existed without it
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'org_usage' AND column_name = 'users_count'
+  ) THEN
+    ALTER TABLE org_usage ADD COLUMN users_count INT NOT NULL DEFAULT 0;
+  END IF;
+END $$;
 
 -- Tracks which org-level migrations have been applied per org schema
 CREATE TABLE IF NOT EXISTS org_migrations (

--- a/packages/saas/migrations/003_create_org_usage.sql
+++ b/packages/saas/migrations/003_create_org_usage.sql
@@ -1,0 +1,20 @@
+-- Phase 1: org_usage and org_migrations tracking tables
+-- Run in public schema
+
+CREATE TABLE IF NOT EXISTS org_usage (
+  id              SERIAL PRIMARY KEY,
+  org_id          UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  month           DATE NOT NULL,                      -- first day of month
+  cinemas_count   INT NOT NULL DEFAULT 0,
+  scrapes_count   INT NOT NULL DEFAULT 0,
+  api_calls_count BIGINT NOT NULL DEFAULT 0,
+  UNIQUE (org_id, month)
+);
+
+-- Tracks which org-level migrations have been applied per org schema
+CREATE TABLE IF NOT EXISTS org_migrations (
+  org_id         UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  migration_name TEXT NOT NULL,
+  applied_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (org_id, migration_name)
+);

--- a/packages/saas/migrations/004_create_subscriptions.sql
+++ b/packages/saas/migrations/004_create_subscriptions.sql
@@ -1,0 +1,19 @@
+-- Phase 4: subscriptions table (Stripe billing)
+-- Run in public schema
+
+CREATE TABLE IF NOT EXISTS subscriptions (
+  id                     UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id                 UUID UNIQUE NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  stripe_customer_id     TEXT UNIQUE,
+  stripe_subscription_id TEXT UNIQUE,
+  plan_id                INT REFERENCES plans(id),
+  status                 TEXT NOT NULL DEFAULT 'trialing', -- active | trialing | past_due | canceled
+  trial_ends_at          TIMESTAMPTZ,
+  current_period_start   TIMESTAMPTZ,
+  current_period_end     TIMESTAMPTZ,
+  cancel_at_period_end   BOOLEAN NOT NULL DEFAULT false,
+  updated_at             TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_subscriptions_org_id ON subscriptions(org_id);
+CREATE INDEX IF NOT EXISTS idx_subscriptions_status ON subscriptions(status);

--- a/packages/saas/migrations/005_create_superadmins.sql
+++ b/packages/saas/migrations/005_create_superadmins.sql
@@ -1,0 +1,31 @@
+-- Phase 5: superadmins table (public schema)
+-- Stores system-level administrator accounts that are NOT tied to any org.
+-- These accounts authenticate with a separate JWT secret (SUPERADMIN_JWT_SECRET)
+-- and have access to the /api/superadmin/* routes.
+--
+-- Idempotent: safe to run on fresh installs and existing databases.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS superadmins (
+  id              SERIAL PRIMARY KEY,
+  username        TEXT UNIQUE NOT NULL,
+  password_hash   TEXT NOT NULL,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Verify
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'superadmins'
+  ) THEN
+    RAISE EXCEPTION 'Migration failed: public.superadmins does not exist';
+  ELSE
+    RAISE NOTICE 'Migration successful: public.superadmins exists';
+  END IF;
+END $$;
+
+COMMIT;

--- a/packages/saas/migrations/006_create_audit_log.sql
+++ b/packages/saas/migrations/006_create_audit_log.sql
@@ -1,0 +1,37 @@
+-- Phase 5: audit_log table (public schema)
+-- Records sensitive superadmin actions: impersonation sessions, plan overrides,
+-- org suspensions/reactivations, trial resets.
+--
+-- Idempotent: safe to run on fresh installs and existing databases.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS audit_log (
+  id            BIGSERIAL PRIMARY KEY,
+  actor_id      INT NOT NULL REFERENCES superadmins(id),
+  action        TEXT NOT NULL,            -- e.g. 'impersonate', 'suspend_org', 'change_plan'
+  target_type   TEXT,                     -- e.g. 'organization'
+  target_id     TEXT,                     -- UUID of the affected resource
+  metadata      JSONB DEFAULT '{}',
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_actor    ON audit_log(actor_id);
+CREATE INDEX IF NOT EXISTS idx_audit_log_action   ON audit_log(action);
+CREATE INDEX IF NOT EXISTS idx_audit_log_target   ON audit_log(target_type, target_id);
+CREATE INDEX IF NOT EXISTS idx_audit_log_created  ON audit_log(created_at DESC);
+
+-- Verify
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'audit_log'
+  ) THEN
+    RAISE EXCEPTION 'Migration failed: public.audit_log does not exist';
+  ELSE
+    RAISE NOTICE 'Migration successful: public.audit_log exists';
+  END IF;
+END $$;
+
+COMMIT;

--- a/packages/saas/migrations/007_add_custom_domain.sql
+++ b/packages/saas/migrations/007_add_custom_domain.sql
@@ -1,0 +1,43 @@
+-- Phase 6: add custom_domain to organizations (Enterprise plan only)
+-- Idempotent migration
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name   = 'organizations'
+      AND column_name  = 'custom_domain'
+  ) THEN
+    ALTER TABLE organizations ADD COLUMN custom_domain TEXT;
+    RAISE NOTICE 'Column organizations.custom_domain added successfully';
+  ELSE
+    RAISE NOTICE 'Column organizations.custom_domain already exists, skipping';
+  END IF;
+END $$;
+
+-- Unique index (a domain can only belong to one org)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_organizations_custom_domain
+  ON organizations(custom_domain)
+  WHERE custom_domain IS NOT NULL;
+
+-- Verify
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name   = 'organizations'
+      AND column_name  = 'custom_domain'
+  ) THEN
+    RAISE NOTICE 'Migration successful: organizations.custom_domain exists';
+  ELSE
+    RAISE EXCEPTION 'Migration failed: organizations.custom_domain does not exist';
+  END IF;
+END $$;
+
+COMMIT;

--- a/packages/saas/migrations/org_schema/000_bootstrap.sql
+++ b/packages/saas/migrations/org_schema/000_bootstrap.sql
@@ -52,11 +52,14 @@ ON CONFLICT (name) DO NOTHING;
 -- ─── Users ─────────────────────────────────────────────────────────────────
 
 CREATE TABLE IF NOT EXISTS users (
-  id            SERIAL PRIMARY KEY,
-  username      VARCHAR(255) UNIQUE NOT NULL,
-  password_hash VARCHAR(255) NOT NULL,
-  role_id       INTEGER NOT NULL REFERENCES roles(id),
-  created_at    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+  id                   SERIAL PRIMARY KEY,
+  username             VARCHAR(255) UNIQUE NOT NULL,
+  password_hash        VARCHAR(255) NOT NULL,
+  role_id              INTEGER NOT NULL REFERENCES roles(id),
+  email_verified       BOOLEAN NOT NULL DEFAULT false,
+  verification_token   TEXT,
+  verification_expires TIMESTAMPTZ,
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE INDEX IF NOT EXISTS idx_users_role_id ON users(role_id);
@@ -257,3 +260,20 @@ CREATE TABLE IF NOT EXISTS rate_limit_audit_log (
 
 CREATE INDEX IF NOT EXISTS idx_rate_limit_audit_log_changed_at ON rate_limit_audit_log(changed_at DESC);
 CREATE INDEX IF NOT EXISTS idx_rate_limit_audit_log_changed_by ON rate_limit_audit_log(changed_by);
+
+-- ─── Invitations ─────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS invitations (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email       TEXT NOT NULL,
+  role_id     INTEGER NOT NULL REFERENCES roles(id),
+  token       TEXT NOT NULL UNIQUE,
+  invited_by  INTEGER NOT NULL REFERENCES users(id),
+  accepted_at TIMESTAMPTZ,
+  expires_at  TIMESTAMPTZ NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_invitations_token      ON invitations(token);
+CREATE INDEX IF NOT EXISTS idx_invitations_email      ON invitations(email);
+CREATE INDEX IF NOT EXISTS idx_invitations_expires_at ON invitations(expires_at);

--- a/packages/saas/migrations/org_schema/000_bootstrap.sql
+++ b/packages/saas/migrations/org_schema/000_bootstrap.sql
@@ -1,0 +1,259 @@
+-- Org schema bootstrap: creates all core tables for a new tenant schema.
+-- This runs with search_path already set to org_{slug}, so all tables
+-- are created in the org's private schema.
+--
+-- NOTE: films stay in public schema (shared) — showtimes reference public.films
+
+-- Enable pg_trgm for full-text search (extension is global but must be visible)
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- ─── Roles & Permissions ───────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS roles (
+  id          SERIAL PRIMARY KEY,
+  name        TEXT NOT NULL UNIQUE,
+  description TEXT,
+  is_system   BOOLEAN NOT NULL DEFAULT false,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS permissions (
+  id          SERIAL PRIMARY KEY,
+  name        TEXT NOT NULL UNIQUE,
+  description TEXT,
+  category    TEXT NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS role_permissions (
+  role_id       INTEGER NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+  permission_id INTEGER NOT NULL REFERENCES permissions(id) ON DELETE CASCADE,
+  PRIMARY KEY (role_id, permission_id)
+);
+
+CREATE TABLE IF NOT EXISTS permission_category_labels (
+  id          SERIAL PRIMARY KEY,
+  category_key TEXT NOT NULL UNIQUE,
+  label_en    TEXT NOT NULL,
+  label_fr    TEXT NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_permission_category_labels_key
+  ON permission_category_labels(category_key);
+
+-- Seed default roles
+INSERT INTO roles (name, description, is_system) VALUES
+  ('admin', 'Full access', true),
+  ('user',  'Read-only access', true)
+ON CONFLICT (name) DO NOTHING;
+
+-- ─── Users ─────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS users (
+  id            SERIAL PRIMARY KEY,
+  username      VARCHAR(255) UNIQUE NOT NULL,
+  password_hash VARCHAR(255) NOT NULL,
+  role_id       INTEGER NOT NULL REFERENCES roles(id),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_role_id ON users(role_id);
+
+-- ─── Org settings (replaces app_settings singleton) ─────────────────────────
+
+CREATE TABLE IF NOT EXISTS org_settings (
+  id                   INTEGER PRIMARY KEY DEFAULT 1,
+  site_name            TEXT NOT NULL DEFAULT 'Allo-Scrapper',
+  logo_base64          TEXT,
+  favicon_base64       TEXT,
+  color_primary        TEXT NOT NULL DEFAULT '#FECC00',
+  color_secondary      TEXT NOT NULL DEFAULT '#1F2937',
+  color_accent         TEXT NOT NULL DEFAULT '#F59E0B',
+  color_background     TEXT NOT NULL DEFAULT '#FFFFFF',
+  color_surface        TEXT NOT NULL DEFAULT '#F3F4F6',
+  color_text_primary   TEXT NOT NULL DEFAULT '#111827',
+  color_text_secondary TEXT NOT NULL DEFAULT '#6B7280',
+  color_success        TEXT NOT NULL DEFAULT '#10B981',
+  color_error          TEXT NOT NULL DEFAULT '#EF4444',
+  font_primary         TEXT NOT NULL DEFAULT 'Inter',
+  font_secondary       TEXT NOT NULL DEFAULT 'Roboto',
+  footer_text          TEXT DEFAULT 'Données fournies par le site source - Mise à jour hebdomadaire',
+  footer_links         JSONB NOT NULL DEFAULT '[]'::jsonb,
+  email_from_name      TEXT DEFAULT 'Allo-Scrapper',
+  email_from_address   TEXT DEFAULT 'no-reply@allocine-scrapper.com',
+  scrape_mode          TEXT NOT NULL DEFAULT 'weekly',
+  scrape_days          INTEGER NOT NULL DEFAULT 7,
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_by           INTEGER REFERENCES users(id),
+  CONSTRAINT singleton_check CHECK (id = 1),
+  CONSTRAINT valid_scrape_mode CHECK (scrape_mode IN ('weekly', 'from_today', 'from_today_limited')),
+  CONSTRAINT valid_scrape_days CHECK (scrape_days >= 1 AND scrape_days <= 14)
+);
+
+CREATE INDEX IF NOT EXISTS idx_org_settings_updated_at ON org_settings(updated_at);
+
+INSERT INTO org_settings (id) VALUES (1) ON CONFLICT DO NOTHING;
+
+-- ─── Cinemas ────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS cinemas (
+  id           TEXT PRIMARY KEY,
+  name         TEXT NOT NULL,
+  address      TEXT,
+  postal_code  TEXT,
+  city         TEXT,
+  screen_count INTEGER,
+  image_url    TEXT,
+  url          TEXT,
+  source       VARCHAR(50) DEFAULT 'allocine'
+);
+
+-- ─── Showtimes (references public.films) ────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS showtimes (
+  id            TEXT PRIMARY KEY,
+  film_id       INTEGER NOT NULL REFERENCES public.films(id),
+  cinema_id     TEXT NOT NULL REFERENCES cinemas(id) ON DELETE CASCADE,
+  date          TEXT NOT NULL,
+  time          TEXT NOT NULL,
+  datetime_iso  TEXT NOT NULL,
+  version       TEXT,
+  format        TEXT,
+  experiences   TEXT,
+  week_start    TEXT NOT NULL,
+  UNIQUE (cinema_id, film_id, date, time, version, format)
+);
+
+CREATE INDEX IF NOT EXISTS idx_showtimes_cinema_date ON showtimes(cinema_id, date);
+CREATE INDEX IF NOT EXISTS idx_showtimes_film_date   ON showtimes(film_id, date);
+CREATE INDEX IF NOT EXISTS idx_showtimes_week        ON showtimes(week_start);
+
+-- ─── Scrape schedules ───────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS scrape_schedules (
+  id               SERIAL PRIMARY KEY,
+  name             VARCHAR(255) NOT NULL UNIQUE,
+  description      TEXT,
+  cron_expression  VARCHAR(100) NOT NULL,
+  enabled          BOOLEAN NOT NULL DEFAULT TRUE,
+  target_cinemas   JSONB,
+  created_by       INTEGER REFERENCES users(id),
+  updated_by       INTEGER REFERENCES users(id),
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_run_at      TIMESTAMPTZ,
+  last_run_status  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_scrape_schedules_enabled ON scrape_schedules(enabled);
+CREATE INDEX IF NOT EXISTS idx_scrape_schedules_name    ON scrape_schedules(name);
+
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS update_scrape_schedules_updated_at ON scrape_schedules;
+CREATE TRIGGER update_scrape_schedules_updated_at
+  BEFORE UPDATE ON scrape_schedules
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ─── Scrape reports ─────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS scrape_reports (
+  id                    SERIAL PRIMARY KEY,
+  started_at            TIMESTAMPTZ NOT NULL,
+  completed_at          TIMESTAMPTZ,
+  status                TEXT NOT NULL,
+  trigger_type          TEXT NOT NULL,
+  total_cinemas         INTEGER,
+  successful_cinemas    INTEGER,
+  failed_cinemas        INTEGER,
+  total_films_scraped   INTEGER,
+  total_showtimes_scraped INTEGER,
+  errors                JSONB,
+  progress_log          JSONB,
+  schedule_id           INTEGER REFERENCES scrape_schedules(id),
+  parent_report_id      INTEGER REFERENCES scrape_reports(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_scrape_reports_started_at ON scrape_reports(started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_scrape_reports_status     ON scrape_reports(status);
+
+-- ─── Scrape attempts ────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS scrape_attempts (
+  id                  SERIAL PRIMARY KEY,
+  report_id           INTEGER NOT NULL REFERENCES scrape_reports(id) ON DELETE CASCADE,
+  cinema_id           TEXT NOT NULL REFERENCES cinemas(id),
+  date                TEXT NOT NULL,
+  status              TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'success', 'failed', 'rate_limited', 'not_attempted')),
+  error_type          TEXT,
+  error_message       TEXT,
+  http_status_code    INTEGER,
+  films_scraped       INTEGER DEFAULT 0,
+  showtimes_scraped   INTEGER DEFAULT 0,
+  attempted_at        TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (report_id, cinema_id, date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_scrape_attempts_report_id     ON scrape_attempts(report_id);
+CREATE INDEX IF NOT EXISTS idx_scrape_attempts_report_status ON scrape_attempts(report_id, status);
+CREATE INDEX IF NOT EXISTS idx_scrape_attempts_cinema_date   ON scrape_attempts(cinema_id, date);
+
+-- ─── Rate limit configs ──────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS rate_limit_configs (
+  id                INTEGER PRIMARY KEY DEFAULT 1,
+  window_ms         INTEGER NOT NULL DEFAULT 900000
+    CHECK (window_ms >= 60000 AND window_ms <= 3600000),
+  general_max       INTEGER NOT NULL DEFAULT 100
+    CHECK (general_max >= 10 AND general_max <= 1000),
+  auth_max          INTEGER NOT NULL DEFAULT 5
+    CHECK (auth_max >= 3 AND auth_max <= 50),
+  register_max      INTEGER NOT NULL DEFAULT 3
+    CHECK (register_max >= 1 AND register_max <= 20),
+  register_window_ms INTEGER NOT NULL DEFAULT 3600000
+    CHECK (register_window_ms >= 300000 AND register_window_ms <= 86400000),
+  protected_max     INTEGER NOT NULL DEFAULT 60
+    CHECK (protected_max >= 10 AND protected_max <= 500),
+  scraper_max       INTEGER NOT NULL DEFAULT 10
+    CHECK (scraper_max >= 5 AND scraper_max <= 100),
+  public_max        INTEGER NOT NULL DEFAULT 100
+    CHECK (public_max >= 20 AND public_max <= 1000),
+  health_max        INTEGER NOT NULL DEFAULT 10
+    CHECK (health_max >= 5 AND health_max <= 100),
+  health_window_ms  INTEGER NOT NULL DEFAULT 60000
+    CHECK (health_window_ms = 60000),
+  updated_at        TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+  updated_by        INTEGER REFERENCES users(id),
+  environment       TEXT DEFAULT 'production'
+    CHECK (environment IN ('development', 'staging', 'production')),
+  CONSTRAINT singleton_check CHECK (id = 1)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rate_limit_configs_updated_at ON rate_limit_configs(updated_at);
+
+INSERT INTO rate_limit_configs (id) VALUES (1) ON CONFLICT DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS rate_limit_audit_log (
+  id                  SERIAL PRIMARY KEY,
+  changed_at          TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  changed_by          INTEGER NOT NULL REFERENCES users(id),
+  changed_by_username TEXT NOT NULL,
+  changed_by_role     TEXT NOT NULL,
+  field_name          TEXT NOT NULL,
+  old_value           TEXT NOT NULL,
+  new_value           TEXT NOT NULL,
+  user_ip             TEXT,
+  user_agent          TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_rate_limit_audit_log_changed_at ON rate_limit_audit_log(changed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_rate_limit_audit_log_changed_by ON rate_limit_audit_log(changed_by);

--- a/packages/saas/package.json
+++ b/packages/saas/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@allo-scrapper/saas",
+  "version": "0.1.0",
+  "description": "SaaS overlay plugin for allo-scrapper",
+  "type": "module",
+  "main": "dist/plugin.js",
+  "types": "dist/plugin.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest",
+    "test:run": "vitest run"
+  },
+  "peerDependencies": {
+    "express": ">=5.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.3",
+    "@types/node": "^22.15.3",
+    "@types/express": "^5.0.2",
+    "vitest": "^3.2.3"
+  }
+}

--- a/packages/saas/package.json
+++ b/packages/saas/package.json
@@ -16,16 +16,17 @@
   },
   "dependencies": {
     "bcryptjs": "^3.0.3",
-    "jsonwebtoken": "^9.0.3"
+    "jsonwebtoken": "^9.0.3",
+    "prom-client": "^15.1.3"
   },
   "devDependencies": {
-    "typescript": "^5.7.3",
-    "@types/node": "^22.15.3",
-    "@types/express": "^5.0.2",
     "@types/bcryptjs": "^3.0.0",
+    "@types/express": "^5.0.2",
     "@types/jsonwebtoken": "^9.0.10",
+    "@types/node": "^22.15.3",
     "@types/supertest": "^6.0.2",
     "supertest": "^7.2.2",
+    "typescript": "^5.7.3",
     "vitest": "^3.2.3"
   }
 }

--- a/packages/saas/package.json
+++ b/packages/saas/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "bcryptjs": "^3.0.3",
+    "express-rate-limit": "^8.3.2",
     "jsonwebtoken": "^9.0.3",
     "prom-client": "^15.1.3"
   },

--- a/packages/saas/package.json
+++ b/packages/saas/package.json
@@ -14,10 +14,18 @@
   "peerDependencies": {
     "express": ">=5.0.0"
   },
+  "dependencies": {
+    "bcryptjs": "^3.0.3",
+    "jsonwebtoken": "^9.0.3"
+  },
   "devDependencies": {
     "typescript": "^5.7.3",
     "@types/node": "^22.15.3",
     "@types/express": "^5.0.2",
+    "@types/bcryptjs": "^3.0.0",
+    "@types/jsonwebtoken": "^9.0.10",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^7.2.2",
     "vitest": "^3.2.3"
   }
 }

--- a/packages/saas/src/db/org-queries.test.ts
+++ b/packages/saas/src/db/org-queries.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  getOrgBySlug,
+  getOrgById,
+  insertOrg,
+  isSlugAvailable,
+  slugToSchemaName,
+  type Organization,
+} from '../db/org-queries.js';
+import type { DB } from '../db/types.js';
+
+const mockOrg: Organization = {
+  id: 'uuid-123',
+  name: 'Cinéma Test',
+  slug: 'cinema-test',
+  plan_id: 1,
+  status: 'trial',
+  schema_name: 'org_cinema_test',
+  trial_ends_at: new Date('2026-04-14'),
+  created_at: new Date('2026-03-31'),
+  updated_at: new Date('2026-03-31'),
+};
+
+function makeDb(rows: unknown[] = [], rowCount = rows.length): DB {
+  return { query: vi.fn().mockResolvedValue({ rows, rowCount }) };
+}
+
+describe('slugToSchemaName', () => {
+  it('prepends org_ prefix', () => {
+    expect(slugToSchemaName('mycinema')).toBe('org_mycinema');
+  });
+  it('replaces hyphens with underscores', () => {
+    expect(slugToSchemaName('my-great-cinema')).toBe('org_my_great_cinema');
+  });
+});
+
+describe('getOrgBySlug', () => {
+  it('returns org when found', async () => {
+    const db = makeDb([mockOrg]);
+    const result = await getOrgBySlug(db, 'cinema-test');
+    expect(result).toEqual(mockOrg);
+    expect(db.query).toHaveBeenCalledWith(expect.stringContaining('slug = $1'), ['cinema-test']);
+  });
+
+  it('returns null when not found', async () => {
+    const db = makeDb([]);
+    const result = await getOrgBySlug(db, 'unknown');
+    expect(result).toBeNull();
+  });
+});
+
+describe('getOrgById', () => {
+  it('returns org when found', async () => {
+    const db = makeDb([mockOrg]);
+    const result = await getOrgById(db, 'uuid-123');
+    expect(result).toEqual(mockOrg);
+  });
+
+  it('returns null when not found', async () => {
+    const db = makeDb([]);
+    const result = await getOrgById(db, 'uuid-999');
+    expect(result).toBeNull();
+  });
+});
+
+describe('insertOrg', () => {
+  it('inserts org and returns the created record', async () => {
+    const db = makeDb([mockOrg]);
+    const result = await insertOrg(db, { name: 'Cinéma Test', slug: 'cinema-test' });
+    expect(result).toEqual(mockOrg);
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO organizations'),
+      expect.arrayContaining(['cinema-test', 'org_cinema_test'])
+    );
+  });
+
+  it('defaults to plan_id = 1 when not provided', async () => {
+    const db = makeDb([mockOrg]);
+    await insertOrg(db, { name: 'Test', slug: 'test' });
+    const [, params] = (db.query as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(params[2]).toBe(1);
+  });
+
+  it('uses provided plan_id', async () => {
+    const db = makeDb([mockOrg]);
+    await insertOrg(db, { name: 'Pro Cinema', slug: 'pro-cinema', plan_id: 3 });
+    const [, params] = (db.query as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(params[2]).toBe(3);
+  });
+
+  it('sets schema_name from slug (hyphens → underscores)', async () => {
+    const db = makeDb([{ ...mockOrg, schema_name: 'org_pro_cinema' }]);
+    const result = await insertOrg(db, { name: 'Pro Cinema', slug: 'pro-cinema' });
+    const [, params] = (db.query as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(params[3]).toBe('org_pro_cinema');
+    expect(result.schema_name).toBe('org_pro_cinema');
+  });
+});
+
+describe('isSlugAvailable', () => {
+  it('returns true when slug is not taken', async () => {
+    const db = makeDb([{ count: '0' }]);
+    const result = await isSlugAvailable(db, 'new-cinema');
+    expect(result).toBe(true);
+  });
+
+  it('returns false when slug is already taken', async () => {
+    const db = makeDb([{ count: '1' }]);
+    const result = await isSlugAvailable(db, 'existing-cinema');
+    expect(result).toBe(false);
+  });
+});

--- a/packages/saas/src/db/org-queries.ts
+++ b/packages/saas/src/db/org-queries.ts
@@ -5,11 +5,12 @@ export interface Organization {
   name: string;
   slug: string;
   plan_id: number;
-  status: string;        // trial | active | suspended | canceled
-  schema_name: string;   // 'org_' + sanitized slug
+  status: string;
+  schema_name: string;
   trial_ends_at: Date | null;
   created_at: Date;
   updated_at: Date;
+  [key: string]: unknown;
 }
 
 export interface Plan {
@@ -22,6 +23,7 @@ export interface Plan {
   price_monthly_cents: number;
   price_yearly_cents: number;
   features: Record<string, unknown>;
+  [key: string]: unknown;
 }
 
 /**

--- a/packages/saas/src/db/org-queries.ts
+++ b/packages/saas/src/db/org-queries.ts
@@ -1,0 +1,79 @@
+import type { DB } from './types.js';
+
+export interface Organization {
+  id: string;
+  name: string;
+  slug: string;
+  plan_id: number;
+  status: string;        // trial | active | suspended | canceled
+  schema_name: string;   // 'org_' + sanitized slug
+  trial_ends_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface Plan {
+  id: number;
+  name: string;
+  max_cinemas: number | null;
+  max_users: number | null;
+  max_scrapes_per_month: number | null;
+  scrape_frequency_min: number | null;
+  price_monthly_cents: number;
+  price_yearly_cents: number;
+  features: Record<string, unknown>;
+}
+
+/**
+ * Build the PostgreSQL schema name from an org slug.
+ * Replaces hyphens with underscores — slugs are validated to be [a-z0-9-].
+ */
+export function slugToSchemaName(slug: string): string {
+  return `org_${slug.replace(/-/g, '_')}`;
+}
+
+export async function getOrgBySlug(db: DB, slug: string): Promise<Organization | null> {
+  const result = await db.query<Organization>(
+    'SELECT * FROM organizations WHERE slug = $1',
+    [slug]
+  );
+  return result.rows[0] ?? null;
+}
+
+export async function getOrgById(db: DB, id: string): Promise<Organization | null> {
+  const result = await db.query<Organization>(
+    'SELECT * FROM organizations WHERE id = $1',
+    [id]
+  );
+  return result.rows[0] ?? null;
+}
+
+export async function insertOrg(
+  db: DB,
+  data: { name: string; slug: string; plan_id?: number }
+): Promise<Organization> {
+  const schemaName = slugToSchemaName(data.slug);
+  const result = await db.query<Organization>(
+    `INSERT INTO organizations (name, slug, plan_id, schema_name, trial_ends_at)
+     VALUES ($1, $2, $3, $4, now() + interval '14 days')
+     RETURNING *`,
+    [data.name, data.slug, data.plan_id ?? 1, schemaName]
+  );
+  return result.rows[0];
+}
+
+export async function isSlugAvailable(db: DB, slug: string): Promise<boolean> {
+  const result = await db.query<{ count: string }>(
+    'SELECT COUNT(*) as count FROM organizations WHERE slug = $1',
+    [slug]
+  );
+  return parseInt(result.rows[0].count) === 0;
+}
+
+export async function getPlanById(db: DB, planId: number): Promise<Plan | null> {
+  const result = await db.query<Plan>(
+    'SELECT * FROM plans WHERE id = $1',
+    [planId]
+  );
+  return result.rows[0] ?? null;
+}

--- a/packages/saas/src/db/types.ts
+++ b/packages/saas/src/db/types.ts
@@ -10,7 +10,8 @@ export interface QueryResult<T> {
 
 /** Thin query wrapper (matches server/src/db/client.ts `db` object) */
 export interface DB {
-  query<T extends Record<string, unknown> = Record<string, unknown>>(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  query<T = Record<string, any>>(
     text: string,
     params?: unknown[]
   ): Promise<QueryResult<T>>;

--- a/packages/saas/src/db/types.ts
+++ b/packages/saas/src/db/types.ts
@@ -1,0 +1,26 @@
+/**
+ * Minimal DB interfaces for the SaaS package.
+ * Compatible with the server's pg.Pool-backed db wrapper.
+ */
+
+export interface QueryResult<T> {
+  rows: T[];
+  rowCount: number | null;
+}
+
+/** Thin query wrapper (matches server/src/db/client.ts `db` object) */
+export interface DB {
+  query<T extends Record<string, unknown> = Record<string, unknown>>(
+    text: string,
+    params?: unknown[]
+  ): Promise<QueryResult<T>>;
+}
+
+/** pg.Pool interface for acquiring dedicated clients (tenant middleware) */
+export interface Pool {
+  connect(): Promise<PoolClient>;
+}
+
+export interface PoolClient extends DB {
+  release(err?: Error): void;
+}

--- a/packages/saas/src/middleware/org-metrics.test.ts
+++ b/packages/saas/src/middleware/org-metrics.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express, { type Express, type Request, type Response, type NextFunction } from 'express';
+import request from 'supertest';
+
+// ── Mock prom-client ──────────────────────────────────────────────────────────
+
+const { mockIncFn, mockObserveFn, MockCounter, MockHistogram, MockRegistry } = vi.hoisted(() => {
+  const mockIncFn = vi.fn();
+  const mockObserveFn = vi.fn();
+
+  class MockCounter {
+    inc = mockIncFn;
+    constructor(public opts: Record<string, unknown>) {}
+  }
+
+  class MockHistogram {
+    observe = mockObserveFn;
+    startTimer = vi.fn().mockReturnValue(vi.fn());
+    constructor(public opts: Record<string, unknown>) {}
+  }
+
+  class MockRegistry {
+    registerMetric = vi.fn();
+    metrics = vi.fn().mockResolvedValue('# metrics');
+    contentType = 'text/plain';
+  }
+
+  return { mockIncFn, mockObserveFn, MockCounter, MockHistogram, MockRegistry };
+});
+
+vi.mock('prom-client', () => ({
+  Counter: MockCounter,
+  Histogram: MockHistogram,
+  Registry: MockRegistry,
+  register: new MockRegistry(),
+}));
+
+import { createOrgMetricsMiddleware, getOrgRegistry } from '../middleware/org-metrics.js';
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+const MOCK_ORG = {
+  id: 'uuid-1',
+  slug: 'cinema-test',
+  name: 'Cinéma Test',
+  schema_name: 'org_cinema_test',
+  status: 'active' as const,
+  plan: 'starter',
+  trial_ends_at: null,
+  created_at: new Date('2026-01-01'),
+};
+
+function buildApp(): Express {
+  const app = express();
+
+  app.use((req: Request, _res: Response, next: NextFunction) => {
+    (req as any).org = MOCK_ORG;
+    next();
+  });
+
+  app.use(createOrgMetricsMiddleware());
+
+  app.get('/api/org/:slug/ping', (_req: Request, res: Response) => {
+    res.json({ success: true });
+  });
+
+  return app;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('createOrgMetricsMiddleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('increments the HTTP request counter for each request', async () => {
+    const app = buildApp();
+    await request(app).get('/api/org/cinema-test/ping');
+
+    expect(mockIncFn).toHaveBeenCalledWith(
+      expect.objectContaining({ org_slug: 'cinema-test' })
+    );
+  });
+
+  it('labels the counter with org_slug', async () => {
+    const app = buildApp();
+    await request(app).get('/api/org/cinema-test/ping');
+
+    const callArgs = mockIncFn.mock.calls[0][0] as Record<string, string>;
+    expect(callArgs.org_slug).toBe('cinema-test');
+  });
+
+  it('labels the counter with HTTP method', async () => {
+    const app = buildApp();
+    await request(app).get('/api/org/cinema-test/ping');
+
+    const callArgs = mockIncFn.mock.calls[0][0] as Record<string, string>;
+    expect(callArgs.method).toBe('GET');
+  });
+
+  it('labels the counter with HTTP status code', async () => {
+    const app = buildApp();
+    await request(app).get('/api/org/cinema-test/ping');
+
+    const callArgs = mockIncFn.mock.calls[0][0] as Record<string, string>;
+    expect(callArgs.status_code).toBeDefined();
+  });
+
+  it('works without req.org (routes not yet tenant-resolved)', async () => {
+    const app = express();
+    app.use(createOrgMetricsMiddleware());
+    app.get('/health', (_req: Request, res: Response) => res.json({ ok: true }));
+
+    // Should not throw
+    await expect(request(app).get('/health')).resolves.not.toThrow();
+  });
+});
+
+describe('getOrgRegistry', () => {
+  it('returns a prom-client Registry instance', () => {
+    const reg = getOrgRegistry();
+    expect(reg).toBeDefined();
+    expect(typeof reg.metrics).toBe('function');
+  });
+});

--- a/packages/saas/src/middleware/org-metrics.ts
+++ b/packages/saas/src/middleware/org-metrics.ts
@@ -1,0 +1,46 @@
+import type { Request, Response, NextFunction } from 'express';
+import { Counter, Registry } from 'prom-client';
+
+// ── Per-org Prometheus registry ───────────────────────────────────────────────
+
+const orgRegistry = new Registry();
+
+const orgHttpRequestsTotal = new Counter({
+  name: 'saas_org_http_requests_total',
+  help: 'Total HTTP requests per org, method, and status code',
+  labelNames: ['org_slug', 'method', 'status_code'] as const,
+  registers: [orgRegistry],
+});
+
+/**
+ * Returns the per-org Prometheus registry.
+ * Expose via GET /api/org/:slug/metrics (or aggregate in the scraper).
+ */
+export function getOrgRegistry(): Registry {
+  return orgRegistry;
+}
+
+// ── Middleware ────────────────────────────────────────────────────────────────
+
+/**
+ * Express middleware that increments a Prometheus counter for every request.
+ * Labels: org_slug (from req.org, if present), method, status_code.
+ *
+ * Works in both SaaS (tenant-resolved) and standalone routes:
+ * - If req.org is absent, org_slug is recorded as "unknown".
+ */
+export function createOrgMetricsMiddleware() {
+  return function orgMetrics(req: Request, res: Response, next: NextFunction): void {
+    // Hook into the finish event to capture final status code
+    res.on('finish', () => {
+      const org = (req as Request & { org?: { slug: string } }).org;
+      orgHttpRequestsTotal.inc({
+        org_slug: org?.slug ?? 'unknown',
+        method: req.method,
+        status_code: String(res.statusCode),
+      });
+    });
+
+    next();
+  };
+}

--- a/packages/saas/src/middleware/quota.test.ts
+++ b/packages/saas/src/middleware/quota.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import express, { type Express } from 'express';
 import supertest from 'supertest';
 import { checkQuota } from '../middleware/quota.js';
@@ -7,14 +7,16 @@ import type { DB } from '../db/types.js';
 // ── mocks ─────────────────────────────────────────────────────────────────────
 
 vi.mock('../services/quota-service.js', () => ({
-  QuotaService: vi.fn().mockImplementation(() => ({
-    getOrCreateUsage: vi.fn(),
-  })),
+  QuotaService: vi.fn(),
 }));
 
 vi.mock('../db/org-queries.js', () => ({
   getPlanById: vi.fn(),
 }));
+
+// Import mocked modules at the top level (works because vi.mock is hoisted)
+import { QuotaService } from '../services/quota-service.js';
+import { getPlanById } from '../db/org-queries.js';
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -58,7 +60,6 @@ function buildApp(resource: 'cinemas' | 'users' | 'scrapes', db: DB): Express {
   const app = express();
   app.use(express.json());
   app.set('db', db);
-  // Inject req.org like resolveTenant would
   app.use((req: any, _res: any, next: any) => {
     req.org = MOCK_ORG;
     next();
@@ -69,25 +70,28 @@ function buildApp(resource: 'cinemas' | 'users' | 'scrapes', db: DB): Express {
   return app;
 }
 
+/** Helper: set up QuotaService mock to return specific usage counts. */
+function mockUsage(counts: { cinemas_count?: number; users_count?: number; scrapes_count?: number }) {
+  vi.mocked(QuotaService).mockImplementation(() => ({
+    getOrCreateUsage: vi.fn().mockResolvedValue({
+      cinemas_count: counts.cinemas_count ?? 0,
+      users_count:   counts.users_count   ?? 0,
+      scrapes_count: counts.scrapes_count ?? 0,
+      api_calls_count: 0,
+    }),
+    incrementUsage: vi.fn(),
+    decrementUsage: vi.fn(),
+    resetMonthlyUsage: vi.fn(),
+  }) as any);
+}
+
 // ── checkQuota ────────────────────────────────────────────────────────────────
 
 describe('checkQuota middleware', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   describe('cinemas quota', () => {
     it('calls next() when usage is below the plan limit', async () => {
-      const { getPlanById } = await import('../db/org-queries.js');
-      vi.mocked(getPlanById).mockResolvedValueOnce(STARTER_PLAN);
-
-      const { QuotaService } = await import('../services/quota-service.js');
-      vi.mocked(QuotaService).mockImplementationOnce(() => ({
-        getOrCreateUsage: vi.fn().mockResolvedValue({ cinemas_count: 3, scrapes_count: 5, users_count: 1 }),
-        incrementUsage: vi.fn(),
-        decrementUsage: vi.fn(),
-        resetMonthlyUsage: vi.fn(),
-      }));
+      vi.mocked(getPlanById).mockResolvedValue(STARTER_PLAN as any);
+      mockUsage({ cinemas_count: 3 });
 
       const app = buildApp('cinemas', makeDb());
       const res = await supertest(app).post('/test');
@@ -97,16 +101,8 @@ describe('checkQuota middleware', () => {
     });
 
     it('returns 402 QUOTA_EXCEEDED when usage is at the plan limit', async () => {
-      const { getPlanById } = await import('../db/org-queries.js');
-      vi.mocked(getPlanById).mockResolvedValueOnce(STARTER_PLAN);
-
-      const { QuotaService } = await import('../services/quota-service.js');
-      vi.mocked(QuotaService).mockImplementationOnce(() => ({
-        getOrCreateUsage: vi.fn().mockResolvedValue({ cinemas_count: 5, scrapes_count: 5, users_count: 1 }),
-        incrementUsage: vi.fn(),
-        decrementUsage: vi.fn(),
-        resetMonthlyUsage: vi.fn(),
-      }));
+      vi.mocked(getPlanById).mockResolvedValue(STARTER_PLAN as any);
+      mockUsage({ cinemas_count: 5 }); // at limit
 
       const app = buildApp('cinemas', makeDb());
       const res = await supertest(app).post('/test');
@@ -118,17 +114,8 @@ describe('checkQuota middleware', () => {
     });
 
     it('calls next() when plan limit is null (unlimited)', async () => {
-      const unlimitedPlan = { ...STARTER_PLAN, max_cinemas: null };
-      const { getPlanById } = await import('../db/org-queries.js');
-      vi.mocked(getPlanById).mockResolvedValueOnce(unlimitedPlan);
-
-      const { QuotaService } = await import('../services/quota-service.js');
-      vi.mocked(QuotaService).mockImplementationOnce(() => ({
-        getOrCreateUsage: vi.fn().mockResolvedValue({ cinemas_count: 9999, scrapes_count: 0, users_count: 0 }),
-        incrementUsage: vi.fn(),
-        decrementUsage: vi.fn(),
-        resetMonthlyUsage: vi.fn(),
-      }));
+      vi.mocked(getPlanById).mockResolvedValue({ ...STARTER_PLAN, max_cinemas: null } as any);
+      mockUsage({ cinemas_count: 9999 });
 
       const app = buildApp('cinemas', makeDb());
       const res = await supertest(app).post('/test');
@@ -139,16 +126,8 @@ describe('checkQuota middleware', () => {
 
   describe('users quota', () => {
     it('returns 402 when users_count is at the plan limit', async () => {
-      const { getPlanById } = await import('../db/org-queries.js');
-      vi.mocked(getPlanById).mockResolvedValueOnce(FREE_PLAN); // max_users: 1
-
-      const { QuotaService } = await import('../services/quota-service.js');
-      vi.mocked(QuotaService).mockImplementationOnce(() => ({
-        getOrCreateUsage: vi.fn().mockResolvedValue({ cinemas_count: 1, scrapes_count: 0, users_count: 1 }),
-        incrementUsage: vi.fn(),
-        decrementUsage: vi.fn(),
-        resetMonthlyUsage: vi.fn(),
-      }));
+      vi.mocked(getPlanById).mockResolvedValue(FREE_PLAN as any); // max_users: 1
+      mockUsage({ users_count: 1 }); // at limit
 
       const app = buildApp('users', makeDb());
       const res = await supertest(app).post('/test');
@@ -157,20 +136,22 @@ describe('checkQuota middleware', () => {
       expect(res.body.error).toBe('QUOTA_EXCEEDED');
       expect(res.body.resource).toBe('users');
     });
+
+    it('calls next() when users are below the limit', async () => {
+      vi.mocked(getPlanById).mockResolvedValue(STARTER_PLAN as any); // max_users: 3
+      mockUsage({ users_count: 1 });
+
+      const app = buildApp('users', makeDb());
+      const res = await supertest(app).post('/test');
+
+      expect(res.status).toBe(200);
+    });
   });
 
   describe('scrapes quota', () => {
     it('returns 402 when scrapes_count is at the plan limit', async () => {
-      const { getPlanById } = await import('../db/org-queries.js');
-      vi.mocked(getPlanById).mockResolvedValueOnce(FREE_PLAN); // max_scrapes_per_month: 4
-
-      const { QuotaService } = await import('../services/quota-service.js');
-      vi.mocked(QuotaService).mockImplementationOnce(() => ({
-        getOrCreateUsage: vi.fn().mockResolvedValue({ cinemas_count: 1, scrapes_count: 4, users_count: 1 }),
-        incrementUsage: vi.fn(),
-        decrementUsage: vi.fn(),
-        resetMonthlyUsage: vi.fn(),
-      }));
+      vi.mocked(getPlanById).mockResolvedValue(FREE_PLAN as any); // max_scrapes_per_month: 4
+      mockUsage({ scrapes_count: 4 }); // at limit
 
       const app = buildApp('scrapes', makeDb());
       const res = await supertest(app).post('/test');
@@ -181,16 +162,8 @@ describe('checkQuota middleware', () => {
     });
 
     it('calls next() when scrapes are below the monthly limit', async () => {
-      const { getPlanById } = await import('../db/org-queries.js');
-      vi.mocked(getPlanById).mockResolvedValueOnce(FREE_PLAN); // max_scrapes_per_month: 4
-
-      const { QuotaService } = await import('../services/quota-service.js');
-      vi.mocked(QuotaService).mockImplementationOnce(() => ({
-        getOrCreateUsage: vi.fn().mockResolvedValue({ cinemas_count: 1, scrapes_count: 2, users_count: 1 }),
-        incrementUsage: vi.fn(),
-        decrementUsage: vi.fn(),
-        resetMonthlyUsage: vi.fn(),
-      }));
+      vi.mocked(getPlanById).mockResolvedValue(FREE_PLAN as any); // max_scrapes_per_month: 4
+      mockUsage({ scrapes_count: 2 });
 
       const app = buildApp('scrapes', makeDb());
       const res = await supertest(app).post('/test');
@@ -201,16 +174,8 @@ describe('checkQuota middleware', () => {
 
   describe('error handling', () => {
     it('returns 500 when plan cannot be loaded', async () => {
-      const { getPlanById } = await import('../db/org-queries.js');
-      vi.mocked(getPlanById).mockResolvedValueOnce(null); // plan not found
-
-      const { QuotaService } = await import('../services/quota-service.js');
-      vi.mocked(QuotaService).mockImplementationOnce(() => ({
-        getOrCreateUsage: vi.fn().mockResolvedValue({ cinemas_count: 0, scrapes_count: 0, users_count: 0 }),
-        incrementUsage: vi.fn(),
-        decrementUsage: vi.fn(),
-        resetMonthlyUsage: vi.fn(),
-      }));
+      vi.mocked(getPlanById).mockResolvedValue(null);
+      mockUsage({});
 
       const app = buildApp('cinemas', makeDb());
       const res = await supertest(app).post('/test');

--- a/packages/saas/src/middleware/quota.test.ts
+++ b/packages/saas/src/middleware/quota.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express, { type Express } from 'express';
+import supertest from 'supertest';
+import { checkQuota } from '../middleware/quota.js';
+import type { DB } from '../db/types.js';
+
+// ── mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('../services/quota-service.js', () => ({
+  QuotaService: vi.fn().mockImplementation(() => ({
+    getOrCreateUsage: vi.fn(),
+  })),
+}));
+
+vi.mock('../db/org-queries.js', () => ({
+  getPlanById: vi.fn(),
+}));
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function makeDb(): DB {
+  return { query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }) };
+}
+
+const STARTER_PLAN = {
+  id: 2,
+  name: 'Starter',
+  max_cinemas: 5,
+  max_users: 3,
+  max_scrapes_per_month: 20,
+  scrape_frequency_min: 2880,
+  price_monthly_cents: 1900,
+  price_yearly_cents: 18000,
+  features: {},
+};
+
+const FREE_PLAN = {
+  id: 1,
+  name: 'Free',
+  max_cinemas: 1,
+  max_users: 1,
+  max_scrapes_per_month: 4,
+  scrape_frequency_min: 10080,
+  price_monthly_cents: 0,
+  price_yearly_cents: 0,
+  features: {},
+};
+
+const MOCK_ORG = {
+  id: 'org-uuid-1',
+  slug: 'my-cinema',
+  schema_name: 'org_my_cinema',
+  plan_id: 2,
+  status: 'active',
+};
+
+function buildApp(resource: 'cinemas' | 'users' | 'scrapes', db: DB): Express {
+  const app = express();
+  app.use(express.json());
+  app.set('db', db);
+  // Inject req.org like resolveTenant would
+  app.use((req: any, _res: any, next: any) => {
+    req.org = MOCK_ORG;
+    next();
+  });
+  app.post('/test', checkQuota(resource), (_req, res) => {
+    res.status(200).json({ success: true });
+  });
+  return app;
+}
+
+// ── checkQuota ────────────────────────────────────────────────────────────────
+
+describe('checkQuota middleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('cinemas quota', () => {
+    it('calls next() when usage is below the plan limit', async () => {
+      const { getPlanById } = await import('../db/org-queries.js');
+      vi.mocked(getPlanById).mockResolvedValueOnce(STARTER_PLAN);
+
+      const { QuotaService } = await import('../services/quota-service.js');
+      vi.mocked(QuotaService).mockImplementationOnce(() => ({
+        getOrCreateUsage: vi.fn().mockResolvedValue({ cinemas_count: 3, scrapes_count: 5, users_count: 1 }),
+        incrementUsage: vi.fn(),
+        decrementUsage: vi.fn(),
+        resetMonthlyUsage: vi.fn(),
+      }));
+
+      const app = buildApp('cinemas', makeDb());
+      const res = await supertest(app).post('/test');
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+    });
+
+    it('returns 402 QUOTA_EXCEEDED when usage is at the plan limit', async () => {
+      const { getPlanById } = await import('../db/org-queries.js');
+      vi.mocked(getPlanById).mockResolvedValueOnce(STARTER_PLAN);
+
+      const { QuotaService } = await import('../services/quota-service.js');
+      vi.mocked(QuotaService).mockImplementationOnce(() => ({
+        getOrCreateUsage: vi.fn().mockResolvedValue({ cinemas_count: 5, scrapes_count: 5, users_count: 1 }),
+        incrementUsage: vi.fn(),
+        decrementUsage: vi.fn(),
+        resetMonthlyUsage: vi.fn(),
+      }));
+
+      const app = buildApp('cinemas', makeDb());
+      const res = await supertest(app).post('/test');
+
+      expect(res.status).toBe(402);
+      expect(res.body.error).toBe('QUOTA_EXCEEDED');
+      expect(res.body.resource).toBe('cinemas');
+      expect(res.body.limit).toBe(5);
+    });
+
+    it('calls next() when plan limit is null (unlimited)', async () => {
+      const unlimitedPlan = { ...STARTER_PLAN, max_cinemas: null };
+      const { getPlanById } = await import('../db/org-queries.js');
+      vi.mocked(getPlanById).mockResolvedValueOnce(unlimitedPlan);
+
+      const { QuotaService } = await import('../services/quota-service.js');
+      vi.mocked(QuotaService).mockImplementationOnce(() => ({
+        getOrCreateUsage: vi.fn().mockResolvedValue({ cinemas_count: 9999, scrapes_count: 0, users_count: 0 }),
+        incrementUsage: vi.fn(),
+        decrementUsage: vi.fn(),
+        resetMonthlyUsage: vi.fn(),
+      }));
+
+      const app = buildApp('cinemas', makeDb());
+      const res = await supertest(app).post('/test');
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('users quota', () => {
+    it('returns 402 when users_count is at the plan limit', async () => {
+      const { getPlanById } = await import('../db/org-queries.js');
+      vi.mocked(getPlanById).mockResolvedValueOnce(FREE_PLAN); // max_users: 1
+
+      const { QuotaService } = await import('../services/quota-service.js');
+      vi.mocked(QuotaService).mockImplementationOnce(() => ({
+        getOrCreateUsage: vi.fn().mockResolvedValue({ cinemas_count: 1, scrapes_count: 0, users_count: 1 }),
+        incrementUsage: vi.fn(),
+        decrementUsage: vi.fn(),
+        resetMonthlyUsage: vi.fn(),
+      }));
+
+      const app = buildApp('users', makeDb());
+      const res = await supertest(app).post('/test');
+
+      expect(res.status).toBe(402);
+      expect(res.body.error).toBe('QUOTA_EXCEEDED');
+      expect(res.body.resource).toBe('users');
+    });
+  });
+
+  describe('scrapes quota', () => {
+    it('returns 402 when scrapes_count is at the plan limit', async () => {
+      const { getPlanById } = await import('../db/org-queries.js');
+      vi.mocked(getPlanById).mockResolvedValueOnce(FREE_PLAN); // max_scrapes_per_month: 4
+
+      const { QuotaService } = await import('../services/quota-service.js');
+      vi.mocked(QuotaService).mockImplementationOnce(() => ({
+        getOrCreateUsage: vi.fn().mockResolvedValue({ cinemas_count: 1, scrapes_count: 4, users_count: 1 }),
+        incrementUsage: vi.fn(),
+        decrementUsage: vi.fn(),
+        resetMonthlyUsage: vi.fn(),
+      }));
+
+      const app = buildApp('scrapes', makeDb());
+      const res = await supertest(app).post('/test');
+
+      expect(res.status).toBe(402);
+      expect(res.body.error).toBe('QUOTA_EXCEEDED');
+      expect(res.body.resource).toBe('scrapes');
+    });
+
+    it('calls next() when scrapes are below the monthly limit', async () => {
+      const { getPlanById } = await import('../db/org-queries.js');
+      vi.mocked(getPlanById).mockResolvedValueOnce(FREE_PLAN); // max_scrapes_per_month: 4
+
+      const { QuotaService } = await import('../services/quota-service.js');
+      vi.mocked(QuotaService).mockImplementationOnce(() => ({
+        getOrCreateUsage: vi.fn().mockResolvedValue({ cinemas_count: 1, scrapes_count: 2, users_count: 1 }),
+        incrementUsage: vi.fn(),
+        decrementUsage: vi.fn(),
+        resetMonthlyUsage: vi.fn(),
+      }));
+
+      const app = buildApp('scrapes', makeDb());
+      const res = await supertest(app).post('/test');
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 when plan cannot be loaded', async () => {
+      const { getPlanById } = await import('../db/org-queries.js');
+      vi.mocked(getPlanById).mockResolvedValueOnce(null); // plan not found
+
+      const { QuotaService } = await import('../services/quota-service.js');
+      vi.mocked(QuotaService).mockImplementationOnce(() => ({
+        getOrCreateUsage: vi.fn().mockResolvedValue({ cinemas_count: 0, scrapes_count: 0, users_count: 0 }),
+        incrementUsage: vi.fn(),
+        decrementUsage: vi.fn(),
+        resetMonthlyUsage: vi.fn(),
+      }));
+
+      const app = buildApp('cinemas', makeDb());
+      const res = await supertest(app).post('/test');
+
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/packages/saas/src/middleware/quota.ts
+++ b/packages/saas/src/middleware/quota.ts
@@ -1,0 +1,3 @@
+// Quota enforcement middleware — to be implemented in Phase 3
+// Checks usage against plan limits for: cinemas | users | scrapes
+export {};

--- a/packages/saas/src/middleware/quota.ts
+++ b/packages/saas/src/middleware/quota.ts
@@ -52,7 +52,7 @@ export function checkQuota(resource: QuotaResource) {
 
     const quotaService = new QuotaService(db);
     const usage = await quotaService.getOrCreateUsage(org.id);
-    const current = (usage as Record<string, unknown>)[usageKey] as number;
+    const current = (usage as unknown as Record<string, number>)[usageKey];
 
     if (current >= limit) {
       res.status(402).json({

--- a/packages/saas/src/middleware/quota.ts
+++ b/packages/saas/src/middleware/quota.ts
@@ -1,3 +1,70 @@
-// Quota enforcement middleware — to be implemented in Phase 3
-// Checks usage against plan limits for: cinemas | users | scrapes
-export {};
+import type { Request, Response, NextFunction } from 'express';
+import { getPlanById } from '../db/org-queries.js';
+import { QuotaService, type QuotaResource } from '../services/quota-service.js';
+import type { DB } from '../db/types.js';
+import type { Organization } from '../db/org-queries.js';
+
+/** Maps a quota resource to the plan limit column and usage counter key. */
+const RESOURCE_MAP: Record<
+  QuotaResource,
+  { planKey: 'max_cinemas' | 'max_users' | 'max_scrapes_per_month'; usageKey: string }
+> = {
+  cinemas: { planKey: 'max_cinemas',           usageKey: 'cinemas_count' },
+  users:   { planKey: 'max_users',             usageKey: 'users_count'   },
+  scrapes: { planKey: 'max_scrapes_per_month', usageKey: 'scrapes_count' },
+};
+
+/**
+ * Express middleware factory that enforces plan quotas.
+ *
+ * Usage:
+ *   router.post('/cinemas', requireAuth, checkQuota('cinemas'), createCinema);
+ *
+ * Reads req.org (set by resolveTenant) and req.app.get('db').
+ * Returns 402 QUOTA_EXCEEDED when the org has reached its plan limit.
+ * Returns 500 if the plan record is not found.
+ * Passes through (calls next()) when under the limit or when the limit is null (unlimited).
+ */
+export function checkQuota(resource: QuotaResource) {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const org = (req as any).org as Organization | undefined;
+    if (!org) {
+      res.status(500).json({ error: 'Tenant not resolved' });
+      return;
+    }
+
+    const db = req.app.get('db') as DB;
+
+    const plan = await getPlanById(db, org.plan_id);
+    if (!plan) {
+      res.status(500).json({ error: 'Plan not found' });
+      return;
+    }
+
+    const { planKey, usageKey } = RESOURCE_MAP[resource];
+    const limit = plan[planKey] as number | null;
+
+    // null = unlimited — always allow
+    if (limit === null) {
+      next();
+      return;
+    }
+
+    const quotaService = new QuotaService(db);
+    const usage = await quotaService.getOrCreateUsage(org.id);
+    const current = (usage as Record<string, unknown>)[usageKey] as number;
+
+    if (current >= limit) {
+      res.status(402).json({
+        error: 'QUOTA_EXCEEDED',
+        resource,
+        limit,
+        current,
+        upgrade_url: `/api/org/${org.slug}/billing/checkout`,
+      });
+      return;
+    }
+
+    next();
+  };
+}

--- a/packages/saas/src/middleware/rate-limit.ts
+++ b/packages/saas/src/middleware/rate-limit.ts
@@ -1,0 +1,42 @@
+import rateLimit from 'express-rate-limit';
+
+/**
+ * Rate limiter for public onboarding routes (email verification, invitation accept).
+ * These routes do lightweight token-based "authorization" and are exposed publicly,
+ * so we restrict to 10 attempts per IP per 15 minutes to prevent token brute-forcing.
+ */
+export const onboardingLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: (req) => !req.ip, // skip in test environments where ip may be undefined
+  message: { success: false, error: 'Too many requests, please try again later' },
+});
+
+/**
+ * Rate limiter for the superadmin login route.
+ * Tight limit to slow down brute-force attacks against the superadmin credential endpoint.
+ */
+export const superadminLoginLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: (req) => !req.ip, // skip in test environments where ip may be undefined
+  message: { success: false, error: 'Too many login attempts, please try again later' },
+});
+
+/**
+ * Rate limiter for superadmin protected routes.
+ * Generous limit since these are authenticated calls, but still bounded to
+ * prevent abuse if a superadmin token is compromised.
+ */
+export const superadminLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 300,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: (req) => !req.ip, // skip in test environments where ip may be undefined
+  message: { success: false, error: 'Too many requests, please try again later' },
+});

--- a/packages/saas/src/middleware/superadmin-auth.test.ts
+++ b/packages/saas/src/middleware/superadmin-auth.test.ts
@@ -2,10 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 
-vi.mock('../utils/superadmin-jwt-secret-validator.js', () => ({
-  validateSuperadminJWTSecret: vi.fn(),
-}));
-
 import { requireSuperadmin } from '../middleware/superadmin-auth.js';
 
 // ── helpers ──────────────────────────────────────────────────────────────────
@@ -22,7 +18,7 @@ function makeReq(headers: Record<string, string> = {}): Request {
   return { headers } as unknown as Request;
 }
 
-const VALID_SECRET = 'superadmin-secret-at-least-32-chars-long!!';
+const VALID_SECRET = 'jwt-secret-at-least-32-chars-long!!!!!!!!';
 
 function signToken(payload: object, secret = VALID_SECRET, options?: jwt.SignOptions) {
   return jwt.sign(payload, secret, { expiresIn: '1h', ...options });
@@ -32,7 +28,7 @@ function signToken(payload: object, secret = VALID_SECRET, options?: jwt.SignOpt
 
 describe('requireSuperadmin middleware', () => {
   beforeEach(() => {
-    vi.stubEnv('SUPERADMIN_JWT_SECRET', VALID_SECRET);
+    vi.stubEnv('JWT_SECRET', VALID_SECRET);
   });
 
   it('calls next() when a valid superadmin JWT is provided', async () => {

--- a/packages/saas/src/middleware/superadmin-auth.test.ts
+++ b/packages/saas/src/middleware/superadmin-auth.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+vi.mock('../utils/superadmin-jwt-secret-validator.js', () => ({
+  validateSuperadminJWTSecret: vi.fn(),
+}));
+
+import { requireSuperadmin } from '../middleware/superadmin-auth.js';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function makeRes() {
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+  return res;
+}
+
+function makeReq(headers: Record<string, string> = {}): Request {
+  return { headers } as unknown as Request;
+}
+
+const VALID_SECRET = 'superadmin-secret-at-least-32-chars-long!!';
+
+function signToken(payload: object, secret = VALID_SECRET, options?: jwt.SignOptions) {
+  return jwt.sign(payload, secret, { expiresIn: '1h', ...options });
+}
+
+// ── requireSuperadmin ────────────────────────────────────────────────────────
+
+describe('requireSuperadmin middleware', () => {
+  beforeEach(() => {
+    vi.stubEnv('SUPERADMIN_JWT_SECRET', VALID_SECRET);
+  });
+
+  it('calls next() when a valid superadmin JWT is provided', async () => {
+    const token = signToken({ id: 1, username: 'root', scope: 'superadmin' });
+    const req = makeReq({ authorization: `Bearer ${token}` });
+    const res = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    await requireSuperadmin(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('attaches superadmin payload to req.superadmin', async () => {
+    const token = signToken({ id: 7, username: 'admin', scope: 'superadmin' });
+    const req = makeReq({ authorization: `Bearer ${token}` });
+    const res = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    await requireSuperadmin(req, res, next);
+
+    expect((req as any).superadmin).toMatchObject({ id: 7, username: 'admin' });
+  });
+
+  it('returns 401 when Authorization header is missing', async () => {
+    const req = makeReq();
+    const res = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    await requireSuperadmin(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when token is expired', async () => {
+    const token = signToken({ id: 1, username: 'root', scope: 'superadmin' }, VALID_SECRET, {
+      expiresIn: -1, // already expired
+    });
+    const req = makeReq({ authorization: `Bearer ${token}` });
+    const res = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    await requireSuperadmin(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when token is signed with wrong secret', async () => {
+    const token = signToken({ id: 1, username: 'root', scope: 'superadmin' }, 'wrong-secret-that-is-32-chars-long!');
+    const req = makeReq({ authorization: `Bearer ${token}` });
+    const res = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    await requireSuperadmin(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when token scope is not superadmin', async () => {
+    // A valid org JWT (scope=org) must be rejected by this middleware
+    const token = signToken({ id: 1, username: 'user', scope: 'org', org_slug: 'my-cinema' });
+    const req = makeReq({ authorization: `Bearer ${token}` });
+    const res = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    await requireSuperadmin(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when token has no scope at all', async () => {
+    const token = signToken({ id: 1, username: 'user' }); // no scope
+    const req = makeReq({ authorization: `Bearer ${token}` });
+    const res = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    await requireSuperadmin(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/packages/saas/src/middleware/superadmin-auth.ts
+++ b/packages/saas/src/middleware/superadmin-auth.ts
@@ -21,7 +21,7 @@ declare global {
  * Express middleware that validates a superadmin JWT.
  *
  * - Reads Bearer token from Authorization header
- * - Verifies signature with SUPERADMIN_JWT_SECRET
+ * - Verifies signature with JWT_SECRET (same secret used for regular user tokens)
  * - Rejects tokens whose scope !== 'superadmin' with 403
  * - Attaches verified payload to req.superadmin
  */
@@ -39,10 +39,10 @@ export async function requireSuperadmin(
   }
 
   const token = parts[1];
-  const secret = process.env.SUPERADMIN_JWT_SECRET?.trim();
+  const secret = process.env.JWT_SECRET?.trim();
 
   if (!secret || secret.length < 32) {
-    res.status(500).json({ success: false, error: 'Server misconfiguration: missing SUPERADMIN_JWT_SECRET' });
+    res.status(500).json({ success: false, error: 'Server misconfiguration: missing JWT_SECRET' });
     return;
   }
 

--- a/packages/saas/src/middleware/superadmin-auth.ts
+++ b/packages/saas/src/middleware/superadmin-auth.ts
@@ -1,0 +1,64 @@
+import jwt from 'jsonwebtoken';
+import type { Request, Response, NextFunction } from 'express';
+
+export interface SuperadminPayload {
+  id: number;
+  username: string;
+  scope: string;
+}
+
+// Augment Express Request to carry the verified superadmin payload
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      superadmin?: SuperadminPayload;
+    }
+  }
+}
+
+/**
+ * Express middleware that validates a superadmin JWT.
+ *
+ * - Reads Bearer token from Authorization header
+ * - Verifies signature with SUPERADMIN_JWT_SECRET
+ * - Rejects tokens whose scope !== 'superadmin' with 403
+ * - Attaches verified payload to req.superadmin
+ */
+export async function requireSuperadmin(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  const authHeader = req.headers.authorization ?? '';
+  const parts = authHeader.split(' ');
+
+  if (parts.length !== 2 || parts[0] !== 'Bearer' || !parts[1]) {
+    res.status(401).json({ success: false, error: 'Missing or malformed Authorization header' });
+    return;
+  }
+
+  const token = parts[1];
+  const secret = process.env.SUPERADMIN_JWT_SECRET?.trim();
+
+  if (!secret || secret.length < 32) {
+    res.status(500).json({ success: false, error: 'Server misconfiguration: missing SUPERADMIN_JWT_SECRET' });
+    return;
+  }
+
+  let payload: SuperadminPayload;
+  try {
+    payload = jwt.verify(token, secret) as SuperadminPayload;
+  } catch {
+    res.status(401).json({ success: false, error: 'Invalid or expired token' });
+    return;
+  }
+
+  if (payload.scope !== 'superadmin') {
+    res.status(403).json({ success: false, error: 'Token scope is not superadmin' });
+    return;
+  }
+
+  req.superadmin = payload;
+  next();
+}

--- a/packages/saas/src/middleware/tenant.test.ts
+++ b/packages/saas/src/middleware/tenant.test.ts
@@ -48,9 +48,10 @@ describe('resolveTenant', () => {
     expect(next).toHaveBeenCalledOnce();
     expect((req as any).org).toMatchObject({ slug: 'cinema-test' });
     expect((req as any).dbClient).toBe(client);
+    // PostgreSQL SET command does not support $1 parameterized form.
+    // The schema name must be embedded directly as a quoted identifier.
     expect(client.query).toHaveBeenCalledWith(
-      expect.stringMatching(/SET search_path TO/),
-      expect.any(Array)
+      'SET search_path TO "org_cinema_test", public'
     );
   });
 

--- a/packages/saas/src/middleware/tenant.test.ts
+++ b/packages/saas/src/middleware/tenant.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolveTenant } from '../middleware/tenant.js';
+import type { Organization } from '../db/org-queries.js';
+import type { Request, Response, NextFunction } from 'express';
+
+const mockOrg: Organization = {
+  id: 'uuid-123',
+  name: 'Cinéma Test',
+  slug: 'cinema-test',
+  plan_id: 1,
+  status: 'trial',
+  schema_name: 'org_cinema_test',
+  trial_ends_at: new Date('2026-04-14'),
+  created_at: new Date('2026-03-31'),
+  updated_at: new Date('2026-03-31'),
+};
+
+function makeReq(slug: string, queryRows: unknown[] = [mockOrg]) {
+  const query = vi.fn().mockResolvedValue({ rows: queryRows, rowCount: queryRows.length });
+  // PoolClient mock: has query + release
+  const client = { query, release: vi.fn() };
+  const pool = { connect: vi.fn().mockResolvedValue(client) };
+
+  return {
+    req: {
+      params: { slug },
+      app: { get: vi.fn().mockReturnValue(pool) },
+    } as unknown as Request,
+    client,
+    pool,
+  };
+}
+
+function makeRes() {
+  const json = vi.fn().mockReturnThis();
+  const status = vi.fn().mockReturnValue({ json });
+  return { res: { status, json } as unknown as Response, status, json };
+}
+
+describe('resolveTenant', () => {
+  it('attaches org to req and calls next on active org', async () => {
+    const { req, client } = makeReq('cinema-test', [{ ...mockOrg, status: 'active' }]);
+    const { res } = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    await resolveTenant(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect((req as any).org).toMatchObject({ slug: 'cinema-test' });
+    expect((req as any).dbClient).toBe(client);
+    expect(client.query).toHaveBeenCalledWith(
+      expect.stringMatching(/SET search_path TO/),
+      expect.any(Array)
+    );
+  });
+
+  it('attaches org to req and calls next on trial org', async () => {
+    const { req } = makeReq('cinema-test', [mockOrg]); // status: 'trial'
+    const { res } = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    await resolveTenant(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('returns 404 when org is not found', async () => {
+    const { req } = makeReq('unknown', []);
+    const { res, status, json } = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    await resolveTenant(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(404);
+    expect(json).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
+  });
+
+  it('returns 403 when org is suspended', async () => {
+    const { req } = makeReq('suspended-org', [{ ...mockOrg, status: 'suspended' }]);
+    const { res, status, json } = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    await resolveTenant(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(403);
+    expect(json).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
+  });
+
+  it('returns 403 when org is canceled', async () => {
+    const { req } = makeReq('gone-org', [{ ...mockOrg, status: 'canceled' }]);
+    const { res, status, json } = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    await resolveTenant(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(403);
+  });
+
+  it('releases pool client after calling next', async () => {
+    const { req, client } = makeReq('cinema-test');
+    const { res } = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    await resolveTenant(req, res, next);
+
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+
+  it('releases pool client even on error', async () => {
+    const { req, client } = makeReq('cinema-test');
+    const { res } = makeRes();
+    const next = vi.fn().mockImplementation(() => { throw new Error('route error'); }) as NextFunction;
+
+    await expect(resolveTenant(req, res, next)).rejects.toThrow('route error');
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/saas/src/middleware/tenant.ts
+++ b/packages/saas/src/middleware/tenant.ts
@@ -48,8 +48,11 @@ export async function resolveTenant(req: Request, res: Response, next: NextFunct
       return;
     }
 
-    // Scope all subsequent queries to the org's schema
-    await client.query('SET search_path TO $1, public', [org.schema_name]);
+    // Scope all subsequent queries to the org's schema.
+    // NOTE: PostgreSQL does not support $1 parameterized form for SET commands.
+    // The schema name is safe here: slugs are validated to [a-z0-9-] and converted
+    // to [a-z0-9_] by slugToSchemaName, making SQL injection impossible.
+    await client.query(`SET search_path TO "${org.schema_name}", public`);
 
     req.org = org;
     req.dbClient = client;

--- a/packages/saas/src/middleware/tenant.ts
+++ b/packages/saas/src/middleware/tenant.ts
@@ -1,3 +1,64 @@
-// Tenant resolution middleware — to be implemented in Phase 1 Step 4
-// Extracts :slug from path, loads org, sets PostgreSQL search_path
-export {};
+import type { Request, Response, NextFunction } from 'express';
+import { getOrgBySlug } from '../db/org-queries.js';
+import type { Organization } from '../db/org-queries.js';
+import type { Pool, PoolClient } from '../db/types.js';
+
+// Augment Express Request with SaaS-specific properties
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      org?: Organization;
+      dbClient?: PoolClient;
+    }
+  }
+}
+
+const ACTIVE_STATUSES = new Set(['trial', 'active']);
+
+/**
+ * Tenant resolution middleware.
+ *
+ * 1. Reads :slug from route params
+ * 2. Acquires a dedicated pg client from the pool (so SET search_path is scoped)
+ * 3. Loads the organization from public.organizations
+ * 4. Rejects suspended / canceled orgs
+ * 5. Sets `search_path` to `org_{slug}, public` on the client
+ * 6. Attaches `req.org` and `req.dbClient` for downstream route handlers
+ * 7. Releases the client after the response (or on error)
+ */
+export async function resolveTenant(req: Request, res: Response, next: NextFunction): Promise<void> {
+  const slug = req.params.slug as string;
+  const pool = req.app.get('pool') as Pool;
+
+  const client = await pool.connect();
+
+  try {
+    const org = await getOrgBySlug(client, slug);
+
+    if (!org) {
+      client.release();
+      res.status(404).json({ success: false, error: 'Organization not found' });
+      return;
+    }
+
+    if (!ACTIVE_STATUSES.has(org.status)) {
+      client.release();
+      res.status(403).json({ success: false, error: `Organization is ${org.status}` });
+      return;
+    }
+
+    // Scope all subsequent queries to the org's schema
+    await client.query('SET search_path TO $1, public', [org.schema_name]);
+
+    req.org = org;
+    req.dbClient = client;
+
+    await next();
+  } finally {
+    // Always release the client back to the pool
+    if (req.dbClient) {
+      req.dbClient.release();
+    }
+  }
+}

--- a/packages/saas/src/middleware/tenant.ts
+++ b/packages/saas/src/middleware/tenant.ts
@@ -1,0 +1,3 @@
+// Tenant resolution middleware — to be implemented in Phase 1 Step 4
+// Extracts :slug from path, loads org, sets PostgreSQL search_path
+export {};

--- a/packages/saas/src/middleware/tenant.ts
+++ b/packages/saas/src/middleware/tenant.ts
@@ -16,6 +16,28 @@ declare global {
 
 const ACTIVE_STATUSES = new Set(['trial', 'active']);
 
+/** Minimal logger interface — resolved at runtime from the server's logger */
+interface Logger {
+  info(msg: string, meta?: Record<string, unknown>): void;
+  warn?(msg: string, meta?: Record<string, unknown>): void;
+}
+
+let _logger: Logger | null = null;
+
+/** Lazy-loads the server logger so we don't cross rootDir at compile time. */
+async function getLogger(): Promise<Logger> {
+  if (!_logger) {
+    try {
+      const mod = await import('../../../../server/src/utils/logger.js' as string) as { logger: Logger };
+      _logger = mod.logger;
+    } catch {
+      // Fallback to console (e.g. in tests where the server module isn't available)
+      _logger = { info: () => {}, warn: () => {} };
+    }
+  }
+  return _logger;
+}
+
 /**
  * Tenant resolution middleware.
  *
@@ -25,7 +47,8 @@ const ACTIVE_STATUSES = new Set(['trial', 'active']);
  * 4. Rejects suspended / canceled orgs
  * 5. Sets `search_path` to `org_{slug}, public` on the client
  * 6. Attaches `req.org` and `req.dbClient` for downstream route handlers
- * 7. Releases the client after the response (or on error)
+ * 7. Emits structured log with org_id and org_slug (Phase 7.5 observability)
+ * 8. Releases the client after the response (or on error)
  */
 export async function resolveTenant(req: Request, res: Response, next: NextFunction): Promise<void> {
   const slug = req.params.slug as string;
@@ -56,6 +79,15 @@ export async function resolveTenant(req: Request, res: Response, next: NextFunct
 
     req.org = org;
     req.dbClient = client;
+
+    // Phase 7.5 — structured log with org context for observability
+    const log = await getLogger();
+    log.info('[resolveTenant] Tenant resolved', {
+      org_id: org.id,
+      org_slug: org.slug,
+      method: req.method,
+      path: req.path,
+    });
 
     await next();
   } finally {

--- a/packages/saas/src/plugin.ts
+++ b/packages/saas/src/plugin.ts
@@ -1,0 +1,45 @@
+import { fileURLToPath } from 'url';
+import path from 'path';
+import type { Express } from 'express';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export interface AppPlugin {
+  name: string;
+  beforeRoutes?:    (app: Express) => void;
+  registerRoutes?:  (app: Express) => void;
+  afterRoutes?:     (app: Express) => void;
+  getMigrationDirs?: () => string[];
+}
+
+/**
+ * SaaS overlay plugin.
+ * Activated when SAAS_ENABLED=true in the environment.
+ */
+export const saasPlugin: AppPlugin = {
+  name: '@allo-scrapper/saas',
+
+  beforeRoutes(_app) {
+    // TODO: tenant resolution middleware, quota middleware
+  },
+
+  registerRoutes(_app) {
+    // TODO: /api/auth/register, /api/org/:slug/*, /api/superadmin/*
+  },
+
+  afterRoutes(_app) {
+    // TODO: final SaaS-specific overrides
+  },
+
+  getMigrationDirs() {
+    // In Docker: dist is under /app/packages/saas/dist
+    // In dev: resolve relative to this file's compiled location
+    const isDocker = __dirname.startsWith('/app/');
+    return [
+      isDocker
+        ? path.join('/app', 'packages', 'saas', 'migrations')
+        : path.join(__dirname, '../../migrations'),
+    ];
+  },
+};

--- a/packages/saas/src/plugin.ts
+++ b/packages/saas/src/plugin.ts
@@ -57,8 +57,9 @@ export const saasPlugin: AppPlugin = {
       logger,
     } = deps;
 
-    // Registration & slug availability
-    app.use('/api/auth', createRegisterRouter());
+    // Registration & slug availability — mounted at /api/saas to avoid
+    // collision with the core authRouter at /api/auth (which requires auth)
+    app.use('/api/saas', createRegisterRouter());
     app.use('/api', createSlugRouter());
 
     // Email verification + invitation join (public routes)

--- a/packages/saas/src/plugin.ts
+++ b/packages/saas/src/plugin.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import type { Express } from 'express';
 import { createRegisterRouter } from './routes/register.js';
 import { createOrgRouter } from './routes/org.js';
+import { createOnboardingRouter } from './routes/onboarding.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -29,6 +30,9 @@ export const saasPlugin: AppPlugin = {
   registerRoutes(app) {
     // Registration & slug availability
     app.use('/api/auth', createRegisterRouter());
+
+    // Email verification + invitation join (public routes)
+    app.use('/api', createOnboardingRouter());
 
     // All org-scoped routes: /api/org/:slug/*
     app.use('/api/org/:slug', createOrgRouter());

--- a/packages/saas/src/plugin.ts
+++ b/packages/saas/src/plugin.ts
@@ -1,6 +1,8 @@
 import { fileURLToPath } from 'url';
 import path from 'path';
 import type { Express } from 'express';
+import { createRegisterRouter } from './routes/register.js';
+import { createOrgRouter } from './routes/org.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -21,25 +23,29 @@ export const saasPlugin: AppPlugin = {
   name: '@allo-scrapper/saas',
 
   beforeRoutes(_app) {
-    // TODO: tenant resolution middleware, quota middleware
+    // Global SaaS middleware (e.g. org rate limiting) — Phase 3
   },
 
-  registerRoutes(_app) {
-    // TODO: /api/auth/register, /api/org/:slug/*, /api/superadmin/*
+  registerRoutes(app) {
+    // Registration & slug availability
+    app.use('/api/auth', createRegisterRouter());
+
+    // All org-scoped routes: /api/org/:slug/*
+    app.use('/api/org/:slug', createOrgRouter());
   },
 
   afterRoutes(_app) {
-    // TODO: final SaaS-specific overrides
+    // Final SaaS-specific overrides — reserved for future use
   },
 
   getMigrationDirs() {
-    // In Docker: dist is under /app/packages/saas/dist
-    // In dev: resolve relative to this file's compiled location
+    // Returns the directory containing SaaS global migrations
+    // (plans, organizations, org_usage, subscriptions)
     const isDocker = __dirname.startsWith('/app/');
     return [
       isDocker
         ? path.join('/app', 'packages', 'saas', 'migrations')
-        : path.join(__dirname, '../../migrations'),
+        : path.join(__dirname, '../migrations'),
     ];
   },
 };

--- a/packages/saas/src/plugin.ts
+++ b/packages/saas/src/plugin.ts
@@ -11,10 +11,25 @@ import type { OrgSettingsRouterDeps } from './routes/org-settings.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+// ---------------------------------------------------------------------------
+// PluginDeps — mirror of the interface defined in server/src/app.ts.
+// Kept in sync manually; no cross-package import needed.
+// ---------------------------------------------------------------------------
+
+export interface PluginDeps {
+  requireAuth: RequestHandler;
+  requirePermission: (...permissions: string[]) => RequestHandler;
+  protectedLimiter: RequestHandler;
+  validateImage: (data: string, type: 'logo' | 'favicon', maxBytes: number) => Promise<{ valid: boolean; error?: string; compressedBase64?: string }>;
+  NotFoundError: new (message: string) => Error;
+  ValidationError: new (message: string) => Error;
+  logger: { info: (msg: string, meta?: Record<string, unknown>) => void };
+}
+
 export interface AppPlugin {
   name: string;
   beforeRoutes?:    (app: Express) => void;
-  registerRoutes?:  (app: Express) => void | Promise<void>;
+  registerRoutes?:  (app: Express, deps: PluginDeps) => void | Promise<void>;
   afterRoutes?:     (app: Express) => void;
   getMigrationDirs?: () => string[];
 }
@@ -31,33 +46,25 @@ export const saasPlugin: AppPlugin = {
     app.use(createOrgMetricsMiddleware());
   },
 
-  async registerRoutes(app) {
+  async registerRoutes(app, deps) {
+    const {
+      requireAuth,
+      requirePermission,
+      protectedLimiter,
+      validateImage,
+      NotFoundError,
+      ValidationError,
+      logger,
+    } = deps;
+
     // Registration & slug availability
     app.use('/api/auth', createRegisterRouter());
 
     // Email verification + invitation join (public routes)
     app.use('/api', createOnboardingRouter());
 
-    // Build settings deps by dynamically importing server utilities.
-    // These imports are resolved at runtime (inside the server process), so
-    // they are always available. The casts below keep the saas package's tsc
-    // compilation clean (rootDir: ./src would reject cross-package imports).
-    const [
-      { requireAuth },
-      { requirePermission },
-      { protectedLimiter },
-      { validateImage },
-      { NotFoundError, ValidationError },
-      { logger },
-    ] = await Promise.all([
-      import('../../../../server/src/middleware/auth.js' as string) as Promise<{ requireAuth: RequestHandler }>,
-      import('../../../../server/src/middleware/permission.js' as string) as Promise<{ requirePermission: (p: string) => RequestHandler }>,
-      import('../../../../server/src/middleware/rate-limit.js' as string) as Promise<{ protectedLimiter: RequestHandler }>,
-      import('../../../../server/src/utils/image-validator.js' as string) as Promise<{ validateImage: OrgSettingsRouterDeps['validateImage'] }>,
-      import('../../../../server/src/utils/errors.js' as string) as Promise<{ NotFoundError: new (msg: string) => Error; ValidationError: new (msg: string) => Error }>,
-      import('../../../../server/src/utils/logger.js' as string) as Promise<{ logger: OrgSettingsRouterDeps['logger'] }>,
-    ]);
-
+    // Build settings deps from injected server utilities.
+    // All server deps are passed in — no cross-package relative imports needed.
     const settingsDeps: OrgSettingsRouterDeps = {
       requireAuth,
       requirePermission,

--- a/packages/saas/src/plugin.ts
+++ b/packages/saas/src/plugin.ts
@@ -1,10 +1,11 @@
 import { fileURLToPath } from 'url';
 import path from 'path';
-import type { Express } from 'express';
+import type { Express, RequestHandler } from 'express';
 import { createRegisterRouter } from './routes/register.js';
 import { createOrgRouter } from './routes/org.js';
 import { createOnboardingRouter } from './routes/onboarding.js';
 import { createSuperadminRouter } from './routes/superadmin.js';
+import type { OrgSettingsRouterDeps } from './routes/org-settings.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -12,7 +13,7 @@ const __dirname = path.dirname(__filename);
 export interface AppPlugin {
   name: string;
   beforeRoutes?:    (app: Express) => void;
-  registerRoutes?:  (app: Express) => void;
+  registerRoutes?:  (app: Express) => void | Promise<void>;
   afterRoutes?:     (app: Express) => void;
   getMigrationDirs?: () => string[];
 }
@@ -28,15 +29,45 @@ export const saasPlugin: AppPlugin = {
     // Global SaaS middleware (e.g. org rate limiting) — Phase 3
   },
 
-  registerRoutes(app) {
+  async registerRoutes(app) {
     // Registration & slug availability
     app.use('/api/auth', createRegisterRouter());
 
     // Email verification + invitation join (public routes)
     app.use('/api', createOnboardingRouter());
 
+    // Build settings deps by dynamically importing server utilities.
+    // These imports are resolved at runtime (inside the server process), so
+    // they are always available. The casts below keep the saas package's tsc
+    // compilation clean (rootDir: ./src would reject cross-package imports).
+    const [
+      { requireAuth },
+      { requirePermission },
+      { protectedLimiter },
+      { validateImage },
+      { NotFoundError, ValidationError },
+      { logger },
+    ] = await Promise.all([
+      import('../../../../server/src/middleware/auth.js' as string) as Promise<{ requireAuth: RequestHandler }>,
+      import('../../../../server/src/middleware/permission.js' as string) as Promise<{ requirePermission: (p: string) => RequestHandler }>,
+      import('../../../../server/src/middleware/rate-limit.js' as string) as Promise<{ protectedLimiter: RequestHandler }>,
+      import('../../../../server/src/utils/image-validator.js' as string) as Promise<{ validateImage: OrgSettingsRouterDeps['validateImage'] }>,
+      import('../../../../server/src/utils/errors.js' as string) as Promise<{ NotFoundError: new (msg: string) => Error; ValidationError: new (msg: string) => Error }>,
+      import('../../../../server/src/utils/logger.js' as string) as Promise<{ logger: OrgSettingsRouterDeps['logger'] }>,
+    ]);
+
+    const settingsDeps: OrgSettingsRouterDeps = {
+      requireAuth,
+      requirePermission,
+      protectedLimiter,
+      validateImage,
+      notFoundError: (msg) => new NotFoundError(msg),
+      validationError: (msg) => new ValidationError(msg),
+      logger,
+    };
+
     // All org-scoped routes: /api/org/:slug/*
-    app.use('/api/org/:slug', createOrgRouter());
+    app.use('/api/org/:slug', createOrgRouter(settingsDeps));
 
     // Superadmin portal: /api/superadmin/*
     app.use('/api/superadmin', createSuperadminRouter());

--- a/packages/saas/src/plugin.ts
+++ b/packages/saas/src/plugin.ts
@@ -4,6 +4,7 @@ import type { Express } from 'express';
 import { createRegisterRouter } from './routes/register.js';
 import { createOrgRouter } from './routes/org.js';
 import { createOnboardingRouter } from './routes/onboarding.js';
+import { createSuperadminRouter } from './routes/superadmin.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -36,6 +37,9 @@ export const saasPlugin: AppPlugin = {
 
     // All org-scoped routes: /api/org/:slug/*
     app.use('/api/org/:slug', createOrgRouter());
+
+    // Superadmin portal: /api/superadmin/*
+    app.use('/api/superadmin', createSuperadminRouter());
   },
 
   afterRoutes(_app) {

--- a/packages/saas/src/plugin.ts
+++ b/packages/saas/src/plugin.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from 'url';
 import path from 'path';
 import type { Express, RequestHandler } from 'express';
-import { createRegisterRouter } from './routes/register.js';
+import { createRegisterRouter, createSlugRouter } from './routes/register.js';
 import { createOrgRouter } from './routes/org.js';
 import { createOnboardingRouter } from './routes/onboarding.js';
 import { createSuperadminRouter } from './routes/superadmin.js';
@@ -59,6 +59,7 @@ export const saasPlugin: AppPlugin = {
 
     // Registration & slug availability
     app.use('/api/auth', createRegisterRouter());
+    app.use('/api', createSlugRouter());
 
     // Email verification + invitation join (public routes)
     app.use('/api', createOnboardingRouter());

--- a/packages/saas/src/plugin.ts
+++ b/packages/saas/src/plugin.ts
@@ -5,6 +5,7 @@ import { createRegisterRouter } from './routes/register.js';
 import { createOrgRouter } from './routes/org.js';
 import { createOnboardingRouter } from './routes/onboarding.js';
 import { createSuperadminRouter } from './routes/superadmin.js';
+import { createOrgMetricsMiddleware, getOrgRegistry } from './middleware/org-metrics.js';
 import type { OrgSettingsRouterDeps } from './routes/org-settings.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -25,8 +26,9 @@ export interface AppPlugin {
 export const saasPlugin: AppPlugin = {
   name: '@allo-scrapper/saas',
 
-  beforeRoutes(_app) {
-    // Global SaaS middleware (e.g. org rate limiting) — Phase 3
+  beforeRoutes(app) {
+    // Phase 7.5 — per-org Prometheus metrics middleware
+    app.use(createOrgMetricsMiddleware());
   },
 
   async registerRoutes(app) {
@@ -68,6 +70,17 @@ export const saasPlugin: AppPlugin = {
 
     // All org-scoped routes: /api/org/:slug/*
     app.use('/api/org/:slug', createOrgRouter(settingsDeps));
+
+    // Phase 7.5 — expose per-org Prometheus metrics at /api/saas/metrics
+    app.get('/api/saas/metrics', async (_req, res) => {
+      try {
+        const registry = getOrgRegistry();
+        res.set('Content-Type', registry.contentType);
+        res.end(await registry.metrics());
+      } catch (err) {
+        res.status(500).end(String(err));
+      }
+    });
 
     // Superadmin portal: /api/superadmin/*
     app.use('/api/superadmin', createSuperadminRouter());

--- a/packages/saas/src/routes/onboarding.test.ts
+++ b/packages/saas/src/routes/onboarding.test.ts
@@ -20,6 +20,7 @@ vi.mock('../services/invitation-service.js', () => ({
   InvitationService: vi.fn().mockImplementation(() => ({
     getInvitationByToken: vi.fn(),
     acceptInvitation: vi.fn(),
+    createInvitation: vi.fn(),
   })),
 }));
 
@@ -33,8 +34,31 @@ vi.mock('../services/saas-auth-service.js', () => ({
 
 const VALID_JWT_SECRET = 'test-secret-that-is-at-least-32-chars-long!!';
 
-function makePool(): Pool {
-  return { connect: vi.fn().mockResolvedValue({ query: vi.fn(), release: vi.fn() }) };
+const MOCK_ORG = {
+  id: 'org-uuid-1',
+  slug: 'my-cinema',
+  schema_name: 'org_my_cinema',
+};
+
+/**
+ * Makes a pool whose client resolves org queries with MOCK_ORG
+ * (used for routes that look up the org from the token prefix).
+ */
+function makePoolWithOrg(): Pool {
+  const client = {
+    query: vi.fn().mockResolvedValue({ rows: [MOCK_ORG], rowCount: 1 }),
+    release: vi.fn(),
+  };
+  return { connect: vi.fn().mockResolvedValue(client) };
+}
+
+/** Pool that returns empty rows — used to simulate org-not-found cases. */
+function makeEmptyPool(): Pool {
+  const client = {
+    query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+    release: vi.fn(),
+  };
+  return { connect: vi.fn().mockResolvedValue(client) };
 }
 
 function buildApp(pool: Pool): Express {
@@ -44,6 +68,10 @@ function buildApp(pool: Pool): Express {
   app.use('/api', createOnboardingRouter());
   return app;
 }
+
+// Token format used in all tests: "<orgSlug>:<hex>"
+const VALID_VERIFY_TOKEN = 'my-cinema:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
+const VALID_INVITE_TOKEN = 'my-cinema:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
 
 // ── GET /api/auth/verify-email/:token ────────────────────────────────────────
 
@@ -62,11 +90,27 @@ describe('GET /api/auth/verify-email/:token', () => {
       sendVerificationEmail: vi.fn(),
     }));
 
-    const app = buildApp(makePool());
-    const res = await supertest(app).get('/api/auth/verify-email/valid-token');
+    const app = buildApp(makePoolWithOrg());
+    const res = await supertest(app).get(`/api/auth/verify-email/${VALID_VERIFY_TOKEN}`);
 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
+  });
+
+  it('returns 400 when the token format is missing a colon separator', async () => {
+    const app = buildApp(makeEmptyPool());
+    const res = await supertest(app).get('/api/auth/verify-email/no-colon-here');
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('returns 400 when org slug in token does not match any organization', async () => {
+    const app = buildApp(makeEmptyPool()); // org lookup returns no rows
+    const res = await supertest(app).get('/api/auth/verify-email/unknown-org:sometoken');
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
   });
 
   it('returns 400 when the token is invalid or expired', async () => {
@@ -79,8 +123,8 @@ describe('GET /api/auth/verify-email/:token', () => {
       sendVerificationEmail: vi.fn(),
     }));
 
-    const app = buildApp(makePool());
-    const res = await supertest(app).get('/api/auth/verify-email/bad-token');
+    const app = buildApp(makePoolWithOrg());
+    const res = await supertest(app).get(`/api/auth/verify-email/${VALID_VERIFY_TOKEN}`);
 
     expect(res.status).toBe(400);
     expect(res.body.success).toBe(false);
@@ -98,7 +142,7 @@ describe('POST /api/auth/join/:token', () => {
     id: 'inv-uuid-1',
     email: 'bob@example.com',
     role_id: 2,
-    token: 'valid-invite-token',
+    token: VALID_INVITE_TOKEN,
     invited_by: 1,
     accepted_at: null,
     expires_at: new Date(Date.now() + 48 * 3600_000),
@@ -109,12 +153,22 @@ describe('POST /api/auth/join/:token', () => {
   };
 
   it('returns 400 when password is missing', async () => {
-    const app = buildApp(makePool());
+    const app = buildApp(makePoolWithOrg());
     const res = await supertest(app)
-      .post('/api/auth/join/some-token')
+      .post(`/api/auth/join/${VALID_INVITE_TOKEN}`)
       .send({});
 
     expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('returns 404 when token format has no colon separator', async () => {
+    const app = buildApp(makeEmptyPool());
+    const res = await supertest(app)
+      .post('/api/auth/join/bad-token-no-colon')
+      .send({ password: 'NewPass1!' });
+
+    expect(res.status).toBe(404);
     expect(res.body.success).toBe(false);
   });
 
@@ -126,9 +180,9 @@ describe('POST /api/auth/join/:token', () => {
       createInvitation: vi.fn(),
     }));
 
-    const app = buildApp(makePool());
+    const app = buildApp(makePoolWithOrg());
     const res = await supertest(app)
-      .post('/api/auth/join/expired-token')
+      .post(`/api/auth/join/${VALID_INVITE_TOKEN}`)
       .send({ password: 'NewPass1!' });
 
     expect(res.status).toBe(404);
@@ -148,9 +202,9 @@ describe('POST /api/auth/join/:token', () => {
       createInvitation: vi.fn(),
     }));
 
-    const app = buildApp(makePool());
+    const app = buildApp(makePoolWithOrg());
     const res = await supertest(app)
-      .post('/api/auth/join/valid-invite-token')
+      .post(`/api/auth/join/${VALID_INVITE_TOKEN}`)
       .send({ password: 'SecurePass1!' });
 
     expect(res.status).toBe(201);
@@ -164,13 +218,6 @@ describe('POST /api/auth/join/:token', () => {
 // ── POST /api/org/:slug/invitations ──────────────────────────────────────────
 
 describe('POST /api/org/:slug/invitations', () => {
-  const MOCK_ORG = {
-    id: 'org-uuid-1',
-    slug: 'my-cinema',
-    schema_name: 'org_my_cinema',
-    status: 'trial',
-  };
-
   function buildAppWithOrg(pool: Pool): Express {
     const app = express();
     app.use(express.json());
@@ -186,7 +233,7 @@ describe('POST /api/org/:slug/invitations', () => {
   }
 
   it('returns 400 when email is missing', async () => {
-    const app = buildAppWithOrg(makePool());
+    const app = buildAppWithOrg(makePoolWithOrg());
     const res = await supertest(app)
       .post('/api/org/my-cinema/invitations')
       .send({ role_id: 2 });
@@ -196,7 +243,7 @@ describe('POST /api/org/:slug/invitations', () => {
   });
 
   it('returns 400 when role_id is missing', async () => {
-    const app = buildAppWithOrg(makePool());
+    const app = buildAppWithOrg(makePoolWithOrg());
     const res = await supertest(app)
       .post('/api/org/my-cinema/invitations')
       .send({ email: 'bob@example.com' });
@@ -211,7 +258,7 @@ describe('POST /api/org/:slug/invitations', () => {
       id: 'inv-uuid-1',
       email: 'bob@example.com',
       role_id: 2,
-      token: 'new-token-xyz',
+      token: 'my-cinema:new-token-xyz',
       invited_by: 1,
       accepted_at: null,
       expires_at: new Date(Date.now() + 48 * 3600_000),
@@ -232,7 +279,7 @@ describe('POST /api/org/:slug/invitations', () => {
       sendVerificationEmail: vi.fn().mockResolvedValue(undefined),
     }));
 
-    const app = buildAppWithOrg(makePool());
+    const app = buildAppWithOrg(makePoolWithOrg());
     const res = await supertest(app)
       .post('/api/org/my-cinema/invitations')
       .send({ email: 'bob@example.com', role_id: 2 });

--- a/packages/saas/src/routes/onboarding.test.ts
+++ b/packages/saas/src/routes/onboarding.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express, { type Express } from 'express';
+import supertest from 'supertest';
+import { createOnboardingRouter } from './onboarding.js';
+import type { Pool } from '../db/types.js';
+
+// ── module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('../services/email-service.js', () => ({
+  EmailService: vi.fn().mockImplementation(() => ({
+    verifyEmailToken: vi.fn(),
+    markEmailVerified: vi.fn().mockResolvedValue(undefined),
+    generateVerificationToken: vi.fn().mockReturnValue('gen-token'),
+    storeVerificationToken: vi.fn().mockResolvedValue(undefined),
+    sendVerificationEmail: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+vi.mock('../services/invitation-service.js', () => ({
+  InvitationService: vi.fn().mockImplementation(() => ({
+    getInvitationByToken: vi.fn(),
+    acceptInvitation: vi.fn(),
+  })),
+}));
+
+vi.mock('../services/saas-auth-service.js', () => ({
+  SaasAuthService: vi.fn().mockImplementation(() => ({
+    mintJwt: vi.fn().mockReturnValue('mock.jwt.token'),
+  })),
+}));
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+const VALID_JWT_SECRET = 'test-secret-that-is-at-least-32-chars-long!!';
+
+function makePool(): Pool {
+  return { connect: vi.fn().mockResolvedValue({ query: vi.fn(), release: vi.fn() }) };
+}
+
+function buildApp(pool: Pool): Express {
+  const app = express();
+  app.use(express.json());
+  app.set('pool', pool);
+  app.use('/api', createOnboardingRouter());
+  return app;
+}
+
+// ── GET /api/auth/verify-email/:token ────────────────────────────────────────
+
+describe('GET /api/auth/verify-email/:token', () => {
+  beforeEach(() => {
+    vi.stubEnv('JWT_SECRET', VALID_JWT_SECRET);
+  });
+
+  it('returns 200 and marks user verified when token is valid', async () => {
+    const { EmailService } = await import('../services/email-service.js');
+    vi.mocked(EmailService).mockImplementationOnce(() => ({
+      verifyEmailToken: vi.fn().mockResolvedValue(42), // returns user_id
+      markEmailVerified: vi.fn().mockResolvedValue(undefined),
+      generateVerificationToken: vi.fn(),
+      storeVerificationToken: vi.fn(),
+      sendVerificationEmail: vi.fn(),
+    }));
+
+    const app = buildApp(makePool());
+    const res = await supertest(app).get('/api/auth/verify-email/valid-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('returns 400 when the token is invalid or expired', async () => {
+    const { EmailService } = await import('../services/email-service.js');
+    vi.mocked(EmailService).mockImplementationOnce(() => ({
+      verifyEmailToken: vi.fn().mockResolvedValue(null), // not found / expired
+      markEmailVerified: vi.fn(),
+      generateVerificationToken: vi.fn(),
+      storeVerificationToken: vi.fn(),
+      sendVerificationEmail: vi.fn(),
+    }));
+
+    const app = buildApp(makePool());
+    const res = await supertest(app).get('/api/auth/verify-email/bad-token');
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+});
+
+// ── POST /api/auth/join/:token ────────────────────────────────────────────────
+
+describe('POST /api/auth/join/:token', () => {
+  beforeEach(() => {
+    vi.stubEnv('JWT_SECRET', VALID_JWT_SECRET);
+  });
+
+  const MOCK_INVITE = {
+    id: 'inv-uuid-1',
+    email: 'bob@example.com',
+    role_id: 2,
+    token: 'valid-invite-token',
+    invited_by: 1,
+    accepted_at: null,
+    expires_at: new Date(Date.now() + 48 * 3600_000),
+    created_at: new Date(),
+    org_id: 'org-uuid-1',
+    org_slug: 'my-cinema',
+    org_schema_name: 'org_my_cinema',
+  };
+
+  it('returns 400 when password is missing', async () => {
+    const app = buildApp(makePool());
+    const res = await supertest(app)
+      .post('/api/auth/join/some-token')
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('returns 404 when invitation token is invalid or expired', async () => {
+    const { InvitationService } = await import('../services/invitation-service.js');
+    vi.mocked(InvitationService).mockImplementationOnce(() => ({
+      getInvitationByToken: vi.fn().mockResolvedValue(null),
+      acceptInvitation: vi.fn(),
+      createInvitation: vi.fn(),
+    }));
+
+    const app = buildApp(makePool());
+    const res = await supertest(app)
+      .post('/api/auth/join/expired-token')
+      .send({ password: 'NewPass1!' });
+
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('returns 201 with token and user on successful join', async () => {
+    const { InvitationService } = await import('../services/invitation-service.js');
+    vi.mocked(InvitationService).mockImplementationOnce(() => ({
+      getInvitationByToken: vi.fn().mockResolvedValue(MOCK_INVITE),
+      acceptInvitation: vi.fn().mockResolvedValue({
+        id: 99,
+        username: 'bob@example.com',
+        role_id: 2,
+        role_name: 'user',
+      }),
+      createInvitation: vi.fn(),
+    }));
+
+    const app = buildApp(makePool());
+    const res = await supertest(app)
+      .post('/api/auth/join/valid-invite-token')
+      .send({ password: 'SecurePass1!' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.token).toBeDefined();
+    expect(res.body.user).toBeDefined();
+    expect(res.body.user.username).toBe('bob@example.com');
+  });
+});
+
+// ── POST /api/org/:slug/invitations ──────────────────────────────────────────
+
+describe('POST /api/org/:slug/invitations', () => {
+  const MOCK_ORG = {
+    id: 'org-uuid-1',
+    slug: 'my-cinema',
+    schema_name: 'org_my_cinema',
+    status: 'trial',
+  };
+
+  function buildAppWithOrg(pool: Pool): Express {
+    const app = express();
+    app.use(express.json());
+    app.set('pool', pool);
+    // Simulate resolveTenant by setting req.org manually
+    app.use((req: any, _res: any, next: any) => {
+      req.org = MOCK_ORG;
+      req.user = { id: 1, username: 'admin@my-cinema.com', role_name: 'admin' };
+      next();
+    });
+    app.use('/api', createOnboardingRouter());
+    return app;
+  }
+
+  it('returns 400 when email is missing', async () => {
+    const app = buildAppWithOrg(makePool());
+    const res = await supertest(app)
+      .post('/api/org/my-cinema/invitations')
+      .send({ role_id: 2 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('returns 400 when role_id is missing', async () => {
+    const app = buildAppWithOrg(makePool());
+    const res = await supertest(app)
+      .post('/api/org/my-cinema/invitations')
+      .send({ email: 'bob@example.com' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('returns 201 with the invitation on success', async () => {
+    const { InvitationService } = await import('../services/invitation-service.js');
+    const MOCK_CREATED = {
+      id: 'inv-uuid-1',
+      email: 'bob@example.com',
+      role_id: 2,
+      token: 'new-token-xyz',
+      invited_by: 1,
+      accepted_at: null,
+      expires_at: new Date(Date.now() + 48 * 3600_000),
+      created_at: new Date(),
+    };
+    vi.mocked(InvitationService).mockImplementationOnce(() => ({
+      createInvitation: vi.fn().mockResolvedValue(MOCK_CREATED),
+      getInvitationByToken: vi.fn(),
+      acceptInvitation: vi.fn(),
+    }));
+
+    const { EmailService } = await import('../services/email-service.js');
+    vi.mocked(EmailService).mockImplementationOnce(() => ({
+      verifyEmailToken: vi.fn(),
+      markEmailVerified: vi.fn(),
+      generateVerificationToken: vi.fn().mockReturnValue('gen-token'),
+      storeVerificationToken: vi.fn(),
+      sendVerificationEmail: vi.fn().mockResolvedValue(undefined),
+    }));
+
+    const app = buildAppWithOrg(makePool());
+    const res = await supertest(app)
+      .post('/api/org/my-cinema/invitations')
+      .send({ email: 'bob@example.com', role_id: 2 });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.invitation).toBeDefined();
+    expect(res.body.invitation.email).toBe('bob@example.com');
+  });
+});

--- a/packages/saas/src/routes/onboarding.test.ts
+++ b/packages/saas/src/routes/onboarding.test.ts
@@ -6,6 +6,11 @@ import type { Pool } from '../db/types.js';
 
 // ── module mocks ──────────────────────────────────────────────────────────────
 
+// Mock checkQuota to be a pass-through — quota enforcement is tested separately
+vi.mock('../middleware/quota.js', () => ({
+  checkQuota: vi.fn(() => (_req: any, _res: any, next: any) => next()),
+}));
+
 vi.mock('../services/email-service.js', () => ({
   EmailService: vi.fn().mockImplementation(() => ({
     verifyEmailToken: vi.fn(),

--- a/packages/saas/src/routes/onboarding.ts
+++ b/packages/saas/src/routes/onboarding.ts
@@ -3,6 +3,7 @@ import { EmailService } from '../services/email-service.js';
 import { InvitationService } from '../services/invitation-service.js';
 import { SaasAuthService } from '../services/saas-auth-service.js';
 import { checkQuota } from '../middleware/quota.js';
+import { onboardingLimiter } from '../middleware/rate-limit.js';
 import type { Pool } from '../db/types.js';
 import type { Organization } from '../db/org-queries.js';
 
@@ -32,7 +33,7 @@ export function createOnboardingRouter(): Router {
   //
   // For simplicity in Phase 2 the token itself stores the org info embedded as
   // `<orgSlug>:<hex>` so we can route to the right schema without a global token table.
-  router.get('/auth/verify-email/:token', async (req: Request, res: Response) => {
+  router.get('/auth/verify-email/:token', onboardingLimiter, async (req: Request, res: Response) => {
     const token = String(req.params.token);
 
     // Token format: "<orgSlug>:<hex32>"
@@ -80,7 +81,7 @@ export function createOnboardingRouter(): Router {
   // Token is a raw hex stored in the invitations table.
   // We need to locate which org the invitation belongs to.
   // Strategy: store org_slug in the invitation token prefix: "<orgSlug>:<hex32>"
-  router.post('/auth/join/:token', async (req: Request, res: Response) => {
+  router.post('/auth/join/:token', onboardingLimiter, async (req: Request, res: Response) => {
     const token = String(req.params.token);
     const { password } = req.body as { password?: string };
 

--- a/packages/saas/src/routes/onboarding.ts
+++ b/packages/saas/src/routes/onboarding.ts
@@ -33,7 +33,7 @@ export function createOnboardingRouter(): Router {
   // For simplicity in Phase 2 the token itself stores the org info embedded as
   // `<orgSlug>:<hex>` so we can route to the right schema without a global token table.
   router.get('/auth/verify-email/:token', async (req: Request, res: Response) => {
-    const { token } = req.params;
+    const token = String(req.params.token);
 
     // Token format: "<orgSlug>:<hex32>"
     const sepIdx = token.indexOf(':');
@@ -81,7 +81,7 @@ export function createOnboardingRouter(): Router {
   // We need to locate which org the invitation belongs to.
   // Strategy: store org_slug in the invitation token prefix: "<orgSlug>:<hex32>"
   router.post('/auth/join/:token', async (req: Request, res: Response) => {
-    const { token } = req.params;
+    const token = String(req.params.token);
     const { password } = req.body as { password?: string };
 
     if (!password || password.length < 8) {

--- a/packages/saas/src/routes/onboarding.ts
+++ b/packages/saas/src/routes/onboarding.ts
@@ -1,0 +1,205 @@
+import { Router, type Request, type Response } from 'express';
+import { EmailService } from '../services/email-service.js';
+import { InvitationService } from '../services/invitation-service.js';
+import { SaasAuthService } from '../services/saas-auth-service.js';
+import type { Pool } from '../db/types.js';
+import type { Organization } from '../db/org-queries.js';
+
+// Extend Express Request with SaaS fields populated by resolveTenant / requireAuth
+declare module 'express-serve-static-core' {
+  interface Request {
+    org?: Organization;
+    user?: {
+      id: number;
+      username: string;
+      role_name: string;
+      is_system_role?: boolean;
+      permissions?: string[];
+      org_id?: string;
+      org_slug?: string;
+    };
+  }
+}
+
+export function createOnboardingRouter(): Router {
+  const router = Router({ mergeParams: true });
+
+  // ── GET /api/auth/verify-email/:token ──────────────────────────────────────
+  // Public — no auth required.
+  // The token encodes which org the user belongs to — look it up in public.organizations
+  // via a join, then flip email_verified in the org schema.
+  //
+  // For simplicity in Phase 2 the token itself stores the org info embedded as
+  // `<orgSlug>:<hex>` so we can route to the right schema without a global token table.
+  router.get('/auth/verify-email/:token', async (req: Request, res: Response) => {
+    const { token } = req.params;
+
+    // Token format: "<orgSlug>:<hex32>"
+    const sepIdx = token.indexOf(':');
+    if (sepIdx === -1) {
+      return res.status(400).json({ success: false, error: 'Invalid verification token format' });
+    }
+    const orgSlug = token.slice(0, sepIdx);
+    const rawToken = token.slice(sepIdx + 1);
+
+    const pool = req.app.get('pool') as Pool;
+
+    // Resolve the org by slug to get schema_name
+    // Re-use a lightweight inline query against public.organizations
+    const client = await pool.connect();
+    let org: { id: string; slug: string; schema_name: string } | null = null;
+    try {
+      const result = await client.query<{ id: string; slug: string; schema_name: string }>(
+        `SELECT id, slug, schema_name FROM organizations WHERE slug = $1`,
+        [orgSlug],
+      );
+      org = result.rows[0] ?? null;
+    } finally {
+      client.release();
+    }
+
+    if (!org) {
+      return res.status(400).json({ success: false, error: 'Invalid verification token' });
+    }
+
+    const emailService = new EmailService(pool);
+    const userId = await emailService.verifyEmailToken(org, rawToken);
+    if (userId === null) {
+      return res.status(400).json({ success: false, error: 'Invalid or expired verification token' });
+    }
+
+    await emailService.markEmailVerified(org, userId);
+
+    return res.json({ success: true, message: 'Email verified successfully' });
+  });
+
+  // ── POST /api/auth/join/:token ─────────────────────────────────────────────
+  // Public — no auth required.
+  // Body: { password }
+  // Token is a raw hex stored in the invitations table.
+  // We need to locate which org the invitation belongs to.
+  // Strategy: store org_slug in the invitation token prefix: "<orgSlug>:<hex32>"
+  router.post('/auth/join/:token', async (req: Request, res: Response) => {
+    const { token } = req.params;
+    const { password } = req.body as { password?: string };
+
+    if (!password || password.length < 8) {
+      return res.status(400).json({
+        success: false,
+        errors: ['password must be at least 8 characters'],
+      });
+    }
+
+    // Token format: "<orgSlug>:<hex32>"
+    const sepIdx = token.indexOf(':');
+    if (sepIdx === -1) {
+      return res.status(404).json({ success: false, error: 'Invalid invitation token' });
+    }
+    const orgSlug = token.slice(0, sepIdx);
+    const rawToken = token.slice(sepIdx + 1);
+
+    const pool = req.app.get('pool') as Pool;
+
+    // Resolve org
+    const client = await pool.connect();
+    let org: { id: string; slug: string; schema_name: string } | null = null;
+    try {
+      const result = await client.query<{ id: string; slug: string; schema_name: string }>(
+        `SELECT id, slug, schema_name FROM organizations WHERE slug = $1`,
+        [orgSlug],
+      );
+      org = result.rows[0] ?? null;
+    } finally {
+      client.release();
+    }
+
+    if (!org) {
+      return res.status(404).json({ success: false, error: 'Invalid invitation token' });
+    }
+
+    const invitationService = new InvitationService(pool);
+    const invitation = await invitationService.getInvitationByToken(org, token);
+    if (!invitation) {
+      return res.status(404).json({ success: false, error: 'Invitation not found or expired' });
+    }
+
+    const user = await invitationService.acceptInvitation(org, invitation, password);
+
+    const authService = new SaasAuthService(pool);
+    const jwt = authService.mintJwt({
+      userId: user.id,
+      username: user.username,
+      orgId: org.id,
+      orgSlug: org.slug,
+      roleId: user.role_id,
+      roleName: user.role_name,
+      permissions: [],
+    });
+
+    return res.status(201).json({
+      success: true,
+      token: jwt,
+      user: {
+        id: user.id,
+        username: user.username,
+        role_id: user.role_id,
+        role_name: user.role_name,
+      },
+    });
+  });
+
+  // ── POST /api/org/:slug/invitations ────────────────────────────────────────
+  // Protected — caller must be authenticated (req.user set by requireAuth).
+  // req.org is set by resolveTenant middleware on the org router.
+  // Body: { email, role_id }
+  router.post('/org/:slug/invitations', async (req: Request, res: Response) => {
+    const { email, role_id } = req.body as { email?: string; role_id?: number };
+
+    if (!email || !email.includes('@')) {
+      return res.status(400).json({ success: false, errors: ['email must be a valid email'] });
+    }
+    if (!role_id || typeof role_id !== 'number') {
+      return res.status(400).json({ success: false, errors: ['role_id must be a number'] });
+    }
+
+    const org = req.org;
+    if (!org) {
+      return res.status(500).json({ success: false, error: 'Tenant not resolved' });
+    }
+
+    const invitedBy = req.user?.id;
+    if (!invitedBy) {
+      return res.status(401).json({ success: false, error: 'Authentication required' });
+    }
+
+    const pool = req.app.get('pool') as Pool;
+    const invitationService = new InvitationService(pool);
+
+    // Build the prefixed token once — stored in DB AND sent by email.
+    // Format: "<orgSlug>:<hex32>" so the /join/:token route can decode the org.
+    const rawToken = (await import('crypto')).randomBytes(32).toString('hex');
+    const prefixedToken = `${org.slug}:${rawToken}`;
+
+    const invitation = await invitationService.createInvitation(org, {
+      email,
+      role_id,
+      invited_by: invitedBy,
+      token: prefixedToken,
+    });
+
+    const emailService = new EmailService(pool);
+    await emailService.sendVerificationEmail(email, prefixedToken, org.slug);
+
+    return res.status(201).json({
+      success: true,
+      invitation: {
+        id: invitation.id,
+        email: invitation.email,
+        role_id: invitation.role_id,
+        expires_at: invitation.expires_at,
+      },
+    });
+  });
+
+  return router;
+}

--- a/packages/saas/src/routes/onboarding.ts
+++ b/packages/saas/src/routes/onboarding.ts
@@ -2,6 +2,7 @@ import { Router, type Request, type Response } from 'express';
 import { EmailService } from '../services/email-service.js';
 import { InvitationService } from '../services/invitation-service.js';
 import { SaasAuthService } from '../services/saas-auth-service.js';
+import { checkQuota } from '../middleware/quota.js';
 import type { Pool } from '../db/types.js';
 import type { Organization } from '../db/org-queries.js';
 
@@ -152,7 +153,8 @@ export function createOnboardingRouter(): Router {
   // Protected — caller must be authenticated (req.user set by requireAuth).
   // req.org is set by resolveTenant middleware on the org router.
   // Body: { email, role_id }
-  router.post('/org/:slug/invitations', async (req: Request, res: Response) => {
+  // checkQuota('users') enforces max_users plan limit before creating the invitation.
+  router.post('/org/:slug/invitations', checkQuota('users'), async (req: Request, res: Response) => {
     const { email, role_id } = req.body as { email?: string; role_id?: number };
 
     if (!email || !email.includes('@')) {

--- a/packages/saas/src/routes/org-export.test.ts
+++ b/packages/saas/src/routes/org-export.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express, { type Express, type Request, type Response, type NextFunction } from 'express';
+import request from 'supertest';
+
+// ── Mock OrgExportService ─────────────────────────────────────────────────────
+vi.mock('../services/org-export-service.js', () => ({
+  OrgExportService: vi.fn(),
+}));
+
+import { createOrgExportRouter } from '../routes/org-export.js';
+import { OrgExportService } from '../services/org-export-service.js';
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+const MOCK_ORG = {
+  id: 'uuid-1',
+  slug: 'cinema-test',
+  name: 'Cinéma Test',
+  schema_name: 'org_cinema_test',
+  status: 'active' as const,
+  plan: 'starter',
+  trial_ends_at: null,
+  created_at: new Date('2026-01-01'),
+};
+
+const MOCK_EXPORT = {
+  org: { slug: 'cinema-test', name: 'Cinéma Test' },
+  cinemas: [{ id: 'C0001', name: 'Cinema Alpha', source: 'allocine' }],
+  showtimes: [{ cinema_id: 'C0001', film_id: 1, show_time: '2026-04-01T20:00:00Z' }],
+  settings: { site_name: 'Cinéma Test', color_primary: '#FECC00' },
+  exported_at: '2026-04-01T00:00:00.000Z',
+};
+
+function buildApp(): Express {
+  const app = express();
+
+  // Inject mock pool + tenant
+  app.use((req: Request, _res: Response, next: NextFunction) => {
+    const mockClient = { query: vi.fn(), release: vi.fn() };
+    req.app.set('pool', { connect: vi.fn().mockResolvedValue(mockClient) });
+    (req as any).org = MOCK_ORG;
+    (req as any).dbClient = mockClient;
+    next();
+  });
+
+  app.use('/api/org/:slug', createOrgExportRouter());
+  return app;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('GET /api/org/:slug/export', () => {
+  let mockExportFn: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExportFn = vi.fn().mockResolvedValue(MOCK_EXPORT);
+    vi.mocked(OrgExportService).mockImplementation(
+      () => ({ exportOrg: mockExportFn }) as unknown as OrgExportService
+    );
+  });
+
+  it('returns 200 with JSON export payload', async () => {
+    const app = buildApp();
+    const res = await request(app).get('/api/org/cinema-test/export');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toBeDefined();
+    expect(res.body.data.org.slug).toBe('cinema-test');
+  });
+
+  it('includes cinemas in the export', async () => {
+    const app = buildApp();
+    const res = await request(app).get('/api/org/cinema-test/export');
+
+    expect(res.body.data.cinemas).toHaveLength(1);
+    expect(res.body.data.cinemas[0].id).toBe('C0001');
+  });
+
+  it('includes showtimes in the export', async () => {
+    const app = buildApp();
+    const res = await request(app).get('/api/org/cinema-test/export');
+
+    expect(res.body.data.showtimes).toHaveLength(1);
+  });
+
+  it('includes settings in the export', async () => {
+    const app = buildApp();
+    const res = await request(app).get('/api/org/cinema-test/export');
+
+    expect(res.body.data.settings).toBeDefined();
+    expect(res.body.data.settings.site_name).toBe('Cinéma Test');
+  });
+
+  it('includes exported_at timestamp', async () => {
+    const app = buildApp();
+    const res = await request(app).get('/api/org/cinema-test/export');
+
+    expect(res.body.data.exported_at).toBeDefined();
+  });
+
+  it('calls OrgExportService.exportOrg with the correct org', async () => {
+    const app = buildApp();
+    await request(app).get('/api/org/cinema-test/export');
+
+    expect(mockExportFn).toHaveBeenCalledOnce();
+  });
+
+  it('returns 500 when export service throws', async () => {
+    mockExportFn.mockRejectedValue(new Error('DB error'));
+    const app = buildApp();
+    const res = await request(app).get('/api/org/cinema-test/export');
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/packages/saas/src/routes/org-export.ts
+++ b/packages/saas/src/routes/org-export.ts
@@ -1,0 +1,27 @@
+import { Router, type Request, type Response } from 'express';
+import { OrgExportService } from '../services/org-export-service.js';
+
+/**
+ * GET /api/org/:slug/export
+ *
+ * Returns a complete JSON snapshot of the org's data:
+ * cinemas, showtimes, and org settings.
+ *
+ * Requires the resolveTenant middleware to have already run
+ * (req.org and req.dbClient must be present).
+ */
+export function createOrgExportRouter(): Router {
+  const router = Router({ mergeParams: true });
+
+  router.get('/export', async (req: Request, res: Response) => {
+    try {
+      const service = new OrgExportService(req.dbClient!);
+      const data = await service.exportOrg(req.org!);
+      res.json({ success: true, data });
+    } catch (err) {
+      res.status(500).json({ success: false, error: 'Export failed' });
+    }
+  });
+
+  return router;
+}

--- a/packages/saas/src/routes/org-settings.test.ts
+++ b/packages/saas/src/routes/org-settings.test.ts
@@ -1,11 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import express, { type Express } from 'express';
+import express, { type Express, type Request, type Response, type NextFunction } from 'express';
 import request from 'supertest';
 
-// ── Mock server middleware that depends on module-level JWT validation ─────────
-vi.mock('../../../../server/src/middleware/auth.js', () => ({
-  requireAuth: vi.fn((_req: express.Request, _res: express.Response, next: express.NextFunction) => {
-    (_req as express.Request & { user?: unknown }).user = {
+// ── Mock OrgSettingsService ────────────────────────────────────────────────────
+vi.mock('../services/org-settings-service.js', () => ({
+  OrgSettingsService: vi.fn(),
+}));
+
+import { createOrgSettingsRouter, type OrgSettingsRouterDeps } from '../routes/org-settings.js';
+import { OrgSettingsService } from '../services/org-settings-service.js';
+
+// ── Shared mock deps ──────────────────────────────────────────────────────────
+
+/** Creates a passthrough requireAuth that injects a fake user */
+const makeRequireAuth = () =>
+  vi.fn((req: Request, _res: Response, next: NextFunction) => {
+    (req as Request & { user?: unknown }).user = {
       id: 1,
       username: 'admin',
       role_name: 'admin',
@@ -19,28 +29,17 @@ vi.mock('../../../../server/src/middleware/auth.js', () => ({
       ],
     };
     next();
-  }),
-}));
+  });
 
-vi.mock('../../../../server/src/middleware/permission.js', () => ({
-  requirePermission: vi.fn(() => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next()),
-}));
-
-vi.mock('../../../../server/src/middleware/rate-limit.js', () => ({
-  protectedLimiter: vi.fn((_req: express.Request, _res: express.Response, next: express.NextFunction) => next()),
-}));
-
-vi.mock('../../../../server/src/utils/image-validator.js', () => ({
+const makeDeps = (): OrgSettingsRouterDeps => ({
+  requireAuth: makeRequireAuth(),
+  requirePermission: vi.fn(() => (_req: Request, _res: Response, next: NextFunction) => next()),
+  protectedLimiter: vi.fn((_req: Request, _res: Response, next: NextFunction) => next()),
   validateImage: vi.fn().mockResolvedValue({ valid: true, compressedBase64: 'data:image/png;base64,abc' }),
-}));
-
-// ── Mock OrgSettingsService ────────────────────────────────────────────────────
-vi.mock('../services/org-settings-service.js', () => ({
-  OrgSettingsService: vi.fn(),
-}));
-
-import { createOrgSettingsRouter } from '../routes/org-settings.js';
-import { OrgSettingsService } from '../services/org-settings-service.js';
+  notFoundError: vi.fn((msg: string) => Object.assign(new Error(msg), { statusCode: 404 })),
+  validationError: vi.fn((msg: string) => Object.assign(new Error(msg), { statusCode: 400 })),
+  logger: { info: vi.fn() },
+});
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -89,23 +88,33 @@ const PUBLIC_SETTINGS = {
   footer_links: [],
 };
 
+// ── Error handler (converts Error with statusCode to JSON) ────────────────────
+
+function addErrorHandler(app: Express): void {
+  app.use((err: Error & { statusCode?: number }, _req: Request, res: Response, _next: NextFunction) => {
+    const status = err.statusCode ?? 500;
+    res.status(status).json({ success: false, error: err.message });
+  });
+}
+
 // ── App builder ───────────────────────────────────────────────────────────────
 
-function buildApp(): Express {
+function buildApp(deps: OrgSettingsRouterDeps): Express {
   const app = express();
   app.use(express.json());
 
   // Simulate what resolveTenant does: attach req.org and req.dbClient
   app.use((req, _res, next) => {
-    req.org = { id: 'org-uuid', slug: 'my-cinema', name: 'My Cinema', status: 'active', schema_name: 'org_my_cinema' } as express.Request['org'];
+    req.org = { id: 'org-uuid', slug: 'my-cinema', name: 'My Cinema', status: 'active', schema_name: 'org_my_cinema' } as Request['org'];
     req.dbClient = {
       query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
       release: vi.fn(),
-    } as express.Request['dbClient'];
+    } as Request['dbClient'];
     next();
   });
 
-  app.use('/settings', createOrgSettingsRouter());
+  app.use('/settings', createOrgSettingsRouter(deps));
+  addErrorHandler(app);
   return app;
 }
 
@@ -124,7 +133,7 @@ describe('GET /settings (public)', () => {
   });
 
   it('returns 200 with public settings', async () => {
-    const app = buildApp();
+    const app = buildApp(makeDeps());
     const res = await request(app).get('/settings');
 
     expect(res.status).toBe(200);
@@ -144,7 +153,7 @@ describe('GET /settings (public)', () => {
       importSettings: vi.fn(),
     } as unknown as InstanceType<typeof OrgSettingsService>));
 
-    const app = buildApp();
+    const app = buildApp(makeDeps());
     const res = await request(app).get('/settings');
 
     expect(res.status).toBe(404);
@@ -166,7 +175,7 @@ describe('GET /settings/admin', () => {
   });
 
   it('returns 200 with full settings including email fields', async () => {
-    const app = buildApp();
+    const app = buildApp(makeDeps());
     const res = await request(app)
       .get('/settings/admin')
       .set('Authorization', 'Bearer token');
@@ -186,7 +195,7 @@ describe('GET /settings/admin', () => {
       importSettings: vi.fn(),
     } as unknown as InstanceType<typeof OrgSettingsService>));
 
-    const app = buildApp();
+    const app = buildApp(makeDeps());
     const res = await request(app)
       .get('/settings/admin')
       .set('Authorization', 'Bearer token');
@@ -210,7 +219,7 @@ describe('PUT /settings', () => {
   });
 
   it('returns 200 with updated settings', async () => {
-    const app = buildApp();
+    const app = buildApp(makeDeps());
     const res = await request(app)
       .put('/settings')
       .set('Authorization', 'Bearer token')
@@ -222,7 +231,7 @@ describe('PUT /settings', () => {
   });
 
   it('returns 400 when site_name exceeds max length', async () => {
-    const app = buildApp();
+    const app = buildApp(makeDeps());
     const res = await request(app)
       .put('/settings')
       .set('Authorization', 'Bearer token')
@@ -232,7 +241,7 @@ describe('PUT /settings', () => {
   });
 
   it('returns 400 when footer link has invalid protocol', async () => {
-    const app = buildApp();
+    const app = buildApp(makeDeps());
     const res = await request(app)
       .put('/settings')
       .set('Authorization', 'Bearer token')
@@ -242,7 +251,7 @@ describe('PUT /settings', () => {
   });
 
   it('returns 400 when scrape_mode is invalid', async () => {
-    const app = buildApp();
+    const app = buildApp(makeDeps());
     const res = await request(app)
       .put('/settings')
       .set('Authorization', 'Bearer token')
@@ -252,7 +261,7 @@ describe('PUT /settings', () => {
   });
 
   it('returns 400 when scrape_days is out of range', async () => {
-    const app = buildApp();
+    const app = buildApp(makeDeps());
     const res = await request(app)
       .put('/settings')
       .set('Authorization', 'Bearer token')
@@ -271,7 +280,7 @@ describe('PUT /settings', () => {
       importSettings: vi.fn(),
     } as unknown as InstanceType<typeof OrgSettingsService>));
 
-    const app = buildApp();
+    const app = buildApp(makeDeps());
     const res = await request(app)
       .put('/settings')
       .set('Authorization', 'Bearer token')
@@ -294,7 +303,7 @@ describe('POST /settings/reset', () => {
       importSettings: vi.fn(),
     } as unknown as InstanceType<typeof OrgSettingsService>));
 
-    const app = buildApp();
+    const app = buildApp(makeDeps());
     const res = await request(app)
       .post('/settings/reset')
       .set('Authorization', 'Bearer token');
@@ -313,7 +322,7 @@ describe('POST /settings/reset', () => {
       importSettings: vi.fn(),
     } as unknown as InstanceType<typeof OrgSettingsService>));
 
-    const app = buildApp();
+    const app = buildApp(makeDeps());
     const res = await request(app)
       .post('/settings/reset')
       .set('Authorization', 'Bearer token');
@@ -341,7 +350,7 @@ describe('POST /settings/export', () => {
       importSettings: vi.fn(),
     } as unknown as InstanceType<typeof OrgSettingsService>));
 
-    const app = buildApp();
+    const app = buildApp(makeDeps());
     const res = await request(app)
       .post('/settings/export')
       .set('Authorization', 'Bearer token');
@@ -361,7 +370,7 @@ describe('POST /settings/export', () => {
       importSettings: vi.fn(),
     } as unknown as InstanceType<typeof OrgSettingsService>));
 
-    const app = buildApp();
+    const app = buildApp(makeDeps());
     const res = await request(app)
       .post('/settings/export')
       .set('Authorization', 'Bearer token');
@@ -392,7 +401,7 @@ describe('POST /settings/import', () => {
       exportSettings: vi.fn(),
     } as unknown as InstanceType<typeof OrgSettingsService>));
 
-    const app = buildApp();
+    const app = buildApp(makeDeps());
     const res = await request(app)
       .post('/settings/import')
       .set('Authorization', 'Bearer token')
@@ -412,7 +421,7 @@ describe('POST /settings/import', () => {
       exportSettings: vi.fn(),
     } as unknown as InstanceType<typeof OrgSettingsService>));
 
-    const app = buildApp();
+    const app = buildApp(makeDeps());
     const res = await request(app)
       .post('/settings/import')
       .set('Authorization', 'Bearer token')
@@ -431,7 +440,7 @@ describe('POST /settings/import', () => {
       exportSettings: vi.fn(),
     } as unknown as InstanceType<typeof OrgSettingsService>));
 
-    const app = buildApp();
+    const app = buildApp(makeDeps());
     const res = await request(app)
       .post('/settings/import')
       .set('Authorization', 'Bearer token')
@@ -450,7 +459,7 @@ describe('POST /settings/import', () => {
       exportSettings: vi.fn(),
     } as unknown as InstanceType<typeof OrgSettingsService>));
 
-    const app = buildApp();
+    const app = buildApp(makeDeps());
     const res = await request(app)
       .post('/settings/import')
       .set('Authorization', 'Bearer token')

--- a/packages/saas/src/routes/org-settings.test.ts
+++ b/packages/saas/src/routes/org-settings.test.ts
@@ -1,0 +1,461 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express, { type Express } from 'express';
+import request from 'supertest';
+
+// ── Mock server middleware that depends on module-level JWT validation ─────────
+vi.mock('../../../../server/src/middleware/auth.js', () => ({
+  requireAuth: vi.fn((_req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    (_req as express.Request & { user?: unknown }).user = {
+      id: 1,
+      username: 'admin',
+      role_name: 'admin',
+      is_system_role: true,
+      permissions: [
+        'settings:read',
+        'settings:update',
+        'settings:reset',
+        'settings:export',
+        'settings:import',
+      ],
+    };
+    next();
+  }),
+}));
+
+vi.mock('../../../../server/src/middleware/permission.js', () => ({
+  requirePermission: vi.fn(() => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next()),
+}));
+
+vi.mock('../../../../server/src/middleware/rate-limit.js', () => ({
+  protectedLimiter: vi.fn((_req: express.Request, _res: express.Response, next: express.NextFunction) => next()),
+}));
+
+vi.mock('../../../../server/src/utils/image-validator.js', () => ({
+  validateImage: vi.fn().mockResolvedValue({ valid: true, compressedBase64: 'data:image/png;base64,abc' }),
+}));
+
+// ── Mock OrgSettingsService ────────────────────────────────────────────────────
+vi.mock('../services/org-settings-service.js', () => ({
+  OrgSettingsService: vi.fn(),
+}));
+
+import { createOrgSettingsRouter } from '../routes/org-settings.js';
+import { OrgSettingsService } from '../services/org-settings-service.js';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const FULL_SETTINGS = {
+  id: 1,
+  site_name: 'My Cinema',
+  logo_base64: null,
+  favicon_base64: null,
+  color_primary: '#FECC00',
+  color_secondary: '#1F2937',
+  color_accent: '#F59E0B',
+  color_background: '#FFFFFF',
+  color_surface: '#F3F4F6',
+  color_text_primary: '#111827',
+  color_text_secondary: '#6B7280',
+  color_success: '#10B981',
+  color_error: '#EF4444',
+  font_primary: 'Inter',
+  font_secondary: 'Roboto',
+  footer_text: null,
+  footer_links: [],
+  email_from_name: 'My Cinema',
+  email_from_address: 'no-reply@mycinema.com',
+  scrape_mode: 'weekly',
+  scrape_days: 7,
+  updated_at: '2026-01-01T00:00:00.000Z',
+  updated_by: null,
+};
+
+const PUBLIC_SETTINGS = {
+  site_name: 'My Cinema',
+  logo_base64: null,
+  favicon_base64: null,
+  color_primary: '#FECC00',
+  color_secondary: '#1F2937',
+  color_accent: '#F59E0B',
+  color_background: '#FFFFFF',
+  color_surface: '#F3F4F6',
+  color_text_primary: '#111827',
+  color_text_secondary: '#6B7280',
+  color_success: '#10B981',
+  color_error: '#EF4444',
+  font_primary: 'Inter',
+  font_secondary: 'Roboto',
+  footer_text: null,
+  footer_links: [],
+};
+
+// ── App builder ───────────────────────────────────────────────────────────────
+
+function buildApp(): Express {
+  const app = express();
+  app.use(express.json());
+
+  // Simulate what resolveTenant does: attach req.org and req.dbClient
+  app.use((req, _res, next) => {
+    req.org = { id: 'org-uuid', slug: 'my-cinema', name: 'My Cinema', status: 'active', schema_name: 'org_my_cinema' } as express.Request['org'];
+    req.dbClient = {
+      query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+      release: vi.fn(),
+    } as express.Request['dbClient'];
+    next();
+  });
+
+  app.use('/settings', createOrgSettingsRouter());
+  return app;
+}
+
+// ── GET /settings (public) ───────────────────────────────────────────────────
+
+describe('GET /settings (public)', () => {
+  beforeEach(() => {
+    vi.mocked(OrgSettingsService).mockImplementation(() => ({
+      getPublicSettings: vi.fn().mockResolvedValue(PUBLIC_SETTINGS),
+      getSettings: vi.fn(),
+      updateSettings: vi.fn(),
+      resetSettings: vi.fn(),
+      exportSettings: vi.fn(),
+      importSettings: vi.fn(),
+    } as unknown as InstanceType<typeof OrgSettingsService>));
+  });
+
+  it('returns 200 with public settings', async () => {
+    const app = buildApp();
+    const res = await request(app).get('/settings');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.site_name).toBe('My Cinema');
+    // sensitive fields must not be present
+    expect(res.body.data.email_from_name).toBeUndefined();
+  });
+
+  it('returns 404 when no settings exist', async () => {
+    vi.mocked(OrgSettingsService).mockImplementationOnce(() => ({
+      getPublicSettings: vi.fn().mockResolvedValue(undefined),
+      getSettings: vi.fn(),
+      updateSettings: vi.fn(),
+      resetSettings: vi.fn(),
+      exportSettings: vi.fn(),
+      importSettings: vi.fn(),
+    } as unknown as InstanceType<typeof OrgSettingsService>));
+
+    const app = buildApp();
+    const res = await request(app).get('/settings');
+
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── GET /settings/admin (auth required) ──────────────────────────────────────
+
+describe('GET /settings/admin', () => {
+  beforeEach(() => {
+    vi.mocked(OrgSettingsService).mockImplementation(() => ({
+      getSettings: vi.fn().mockResolvedValue(FULL_SETTINGS),
+      getPublicSettings: vi.fn(),
+      updateSettings: vi.fn(),
+      resetSettings: vi.fn(),
+      exportSettings: vi.fn(),
+      importSettings: vi.fn(),
+    } as unknown as InstanceType<typeof OrgSettingsService>));
+  });
+
+  it('returns 200 with full settings including email fields', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .get('/settings/admin')
+      .set('Authorization', 'Bearer token');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.email_from_name).toBe('My Cinema');
+  });
+
+  it('returns 404 when no settings exist', async () => {
+    vi.mocked(OrgSettingsService).mockImplementationOnce(() => ({
+      getSettings: vi.fn().mockResolvedValue(undefined),
+      getPublicSettings: vi.fn(),
+      updateSettings: vi.fn(),
+      resetSettings: vi.fn(),
+      exportSettings: vi.fn(),
+      importSettings: vi.fn(),
+    } as unknown as InstanceType<typeof OrgSettingsService>));
+
+    const app = buildApp();
+    const res = await request(app)
+      .get('/settings/admin')
+      .set('Authorization', 'Bearer token');
+
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── PUT /settings ─────────────────────────────────────────────────────────────
+
+describe('PUT /settings', () => {
+  beforeEach(() => {
+    vi.mocked(OrgSettingsService).mockImplementation(() => ({
+      updateSettings: vi.fn().mockResolvedValue({ ...FULL_SETTINGS, site_name: 'Updated' }),
+      getSettings: vi.fn(),
+      getPublicSettings: vi.fn(),
+      resetSettings: vi.fn(),
+      exportSettings: vi.fn(),
+      importSettings: vi.fn(),
+    } as unknown as InstanceType<typeof OrgSettingsService>));
+  });
+
+  it('returns 200 with updated settings', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .put('/settings')
+      .set('Authorization', 'Bearer token')
+      .send({ site_name: 'Updated' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.site_name).toBe('Updated');
+  });
+
+  it('returns 400 when site_name exceeds max length', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .put('/settings')
+      .set('Authorization', 'Bearer token')
+      .send({ site_name: 'A'.repeat(101) });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when footer link has invalid protocol', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .put('/settings')
+      .set('Authorization', 'Bearer token')
+      .send({ footer_links: [{ label: 'XSS', url: 'javascript:alert(1)' }] });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when scrape_mode is invalid', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .put('/settings')
+      .set('Authorization', 'Bearer token')
+      .send({ scrape_mode: 'invalid_mode' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when scrape_days is out of range', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .put('/settings')
+      .set('Authorization', 'Bearer token')
+      .send({ scrape_days: 99 });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 when update returns undefined', async () => {
+    vi.mocked(OrgSettingsService).mockImplementationOnce(() => ({
+      updateSettings: vi.fn().mockResolvedValue(undefined),
+      getSettings: vi.fn(),
+      getPublicSettings: vi.fn(),
+      resetSettings: vi.fn(),
+      exportSettings: vi.fn(),
+      importSettings: vi.fn(),
+    } as unknown as InstanceType<typeof OrgSettingsService>));
+
+    const app = buildApp();
+    const res = await request(app)
+      .put('/settings')
+      .set('Authorization', 'Bearer token')
+      .send({ site_name: 'X' });
+
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── POST /settings/reset ──────────────────────────────────────────────────────
+
+describe('POST /settings/reset', () => {
+  it('returns 200 with default settings', async () => {
+    vi.mocked(OrgSettingsService).mockImplementation(() => ({
+      resetSettings: vi.fn().mockResolvedValue(FULL_SETTINGS),
+      getSettings: vi.fn(),
+      getPublicSettings: vi.fn(),
+      updateSettings: vi.fn(),
+      exportSettings: vi.fn(),
+      importSettings: vi.fn(),
+    } as unknown as InstanceType<typeof OrgSettingsService>));
+
+    const app = buildApp();
+    const res = await request(app)
+      .post('/settings/reset')
+      .set('Authorization', 'Bearer token');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('returns 500 when reset fails', async () => {
+    vi.mocked(OrgSettingsService).mockImplementation(() => ({
+      resetSettings: vi.fn().mockResolvedValue(undefined),
+      getSettings: vi.fn(),
+      getPublicSettings: vi.fn(),
+      updateSettings: vi.fn(),
+      exportSettings: vi.fn(),
+      importSettings: vi.fn(),
+    } as unknown as InstanceType<typeof OrgSettingsService>));
+
+    const app = buildApp();
+    const res = await request(app)
+      .post('/settings/reset')
+      .set('Authorization', 'Bearer token');
+
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── POST /settings/export ─────────────────────────────────────────────────────
+
+describe('POST /settings/export', () => {
+  it('returns 200 with export data', async () => {
+    const exportData = {
+      version: '1.0',
+      exported_at: new Date().toISOString(),
+      settings: { site_name: 'My Cinema' },
+    };
+
+    vi.mocked(OrgSettingsService).mockImplementation(() => ({
+      exportSettings: vi.fn().mockResolvedValue(exportData),
+      getSettings: vi.fn(),
+      getPublicSettings: vi.fn(),
+      updateSettings: vi.fn(),
+      resetSettings: vi.fn(),
+      importSettings: vi.fn(),
+    } as unknown as InstanceType<typeof OrgSettingsService>));
+
+    const app = buildApp();
+    const res = await request(app)
+      .post('/settings/export')
+      .set('Authorization', 'Bearer token');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.version).toBe('1.0');
+  });
+
+  it('returns 404 when nothing to export', async () => {
+    vi.mocked(OrgSettingsService).mockImplementation(() => ({
+      exportSettings: vi.fn().mockResolvedValue(undefined),
+      getSettings: vi.fn(),
+      getPublicSettings: vi.fn(),
+      updateSettings: vi.fn(),
+      resetSettings: vi.fn(),
+      importSettings: vi.fn(),
+    } as unknown as InstanceType<typeof OrgSettingsService>));
+
+    const app = buildApp();
+    const res = await request(app)
+      .post('/settings/export')
+      .set('Authorization', 'Bearer token');
+
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── POST /settings/import ─────────────────────────────────────────────────────
+
+describe('POST /settings/import', () => {
+  const VALID_IMPORT = {
+    version: '1.0',
+    exported_at: '2026-01-01T00:00:00.000Z',
+    settings: {
+      site_name: 'Imported Cinema',
+      color_primary: '#FECC00',
+    },
+  };
+
+  it('returns 200 with imported settings', async () => {
+    vi.mocked(OrgSettingsService).mockImplementation(() => ({
+      importSettings: vi.fn().mockResolvedValue(FULL_SETTINGS),
+      getSettings: vi.fn(),
+      getPublicSettings: vi.fn(),
+      updateSettings: vi.fn(),
+      resetSettings: vi.fn(),
+      exportSettings: vi.fn(),
+    } as unknown as InstanceType<typeof OrgSettingsService>));
+
+    const app = buildApp();
+    const res = await request(app)
+      .post('/settings/import')
+      .set('Authorization', 'Bearer token')
+      .send(VALID_IMPORT);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('returns 400 when import data is missing version', async () => {
+    vi.mocked(OrgSettingsService).mockImplementation(() => ({
+      importSettings: vi.fn(),
+      getSettings: vi.fn(),
+      getPublicSettings: vi.fn(),
+      updateSettings: vi.fn(),
+      resetSettings: vi.fn(),
+      exportSettings: vi.fn(),
+    } as unknown as InstanceType<typeof OrgSettingsService>));
+
+    const app = buildApp();
+    const res = await request(app)
+      .post('/settings/import')
+      .set('Authorization', 'Bearer token')
+      .send({ settings: {} }); // missing version
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when importSettings throws a version error', async () => {
+    vi.mocked(OrgSettingsService).mockImplementation(() => ({
+      importSettings: vi.fn().mockRejectedValue(new Error('Incompatible version: 2.0. Expected 1.0')),
+      getSettings: vi.fn(),
+      getPublicSettings: vi.fn(),
+      updateSettings: vi.fn(),
+      resetSettings: vi.fn(),
+      exportSettings: vi.fn(),
+    } as unknown as InstanceType<typeof OrgSettingsService>));
+
+    const app = buildApp();
+    const res = await request(app)
+      .post('/settings/import')
+      .set('Authorization', 'Bearer token')
+      .send(VALID_IMPORT);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 when import succeeds but returns undefined', async () => {
+    vi.mocked(OrgSettingsService).mockImplementation(() => ({
+      importSettings: vi.fn().mockResolvedValue(undefined),
+      getSettings: vi.fn(),
+      getPublicSettings: vi.fn(),
+      updateSettings: vi.fn(),
+      resetSettings: vi.fn(),
+      exportSettings: vi.fn(),
+    } as unknown as InstanceType<typeof OrgSettingsService>));
+
+    const app = buildApp();
+    const res = await request(app)
+      .post('/settings/import')
+      .set('Authorization', 'Bearer token')
+      .send(VALID_IMPORT);
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/packages/saas/src/routes/org-settings.ts
+++ b/packages/saas/src/routes/org-settings.ts
@@ -1,0 +1,354 @@
+import {
+  Router,
+  type Request,
+  type Response,
+  type NextFunction,
+  type RequestHandler,
+} from 'express';
+import { OrgSettingsService } from '../services/org-settings-service.js';
+import type { OrgSettingsUpdate, OrgSettingsExport, ScrapeMode } from '../services/org-settings-service.js';
+
+// ── Minimal inline types (avoids cross-package rootDir violation) ─────────────
+
+interface ApiResponse {
+  success: boolean;
+  data?: unknown;
+  error?: string;
+}
+
+/** Minimal user shape attached by requireAuth */
+interface AuthUser {
+  id: number;
+  username: string;
+  role_name: string;
+  is_system_role: boolean;
+  permissions: string[];
+  org_id?: string;
+  org_slug?: string;
+}
+
+interface AuthRequest extends Request {
+  user?: AuthUser;
+}
+
+/** Minimal image validation result */
+interface ImageValidationResult {
+  valid: boolean;
+  error?: string;
+  compressedBase64?: string;
+}
+
+// ── Injectable middleware types ───────────────────────────────────────────────
+
+type AuthMiddleware = RequestHandler;
+type PermissionMiddlewareFactory = (permission: string) => RequestHandler;
+type ImageValidator = (
+  data: string,
+  type: 'logo' | 'favicon',
+  maxBytes: number,
+) => Promise<ImageValidationResult>;
+type ErrorFactory = (message: string) => Error & { statusCode?: number };
+
+/** Dependencies injected by the caller (allows full decoupling from server pkg) */
+export interface OrgSettingsRouterDeps {
+  requireAuth: AuthMiddleware;
+  requirePermission: PermissionMiddlewareFactory;
+  protectedLimiter: AuthMiddleware;
+  validateImage: ImageValidator;
+  /** Factory that produces a 404 error */
+  notFoundError: ErrorFactory;
+  /** Factory that produces a 400 validation error */
+  validationError: ErrorFactory;
+  logger: { info: (msg: string, meta?: Record<string, unknown>) => void };
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const LOGO_MAX_SIZE = 200000; // 200 KB
+const FAVICON_MAX_SIZE = 50000; // 50 KB
+
+const VALID_SCRAPE_MODES: ScrapeMode[] = ['weekly', 'from_today', 'from_today_limited'];
+const SCRAPE_DAYS_MIN = 1;
+const SCRAPE_DAYS_MAX = 14;
+
+const INPUT_LIMITS: Record<string, number> = {
+  site_name: 100,
+  footer_text: 500,
+  email_from_name: 100,
+  email_from_address: 255,
+  font_primary: 100,
+  font_secondary: 100,
+};
+
+// ── Router factory ────────────────────────────────────────────────────────────
+
+/**
+ * Creates the settings sub-router for an org.
+ * Mounted at /api/org/:slug/settings by createOrgRouter().
+ * Assumes resolveTenant middleware has already run (req.org and req.dbClient set).
+ *
+ * All server-specific dependencies are injected so this router stays within
+ * the saas package's rootDir and can be unit-tested in isolation.
+ */
+export function createOrgSettingsRouter(deps: OrgSettingsRouterDeps): Router {
+  const {
+    requireAuth,
+    requirePermission,
+    protectedLimiter,
+    validateImage,
+    notFoundError,
+    validationError,
+    logger,
+  } = deps;
+
+  const router = Router({ mergeParams: true });
+
+  // ── GET /settings (public) ─────────────────────────────────────────────────
+  router.get('/', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const svc = new OrgSettingsService(req.dbClient!);
+      const settings = await svc.getPublicSettings();
+
+      if (!settings) {
+        return next(notFoundError('Settings not found'));
+      }
+
+      const response: ApiResponse = { success: true, data: settings };
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  // ── GET /settings/admin (auth required) ────────────────────────────────────
+  router.get(
+    '/admin',
+    protectedLimiter,
+    requireAuth,
+    requirePermission('settings:read'),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const svc = new OrgSettingsService(req.dbClient!);
+        const settings = await svc.getSettings();
+
+        if (!settings) {
+          return next(notFoundError('Settings not found'));
+        }
+
+        const response: ApiResponse = { success: true, data: settings };
+        res.json(response);
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  // ── PUT /settings (auth required) ─────────────────────────────────────────
+  router.put(
+    '/',
+    protectedLimiter,
+    requireAuth,
+    requirePermission('settings:update'),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const authReq = req as AuthRequest;
+        const updates: OrgSettingsUpdate = req.body;
+
+        // Validate logo
+        if (updates.logo_base64) {
+          const logoValidation = await validateImage(updates.logo_base64, 'logo', LOGO_MAX_SIZE);
+          if (!logoValidation.valid) {
+            return next(validationError(`Invalid logo: ${logoValidation.error}`));
+          }
+          updates.logo_base64 = logoValidation.compressedBase64!;
+        }
+
+        // Validate favicon
+        if (updates.favicon_base64) {
+          const faviconValidation = await validateImage(
+            updates.favicon_base64,
+            'favicon',
+            FAVICON_MAX_SIZE,
+          );
+          if (!faviconValidation.valid) {
+            return next(validationError(`Invalid favicon: ${faviconValidation.error}`));
+          }
+          updates.favicon_base64 = faviconValidation.compressedBase64!;
+        }
+
+        // Validate text field lengths
+        for (const [field, limit] of Object.entries(INPUT_LIMITS)) {
+          const value = updates[field as keyof OrgSettingsUpdate];
+          if (typeof value === 'string' && value.length > limit) {
+            return next(
+              validationError(`${field} exceeds maximum length of ${limit} characters`),
+            );
+          }
+        }
+
+        // Validate footer links — prevent stored XSS via javascript: / data: URIs
+        if (updates.footer_links && Array.isArray(updates.footer_links)) {
+          for (const link of updates.footer_links) {
+            if (link.url) {
+              try {
+                const parsedUrl = new URL(link.url, 'http://dummy.com');
+                if (
+                  parsedUrl.protocol !== 'http:' &&
+                  parsedUrl.protocol !== 'https:' &&
+                  parsedUrl.protocol !== 'mailto:' &&
+                  parsedUrl.protocol !== 'tel:'
+                ) {
+                  return next(
+                    validationError(`Invalid URL protocol in footer link: ${link.url}`),
+                  );
+                }
+              } catch {
+                return next(
+                  validationError(`Invalid URL format in footer link: ${link.url}`),
+                );
+              }
+            }
+          }
+        }
+
+        // Validate scrape_mode
+        if (updates.scrape_mode !== undefined) {
+          if (!VALID_SCRAPE_MODES.includes(updates.scrape_mode)) {
+            return next(
+              validationError(
+                `Invalid scrape_mode: must be one of ${VALID_SCRAPE_MODES.join(', ')}`,
+              ),
+            );
+          }
+        }
+
+        // Validate scrape_days
+        if (updates.scrape_days !== undefined) {
+          const days = updates.scrape_days;
+          if (!Number.isInteger(days) || days < SCRAPE_DAYS_MIN || days > SCRAPE_DAYS_MAX) {
+            return next(
+              validationError(
+                `Invalid scrape_days: must be an integer between ${SCRAPE_DAYS_MIN} and ${SCRAPE_DAYS_MAX}`,
+              ),
+            );
+          }
+        }
+
+        const svc = new OrgSettingsService(req.dbClient!);
+        const updatedSettings = await svc.updateSettings(updates, authReq.user!.id);
+
+        if (!updatedSettings) {
+          return next(new Error('Failed to update settings'));
+        }
+
+        logger.info(`Org settings updated by user ${authReq.user!.username}`, {
+          orgSlug: req.org?.slug,
+          userId: authReq.user!.id,
+          updatedFields: Object.keys(updates),
+        });
+
+        const response: ApiResponse = { success: true, data: updatedSettings };
+        res.json(response);
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  // ── POST /settings/reset ───────────────────────────────────────────────────
+  router.post(
+    '/reset',
+    protectedLimiter,
+    requireAuth,
+    requirePermission('settings:reset'),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const authReq = req as AuthRequest;
+        const svc = new OrgSettingsService(req.dbClient!);
+        const defaultSettings = await svc.resetSettings(authReq.user!.id);
+
+        if (!defaultSettings) {
+          return next(new Error('Failed to reset settings'));
+        }
+
+        logger.info(`Org settings reset to defaults by user ${authReq.user!.username}`, {
+          orgSlug: req.org?.slug,
+          userId: authReq.user!.id,
+        });
+
+        const response: ApiResponse = { success: true, data: defaultSettings };
+        res.json(response);
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  // ── POST /settings/export ──────────────────────────────────────────────────
+  router.post(
+    '/export',
+    protectedLimiter,
+    requireAuth,
+    requirePermission('settings:export'),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const authReq = req as AuthRequest;
+        const svc = new OrgSettingsService(req.dbClient!);
+        const exportData = await svc.exportSettings();
+
+        if (!exportData) {
+          return next(notFoundError('No settings to export'));
+        }
+
+        logger.info('Org settings exported', {
+          orgSlug: req.org?.slug,
+          userId: authReq.user!.id,
+        });
+
+        const response: ApiResponse = { success: true, data: exportData };
+        res.json(response);
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  // ── POST /settings/import ──────────────────────────────────────────────────
+  router.post(
+    '/import',
+    protectedLimiter,
+    requireAuth,
+    requirePermission('settings:import'),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const authReq = req as AuthRequest;
+        const importData: OrgSettingsExport = req.body;
+
+        // Basic structure check before delegating to service
+        if (!importData.version || !importData.settings) {
+          return next(validationError('Invalid import data format'));
+        }
+
+        const svc = new OrgSettingsService(req.dbClient!);
+        const importedSettings = await svc.importSettings(importData, authReq.user!.id);
+
+        if (!importedSettings) {
+          return next(new Error('Failed to import settings'));
+        }
+
+        logger.info(`Org settings imported by user ${authReq.user!.username}`, {
+          orgSlug: req.org?.slug,
+          userId: authReq.user!.id,
+          version: importData.version,
+        });
+
+        const response: ApiResponse = { success: true, data: importedSettings };
+        res.json(response);
+      } catch (error) {
+        return next(error instanceof Error ? validationError(error.message) : error);
+      }
+    },
+  );
+
+  return router;
+}

--- a/packages/saas/src/routes/org.ts
+++ b/packages/saas/src/routes/org.ts
@@ -1,12 +1,13 @@
 import { Router, type Request, type Response } from 'express';
 import { resolveTenant } from '../middleware/tenant.js';
+import { checkQuota } from '../middleware/quota.js';
 
 /**
  * All routes under /api/org/:slug/* use the resolveTenant middleware,
- * which sets req.org and req.dbClient (pg client with search_path scoped to org schema).
+ * which sets req.org and scopes the DB connection to the org schema.
  *
- * Route handlers should use req.dbClient instead of req.app.get('db')
- * to benefit from the schema isolation.
+ * Quota enforcement is applied via checkQuota('resource') before any
+ * write operation that creates cinemas, users, or triggers scrapes.
  */
 export function createOrgRouter(): Router {
   const router = Router({ mergeParams: true });
@@ -14,10 +15,7 @@ export function createOrgRouter(): Router {
   // Apply tenant resolution to all org routes
   router.use(resolveTenant);
 
-  // TODO Phase 5: re-mount core resource routes under org context
-  // e.g. cinemas, showtimes, reports, settings, users, scraper
-
-  // Temporary health check to verify tenant resolution
+  // ── Health / ping ──────────────────────────────────────────────────────────
   router.get('/ping', (req: Request, res: Response) => {
     res.json({
       success: true,
@@ -28,6 +26,25 @@ export function createOrgRouter(): Router {
         status: req.org!.status,
       },
     });
+  });
+
+  // ── Cinemas ────────────────────────────────────────────────────────────────
+  // POST /api/org/:slug/cinemas — quota-guarded cinema creation
+  // Full implementation in Phase 5 (core route re-mount under org context)
+  router.post('/cinemas', checkQuota('cinemas'), (_req: Request, res: Response) => {
+    res.status(501).json({ success: false, error: 'Not implemented — Phase 5' });
+  });
+
+  // ── Users / invitations ────────────────────────────────────────────────────
+  // POST /api/org/:slug/users — quota-guarded user creation (direct, no invite)
+  router.post('/users', checkQuota('users'), (_req: Request, res: Response) => {
+    res.status(501).json({ success: false, error: 'Not implemented — Phase 5' });
+  });
+
+  // ── Scrape trigger ─────────────────────────────────────────────────────────
+  // POST /api/org/:slug/scrape — quota-guarded scrape trigger
+  router.post('/scrape', checkQuota('scrapes'), (_req: Request, res: Response) => {
+    res.status(501).json({ success: false, error: 'Not implemented — Phase 5' });
   });
 
   return router;

--- a/packages/saas/src/routes/org.ts
+++ b/packages/saas/src/routes/org.ts
@@ -1,0 +1,34 @@
+import { Router, type Request, type Response } from 'express';
+import { resolveTenant } from '../middleware/tenant.js';
+
+/**
+ * All routes under /api/org/:slug/* use the resolveTenant middleware,
+ * which sets req.org and req.dbClient (pg client with search_path scoped to org schema).
+ *
+ * Route handlers should use req.dbClient instead of req.app.get('db')
+ * to benefit from the schema isolation.
+ */
+export function createOrgRouter(): Router {
+  const router = Router({ mergeParams: true });
+
+  // Apply tenant resolution to all org routes
+  router.use(resolveTenant);
+
+  // TODO Phase 5: re-mount core resource routes under org context
+  // e.g. cinemas, showtimes, reports, settings, users, scraper
+
+  // Temporary health check to verify tenant resolution
+  router.get('/ping', (req: Request, res: Response) => {
+    res.json({
+      success: true,
+      org: {
+        id: req.org!.id,
+        slug: req.org!.slug,
+        name: req.org!.name,
+        status: req.org!.status,
+      },
+    });
+  });
+
+  return router;
+}

--- a/packages/saas/src/routes/org.ts
+++ b/packages/saas/src/routes/org.ts
@@ -2,6 +2,7 @@ import { Router, type Request, type Response } from 'express';
 import { resolveTenant } from '../middleware/tenant.js';
 import { checkQuota } from '../middleware/quota.js';
 import { createOrgSettingsRouter, type OrgSettingsRouterDeps } from './org-settings.js';
+import { createOrgExportRouter } from './org-export.js';
 
 /**
  * All routes under /api/org/:slug/* use the resolveTenant middleware,
@@ -55,6 +56,10 @@ export function createOrgRouter(settingsDeps: OrgSettingsRouterDeps): Router {
   // ── Settings ───────────────────────────────────────────────────────────────
   // GET/PUT /api/org/:slug/settings, /settings/admin, /settings/reset, etc.
   router.use('/settings', createOrgSettingsRouter(settingsDeps));
+
+  // ── Export ─────────────────────────────────────────────────────────────────
+  // GET /api/org/:slug/export — full JSON export of org data
+  router.use('/', createOrgExportRouter());
 
   return router;
 }

--- a/packages/saas/src/routes/org.ts
+++ b/packages/saas/src/routes/org.ts
@@ -1,6 +1,7 @@
 import { Router, type Request, type Response } from 'express';
 import { resolveTenant } from '../middleware/tenant.js';
 import { checkQuota } from '../middleware/quota.js';
+import { createOrgSettingsRouter, type OrgSettingsRouterDeps } from './org-settings.js';
 
 /**
  * All routes under /api/org/:slug/* use the resolveTenant middleware,
@@ -8,8 +9,12 @@ import { checkQuota } from '../middleware/quota.js';
  *
  * Quota enforcement is applied via checkQuota('resource') before any
  * write operation that creates cinemas, users, or triggers scrapes.
+ *
+ * @param settingsDeps - Injected server-side dependencies for the settings router.
+ *   Passed in from plugin.ts at registration time so the saas package
+ *   itself does not need to cross the rootDir boundary at compile time.
  */
-export function createOrgRouter(): Router {
+export function createOrgRouter(settingsDeps: OrgSettingsRouterDeps): Router {
   const router = Router({ mergeParams: true });
 
   // Apply tenant resolution to all org routes
@@ -46,6 +51,10 @@ export function createOrgRouter(): Router {
   router.post('/scrape', checkQuota('scrapes'), (_req: Request, res: Response) => {
     res.status(501).json({ success: false, error: 'Not implemented — Phase 5' });
   });
+
+  // ── Settings ───────────────────────────────────────────────────────────────
+  // GET/PUT /api/org/:slug/settings, /settings/admin, /settings/reset, etc.
+  router.use('/settings', createOrgSettingsRouter(settingsDeps));
 
   return router;
 }

--- a/packages/saas/src/routes/register.test.ts
+++ b/packages/saas/src/routes/register.test.ts
@@ -59,6 +59,46 @@ function buildApp(db: DB, pool: Pool): Express {
 
 // ── tests ────────────────────────────────────────────────────────────────────
 
+describe('GET /api/orgs/:slug/available', () => {
+  it('returns available:true when slug is free', async () => {
+    const { isSlugAvailable } = await import('../db/org-queries.js');
+    vi.mocked(isSlugAvailable).mockResolvedValueOnce(true);
+
+    const { pool } = makePool();
+    const app = buildApp(makeDb(), pool);
+
+    const { default: supertest } = await import('supertest');
+    const response = await supertest(app).get('/api/orgs/free-slug/available');
+
+    expect(response.status).toBe(200);
+    expect(response.body.available).toBe(true);
+  });
+
+  it('returns available:false when slug is taken', async () => {
+    const { isSlugAvailable } = await import('../db/org-queries.js');
+    vi.mocked(isSlugAvailable).mockResolvedValueOnce(false);
+
+    const { pool } = makePool();
+    const app = buildApp(makeDb(), pool);
+
+    const { default: supertest } = await import('supertest');
+    const response = await supertest(app).get('/api/orgs/taken-slug/available');
+
+    expect(response.status).toBe(200);
+    expect(response.body.available).toBe(false);
+  });
+
+  it('returns 400 on invalid slug format', async () => {
+    const { pool } = makePool();
+    const app = buildApp(makeDb(), pool);
+
+    const { default: supertest } = await import('supertest');
+    const response = await supertest(app).get('/api/orgs/INVALID_SLUG/available');
+
+    expect(response.status).toBe(400);
+  });
+});
+
 describe('POST /api/auth/register (SaaS)', () => {
   beforeEach(() => {
     vi.stubEnv('JWT_SECRET', VALID_JWT_SECRET);

--- a/packages/saas/src/routes/register.test.ts
+++ b/packages/saas/src/routes/register.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import express, { type Express } from 'express';
-import { createRegisterRouter } from './register.js';
+import { createRegisterRouter, createSlugRouter } from './register.js';
 import type { DB, Pool } from '../db/types.js';
 
 // ── module mocks ─────────────────────────────────────────────────────────────
@@ -53,6 +53,7 @@ function buildApp(db: DB, pool: Pool): Express {
   app.use(express.json());
   app.set('db', db);
   app.set('pool', pool);
+  app.use('/api', createSlugRouter());
   app.use('/api', createRegisterRouter());
   return app;
 }

--- a/packages/saas/src/routes/register.test.ts
+++ b/packages/saas/src/routes/register.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express, { type Express } from 'express';
+import { createRegisterRouter } from './register.js';
+import type { DB, Pool } from '../db/types.js';
+
+// ── module mocks ─────────────────────────────────────────────────────────────
+
+// Mock org-service so we don't hit the filesystem (bootstrapOrgSchema reads SQL files)
+vi.mock('../services/org-service.js', () => ({
+  createOrg: vi.fn().mockResolvedValue({
+    org: {
+      id: 'org-uuid-1',
+      name: 'My Cinema',
+      slug: 'my-cinema',
+      plan_id: 1,
+      status: 'trial',
+      schema_name: 'org_my_cinema',
+      trial_ends_at: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+      created_at: new Date(),
+      updated_at: new Date(),
+    },
+    schemaCreated: true,
+  }),
+}));
+
+// Mock org-queries for slug availability check
+vi.mock('../db/org-queries.js', () => ({
+  isSlugAvailable: vi.fn().mockResolvedValue(true),
+  getOrgBySlug: vi.fn(),
+  insertOrg: vi.fn(),
+  slugToSchemaName: vi.fn((s: string) => `org_${s.replace(/-/g, '_')}`),
+}));
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const VALID_JWT_SECRET = 'test-secret-that-is-at-least-32-chars-long!!';
+
+function makeDb(): DB {
+  return { query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }) };
+}
+
+function makePool() {
+  const newUser = { id: 1, username: 'admin@my-cinema.com', role_id: 1, role_name: 'admin' };
+  const client = {
+    query: vi.fn().mockResolvedValue({ rows: [newUser], rowCount: 1 }),
+    release: vi.fn(),
+  };
+  return { pool: { connect: vi.fn().mockResolvedValue(client) }, client };
+}
+
+function buildApp(db: DB, pool: Pool): Express {
+  const app = express();
+  app.use(express.json());
+  app.set('db', db);
+  app.set('pool', pool);
+  app.use('/api', createRegisterRouter());
+  return app;
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+describe('POST /api/auth/register (SaaS)', () => {
+  beforeEach(() => {
+    vi.stubEnv('JWT_SECRET', VALID_JWT_SECRET);
+    vi.stubEnv('JWT_EXPIRES_IN', '24h');
+  });
+
+  it('returns 201 with org, admin user, and JWT token on success', async () => {
+    const { pool } = makePool();
+    const app = buildApp(makeDb(), pool);
+
+    const { default: supertest } = await import('supertest');
+    const response = await supertest(app)
+      .post('/api/auth/register')
+      .send({
+        orgName: 'My Cinema',
+        slug: 'my-cinema',
+        adminEmail: 'admin@my-cinema.com',
+        adminPassword: 'Password1!',
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body.success).toBe(true);
+    expect(response.body.org).toBeDefined();
+    expect(response.body.org.slug).toBe('my-cinema');
+    // Admin user must be in the response
+    expect(response.body.admin).toBeDefined();
+    expect(response.body.admin.username).toBe('admin@my-cinema.com');
+    // JWT token must be present
+    expect(response.body.token).toBeDefined();
+    expect(typeof response.body.token).toBe('string');
+    expect(response.body.token.split('.')).toHaveLength(3);
+  });
+
+  it('returns 409 when slug is already taken', async () => {
+    const { isSlugAvailable } = await import('../db/org-queries.js');
+    vi.mocked(isSlugAvailable).mockResolvedValueOnce(false);
+
+    const { pool } = makePool();
+    const app = buildApp(makeDb(), pool);
+
+    const { default: supertest } = await import('supertest');
+    const response = await supertest(app)
+      .post('/api/auth/register')
+      .send({
+        orgName: 'My Cinema',
+        slug: 'my-cinema',
+        adminEmail: 'admin@my-cinema.com',
+        adminPassword: 'Password1!',
+      });
+
+    expect(response.status).toBe(409);
+    expect(response.body.success).toBe(false);
+  });
+
+  it('returns 400 on missing required fields', async () => {
+    const { pool } = makePool();
+    const app = buildApp(makeDb(), pool);
+
+    const { default: supertest } = await import('supertest');
+    const response = await supertest(app)
+      .post('/api/auth/register')
+      .send({ orgName: 'X', slug: 'x' }); // missing email + password
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.errors).toBeDefined();
+  });
+
+  it('JWT payload contains org_id and org_slug', async () => {
+    const { pool } = makePool();
+    const app = buildApp(makeDb(), pool);
+
+    const { default: supertest } = await import('supertest');
+    const response = await supertest(app)
+      .post('/api/auth/register')
+      .send({
+        orgName: 'My Cinema',
+        slug: 'my-cinema',
+        adminEmail: 'admin@my-cinema.com',
+        adminPassword: 'Password1!',
+      });
+
+    expect(response.status).toBe(201);
+
+    const token = response.body.token as string;
+    const payloadB64 = token.split('.')[1];
+    const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf8'));
+
+    expect(payload.org_id).toBe('org-uuid-1');
+    expect(payload.org_slug).toBe('my-cinema');
+  });
+});

--- a/packages/saas/src/routes/register.test.ts
+++ b/packages/saas/src/routes/register.test.ts
@@ -54,7 +54,7 @@ function buildApp(db: DB, pool: Pool): Express {
   app.set('db', db);
   app.set('pool', pool);
   app.use('/api', createSlugRouter());
-  app.use('/api', createRegisterRouter());
+  app.use('/api/saas', createRegisterRouter());
   return app;
 }
 
@@ -100,7 +100,7 @@ describe('GET /api/orgs/:slug/available', () => {
   });
 });
 
-describe('POST /api/auth/register (SaaS)', () => {
+describe('POST /api/saas/register (SaaS)', () => {
   beforeEach(() => {
     vi.stubEnv('JWT_SECRET', VALID_JWT_SECRET);
     vi.stubEnv('JWT_EXPIRES_IN', '24h');
@@ -112,7 +112,7 @@ describe('POST /api/auth/register (SaaS)', () => {
 
     const { default: supertest } = await import('supertest');
     const response = await supertest(app)
-      .post('/api/auth/register')
+      .post('/api/saas/register')
       .send({
         orgName: 'My Cinema',
         slug: 'my-cinema',
@@ -142,7 +142,7 @@ describe('POST /api/auth/register (SaaS)', () => {
 
     const { default: supertest } = await import('supertest');
     const response = await supertest(app)
-      .post('/api/auth/register')
+      .post('/api/saas/register')
       .send({
         orgName: 'My Cinema',
         slug: 'my-cinema',
@@ -160,7 +160,7 @@ describe('POST /api/auth/register (SaaS)', () => {
 
     const { default: supertest } = await import('supertest');
     const response = await supertest(app)
-      .post('/api/auth/register')
+      .post('/api/saas/register')
       .send({ orgName: 'X', slug: 'x' }); // missing email + password
 
     expect(response.status).toBe(400);
@@ -174,7 +174,7 @@ describe('POST /api/auth/register (SaaS)', () => {
 
     const { default: supertest } = await import('supertest');
     const response = await supertest(app)
-      .post('/api/auth/register')
+      .post('/api/saas/register')
       .send({
         orgName: 'My Cinema',
         slug: 'my-cinema',
@@ -190,5 +190,49 @@ describe('POST /api/auth/register (SaaS)', () => {
 
     expect(payload.org_id).toBe('org-uuid-1');
     expect(payload.org_slug).toBe('my-cinema');
+  });
+});
+
+describe('POST /api/saas/register — route must be reachable at /saas/register, not /auth/register', () => {
+  beforeEach(() => {
+    vi.stubEnv('JWT_SECRET', VALID_JWT_SECRET);
+    vi.stubEnv('JWT_EXPIRES_IN', '24h');
+  });
+
+  it('returns 201 when called at /api/saas/register', async () => {
+    const { pool } = makePool();
+    const app = buildApp(makeDb(), pool);
+
+    const { default: supertest } = await import('supertest');
+    const response = await supertest(app)
+      .post('/api/saas/register')
+      .send({
+        orgName: 'My Cinema',
+        slug: 'my-cinema',
+        adminEmail: 'admin@my-cinema.com',
+        adminPassword: 'Password1!',
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body.success).toBe(true);
+  });
+
+  it('returns 404 when called at /api/auth/register (old conflicting path)', async () => {
+    const { pool } = makePool();
+    const app = buildApp(makeDb(), pool);
+
+    const { default: supertest } = await import('supertest');
+    const response = await supertest(app)
+      .post('/api/auth/register')
+      .send({
+        orgName: 'My Cinema',
+        slug: 'my-cinema',
+        adminEmail: 'admin@my-cinema.com',
+        adminPassword: 'Password1!',
+      });
+
+    // Must NOT be reachable at /api/auth/register to avoid collision with
+    // the core authRouter which requires authentication on that path.
+    expect(response.status).toBe(404);
   });
 });

--- a/packages/saas/src/routes/register.ts
+++ b/packages/saas/src/routes/register.ts
@@ -2,6 +2,7 @@ import { Router, type Request, type Response } from 'express';
 import { isSlugAvailable } from '../db/org-queries.js';
 import { createOrg } from '../services/org-service.js';
 import { SaasAuthService } from '../services/saas-auth-service.js';
+import { EmailService } from '../services/email-service.js';
 import type { DB, Pool } from '../db/types.js';
 
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{1,28}[a-z0-9]$/;
@@ -58,6 +59,18 @@ export function createRegisterRouter(): Router {
       roleName: adminUser.role_name,
       permissions: [], // Phase 3: load from org schema permissions table
     });
+
+    // Send email verification for the admin user (fire-and-forget, non-blocking)
+    try {
+      const emailService = new EmailService(pool);
+      const rawToken = emailService.generateVerificationToken();
+      await emailService.storeVerificationToken(org, adminUser.id, rawToken);
+      const prefixedToken = `${org.slug}:${rawToken}`;
+      await emailService.sendVerificationEmail(adminEmail, prefixedToken, org.slug);
+    } catch (_err) {
+      // Non-critical: log but do not fail registration if email dispatch fails
+      console.warn('[register] Failed to send verification email:', _err);
+    }
 
     return res.status(201).json({
       success: true,

--- a/packages/saas/src/routes/register.ts
+++ b/packages/saas/src/routes/register.ts
@@ -1,7 +1,8 @@
 import { Router, type Request, type Response } from 'express';
 import { isSlugAvailable } from '../db/org-queries.js';
 import { createOrg } from '../services/org-service.js';
-import type { DB } from '../db/types.js';
+import { SaasAuthService } from '../services/saas-auth-service.js';
+import type { DB, Pool } from '../db/types.js';
 
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{1,28}[a-z0-9]$/;
 
@@ -10,11 +11,12 @@ export function createRegisterRouter(): Router {
 
   /**
    * POST /api/auth/register
-   * Creates a new organization with its dedicated PostgreSQL schema.
+   * Creates a new organization with its dedicated PostgreSQL schema,
+   * provisions the admin user inside that schema, and returns a JWT.
    *
    * Body: { orgName, slug, adminEmail, adminPassword }
    */
-  router.post('/register', async (req: Request, res: Response) => {
+  router.post('/auth/register', async (req: Request, res: Response) => {
     const { orgName, slug, adminEmail, adminPassword } = req.body as Record<string, string>;
 
     // Basic validation
@@ -29,6 +31,7 @@ export function createRegisterRouter(): Router {
     }
 
     const db = req.app.get('db') as DB;
+    const pool = req.app.get('pool') as Pool;
 
     // Check slug availability before attempting creation
     const slugFree = await isSlugAvailable(db, slug);
@@ -43,10 +46,28 @@ export function createRegisterRouter(): Router {
       plan_id: 1, // Free plan by default
     });
 
-    // TODO (Phase 5): create admin user in org schema + return JWT
+    // Create admin user in the org's private schema and mint JWT
+    const authService = new SaasAuthService(pool);
+    const adminUser = await authService.createAdminUser(org, adminEmail, adminPassword);
+    const token = authService.mintJwt({
+      userId: adminUser.id,
+      username: adminUser.username,
+      orgId: org.id,
+      orgSlug: org.slug,
+      roleId: adminUser.role_id,
+      roleName: adminUser.role_name,
+      permissions: [], // Phase 3: load from org schema permissions table
+    });
 
     return res.status(201).json({
       success: true,
+      token,
+      admin: {
+        id: adminUser.id,
+        username: adminUser.username,
+        role_id: adminUser.role_id,
+        role_name: adminUser.role_name,
+      },
       org: {
         id: org.id,
         name: org.name,

--- a/packages/saas/src/routes/register.ts
+++ b/packages/saas/src/routes/register.ts
@@ -31,13 +31,13 @@ export function createRegisterRouter(): Router {
   const router = Router();
 
   /**
-   * POST /api/auth/register
+   * POST /api/saas/register
    * Creates a new organization with its dedicated PostgreSQL schema,
    * provisions the admin user inside that schema, and returns a JWT.
    *
    * Body: { orgName, slug, adminEmail, adminPassword }
    */
-  router.post('/auth/register', async (req: Request, res: Response) => {
+  router.post('/register', async (req: Request, res: Response) => {
     const { orgName, slug, adminEmail, adminPassword } = req.body as Record<string, string>;
 
     // Basic validation

--- a/packages/saas/src/routes/register.ts
+++ b/packages/saas/src/routes/register.ts
@@ -1,0 +1,76 @@
+import { Router, type Request, type Response } from 'express';
+import { isSlugAvailable } from '../db/org-queries.js';
+import { createOrg } from '../services/org-service.js';
+import type { DB } from '../db/types.js';
+
+const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{1,28}[a-z0-9]$/;
+
+export function createRegisterRouter(): Router {
+  const router = Router();
+
+  /**
+   * POST /api/auth/register
+   * Creates a new organization with its dedicated PostgreSQL schema.
+   *
+   * Body: { orgName, slug, adminEmail, adminPassword }
+   */
+  router.post('/register', async (req: Request, res: Response) => {
+    const { orgName, slug, adminEmail, adminPassword } = req.body as Record<string, string>;
+
+    // Basic validation
+    const errors: string[] = [];
+    if (!orgName || orgName.trim().length < 2) errors.push('orgName must be at least 2 characters');
+    if (!slug || !SLUG_PATTERN.test(slug)) errors.push('slug must be 3-30 chars, lowercase alphanumeric and hyphens');
+    if (!adminEmail || !adminEmail.includes('@')) errors.push('adminEmail must be a valid email');
+    if (!adminPassword || adminPassword.length < 8) errors.push('adminPassword must be at least 8 characters');
+
+    if (errors.length > 0) {
+      return res.status(400).json({ success: false, errors });
+    }
+
+    const db = req.app.get('db') as DB;
+
+    // Check slug availability before attempting creation
+    const slugFree = await isSlugAvailable(db, slug);
+    if (!slugFree) {
+      return res.status(409).json({ success: false, errors: [`Slug "${slug}" is already taken`] });
+    }
+
+    // Create org + schema + bootstrap tables
+    const { org } = await createOrg(db, {
+      name: orgName.trim(),
+      slug,
+      plan_id: 1, // Free plan by default
+    });
+
+    // TODO (Phase 5): create admin user in org schema + return JWT
+
+    return res.status(201).json({
+      success: true,
+      org: {
+        id: org.id,
+        name: org.name,
+        slug: org.slug,
+        schema_name: org.schema_name,
+        status: org.status,
+        trial_ends_at: org.trial_ends_at,
+      },
+    });
+  });
+
+  /**
+   * GET /api/orgs/:slug/available
+   * Quick slug availability check (public, no auth).
+   */
+  router.get('/orgs/:slug/available', async (req: Request, res: Response) => {
+    const { slug } = req.params;
+    if (!SLUG_PATTERN.test(slug)) {
+      return res.status(400).json({ success: false, available: false, error: 'Invalid slug format' });
+    }
+    const db = req.app.get('db') as DB;
+    const available = await isSlugAvailable(db, slug);
+    return res.json({ success: true, available });
+  });
+
+  return router;
+}

--- a/packages/saas/src/routes/register.ts
+++ b/packages/saas/src/routes/register.ts
@@ -63,7 +63,7 @@ export function createRegisterRouter(): Router {
    * Quick slug availability check (public, no auth).
    */
   router.get('/orgs/:slug/available', async (req: Request, res: Response) => {
-    const { slug } = req.params;
+    const slug = req.params['slug'] as string;
     if (!SLUG_PATTERN.test(slug)) {
       return res.status(400).json({ success: false, available: false, error: 'Invalid slug format' });
     }

--- a/packages/saas/src/routes/register.ts
+++ b/packages/saas/src/routes/register.ts
@@ -7,6 +7,26 @@ import type { DB, Pool } from '../db/types.js';
 
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{1,28}[a-z0-9]$/;
 
+/**
+ * createSlugRouter — public slug availability check.
+ * Mount at /api so the route resolves to GET /api/orgs/:slug/available.
+ */
+export function createSlugRouter(): Router {
+  const router = Router();
+
+  router.get('/orgs/:slug/available', async (req: Request, res: Response) => {
+    const slug = req.params['slug'] as string;
+    if (!SLUG_PATTERN.test(slug)) {
+      return res.status(400).json({ success: false, available: false, error: 'Invalid slug format' });
+    }
+    const db = req.app.get('db') as DB;
+    const available = await isSlugAvailable(db, slug);
+    return res.json({ success: true, available });
+  });
+
+  return router;
+}
+
 export function createRegisterRouter(): Router {
   const router = Router();
 
@@ -90,20 +110,6 @@ export function createRegisterRouter(): Router {
         trial_ends_at: org.trial_ends_at,
       },
     });
-  });
-
-  /**
-   * GET /api/orgs/:slug/available
-   * Quick slug availability check (public, no auth).
-   */
-  router.get('/orgs/:slug/available', async (req: Request, res: Response) => {
-    const slug = req.params['slug'] as string;
-    if (!SLUG_PATTERN.test(slug)) {
-      return res.status(400).json({ success: false, available: false, error: 'Invalid slug format' });
-    }
-    const db = req.app.get('db') as DB;
-    const available = await isSlugAvailable(db, slug);
-    return res.json({ success: true, available });
   });
 
   return router;

--- a/packages/saas/src/routes/superadmin.test.ts
+++ b/packages/saas/src/routes/superadmin.test.ts
@@ -1,0 +1,423 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express, { type Express } from 'express';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+
+// ── mock requireSuperadmin so we control auth in route tests ──────────────────
+vi.mock('../middleware/superadmin-auth.js', () => ({
+  requireSuperadmin: vi.fn((_req, _res, next) => {
+    _req.superadmin = { id: 1, username: 'root' };
+    next();
+  }),
+}));
+
+// ── mock SuperadminAuthService ────────────────────────────────────────────────
+vi.mock('../services/superadmin-auth-service.js', () => ({
+  SuperadminAuthService: vi.fn(),
+}));
+
+import { createSuperadminRouter } from '../routes/superadmin.js';
+import { SuperadminAuthService } from '../services/superadmin-auth-service.js';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const VALID_SECRET = 'superadmin-secret-at-least-32-chars-long!!';
+
+function buildApp(dbRows?: { query: ReturnType<typeof vi.fn> }): Express {
+  const app = express();
+  app.use(express.json());
+
+  const mockPool = {
+    connect: vi.fn().mockResolvedValue({
+      query: dbRows?.query ?? vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+      release: vi.fn(),
+    }),
+  };
+
+  app.set('pool', mockPool);
+
+  app.use('/api/superadmin', createSuperadminRouter());
+  return app;
+}
+
+function authHeader(): string {
+  const token = jwt.sign({ id: 1, username: 'root', scope: 'superadmin' }, VALID_SECRET, {
+    expiresIn: '1h',
+  });
+  return `Bearer ${token}`;
+}
+
+// ── POST /api/superadmin/login ────────────────────────────────────────────────
+
+describe('POST /api/superadmin/login', () => {
+  beforeEach(() => {
+    vi.stubEnv('SUPERADMIN_JWT_SECRET', VALID_SECRET);
+  });
+
+  it('returns 200 and a token when credentials are valid', async () => {
+    vi.mocked(SuperadminAuthService).mockImplementation(() => ({
+      validateCredentials: vi.fn().mockResolvedValue({ id: 1, username: 'root' }),
+      mintSuperadminJwt: vi.fn().mockReturnValue('superadmin.jwt.token'),
+      createSuperadmin: vi.fn(),
+    } as any));
+
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/superadmin/login')
+      .send({ username: 'root', password: 'Password1!' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.token).toBeDefined();
+  });
+
+  it('returns 401 when credentials are invalid', async () => {
+    vi.mocked(SuperadminAuthService).mockImplementation(() => ({
+      validateCredentials: vi.fn().mockResolvedValue(null),
+      mintSuperadminJwt: vi.fn(),
+      createSuperadmin: vi.fn(),
+    } as any));
+
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/superadmin/login')
+      .send({ username: 'root', password: 'wrong' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('returns 400 when username or password is missing', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/superadmin/login')
+      .send({ username: 'root' }); // no password
+
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── GET /api/superadmin/dashboard ─────────────────────────────────────────────
+
+describe('GET /api/superadmin/dashboard', () => {
+  it('returns 200 with MRR, ARR, counts', async () => {
+    // Mock: org counts query → { total: 5, active: 3, trial: 1, suspended: 1 }
+    const queryFn = vi
+      .fn()
+      // orgs by status
+      .mockResolvedValueOnce({
+        rows: [
+          { status: 'active', count: '3' },
+          { status: 'trial', count: '1' },
+          { status: 'suspended', count: '1' },
+        ],
+        rowCount: 3,
+      })
+      // new orgs this week
+      .mockResolvedValueOnce({ rows: [{ count: '2' }], rowCount: 1 })
+      // MRR
+      .mockResolvedValueOnce({ rows: [{ mrr_cents: '29900' }], rowCount: 1 });
+
+    const app = buildApp({ query: queryFn });
+
+    const res = await request(app)
+      .get('/api/superadmin/dashboard')
+      .set('Authorization', authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toMatchObject({
+      orgs: expect.any(Object),
+      new_orgs_this_week: expect.any(Number),
+      mrr_cents: expect.any(Number),
+    });
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    // Remove the mock pass-through for this test
+    const { requireSuperadmin } = await import('../middleware/superadmin-auth.js');
+    vi.mocked(requireSuperadmin).mockImplementationOnce((_req, res, _next) => {
+      res.status(401).json({ success: false, error: 'Unauthorized' });
+    });
+
+    const app = buildApp();
+    const res = await request(app).get('/api/superadmin/dashboard');
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── GET /api/superadmin/orgs ──────────────────────────────────────────────────
+
+describe('GET /api/superadmin/orgs', () => {
+  it('returns 200 with list of orgs', async () => {
+    const queryFn = vi.fn().mockResolvedValue({
+      rows: [
+        { id: 'uuid-1', name: 'Cinema A', slug: 'cinema-a', status: 'active', plan_id: 1 },
+        { id: 'uuid-2', name: 'Cinema B', slug: 'cinema-b', status: 'trial', plan_id: 1 },
+      ],
+      rowCount: 2,
+    });
+
+    const app = buildApp({ query: queryFn });
+    const res = await request(app)
+      .get('/api/superadmin/orgs')
+      .set('Authorization', authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body.data).toHaveLength(2);
+  });
+
+  it('supports ?status= filter', async () => {
+    const queryFn = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+    const app = buildApp({ query: queryFn });
+
+    await request(app)
+      .get('/api/superadmin/orgs?status=suspended')
+      .set('Authorization', authHeader());
+
+    // The query should have been called with a status filter
+    const queryText: string = queryFn.mock.calls[0][0];
+    expect(queryText).toMatch(/status/i);
+  });
+});
+
+// ── GET /api/superadmin/orgs/:id ─────────────────────────────────────────────
+
+describe('GET /api/superadmin/orgs/:id', () => {
+  it('returns 200 with org detail', async () => {
+    const queryFn = vi
+      .fn()
+      // org lookup
+      .mockResolvedValueOnce({
+        rows: [{ id: 'uuid-1', name: 'Cinema A', slug: 'cinema-a', status: 'active', plan_id: 1 }],
+        rowCount: 1,
+      });
+
+    const app = buildApp({ query: queryFn });
+    const res = await request(app)
+      .get('/api/superadmin/orgs/uuid-1')
+      .set('Authorization', authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.id).toBe('uuid-1');
+  });
+
+  it('returns 404 when org does not exist', async () => {
+    const queryFn = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+    const app = buildApp({ query: queryFn });
+
+    const res = await request(app)
+      .get('/api/superadmin/orgs/nonexistent')
+      .set('Authorization', authHeader());
+
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── POST /api/superadmin/orgs/:id/suspend ────────────────────────────────────
+
+describe('POST /api/superadmin/orgs/:id/suspend', () => {
+  it('returns 200 and suspends the org', async () => {
+    const queryFn = vi
+      .fn()
+      // org lookup
+      .mockResolvedValueOnce({
+        rows: [{ id: 'uuid-1', name: 'Cinema A', slug: 'cinema-a', status: 'active', plan_id: 1 }],
+        rowCount: 1,
+      })
+      // UPDATE status
+      .mockResolvedValueOnce({
+        rows: [{ id: 'uuid-1', status: 'suspended' }],
+        rowCount: 1,
+      })
+      // audit log insert
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+    const app = buildApp({ query: queryFn });
+    const res = await request(app)
+      .post('/api/superadmin/orgs/uuid-1/suspend')
+      .set('Authorization', authHeader())
+      .send({ reason: 'Non-payment' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('returns 404 when org does not exist', async () => {
+    const queryFn = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+    const app = buildApp({ query: queryFn });
+
+    const res = await request(app)
+      .post('/api/superadmin/orgs/nonexistent/suspend')
+      .set('Authorization', authHeader());
+
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── POST /api/superadmin/orgs/:id/reactivate ─────────────────────────────────
+
+describe('POST /api/superadmin/orgs/:id/reactivate', () => {
+  it('returns 200 and sets status to active', async () => {
+    const queryFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        rows: [{ id: 'uuid-1', name: 'Cinema A', slug: 'cinema-a', status: 'suspended', plan_id: 1 }],
+        rowCount: 1,
+      })
+      .mockResolvedValueOnce({ rows: [{ id: 'uuid-1', status: 'active' }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 }); // audit log
+
+    const app = buildApp({ query: queryFn });
+    const res = await request(app)
+      .post('/api/superadmin/orgs/uuid-1/reactivate')
+      .set('Authorization', authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});
+
+// ── PUT /api/superadmin/orgs/:id/plan ────────────────────────────────────────
+
+describe('PUT /api/superadmin/orgs/:id/plan', () => {
+  it('returns 200 and updates the plan', async () => {
+    const queryFn = vi
+      .fn()
+      // org lookup
+      .mockResolvedValueOnce({
+        rows: [{ id: 'uuid-1', name: 'Cinema A', slug: 'cinema-a', status: 'active', plan_id: 1 }],
+        rowCount: 1,
+      })
+      // plan lookup
+      .mockResolvedValueOnce({ rows: [{ id: 2, name: 'Pro' }], rowCount: 1 })
+      // UPDATE plan_id
+      .mockResolvedValueOnce({ rows: [{ id: 'uuid-1', plan_id: 2 }], rowCount: 1 })
+      // audit log
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+    const app = buildApp({ query: queryFn });
+    const res = await request(app)
+      .put('/api/superadmin/orgs/uuid-1/plan')
+      .set('Authorization', authHeader())
+      .send({ plan_id: 2 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('returns 400 when plan_id is missing', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .put('/api/superadmin/orgs/uuid-1/plan')
+      .set('Authorization', authHeader())
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when plan does not exist', async () => {
+    const queryFn = vi
+      .fn()
+      // org lookup succeeds
+      .mockResolvedValueOnce({
+        rows: [{ id: 'uuid-1', name: 'Cinema A', slug: 'cinema-a', status: 'active', plan_id: 1 }],
+        rowCount: 1,
+      })
+      // plan lookup → empty
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const app = buildApp({ query: queryFn });
+    const res = await request(app)
+      .put('/api/superadmin/orgs/uuid-1/plan')
+      .set('Authorization', authHeader())
+      .send({ plan_id: 99 });
+
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── POST /api/superadmin/orgs/:id/reset-trial ────────────────────────────────
+
+describe('POST /api/superadmin/orgs/:id/reset-trial', () => {
+  it('returns 200 and resets the trial period', async () => {
+    const queryFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        rows: [{ id: 'uuid-1', name: 'Cinema A', slug: 'cinema-a', status: 'trial', plan_id: 1 }],
+        rowCount: 1,
+      })
+      .mockResolvedValueOnce({ rows: [{ id: 'uuid-1', trial_ends_at: new Date() }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 }); // audit log
+
+    const app = buildApp({ query: queryFn });
+    const res = await request(app)
+      .post('/api/superadmin/orgs/uuid-1/reset-trial')
+      .set('Authorization', authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});
+
+// ── POST /api/superadmin/impersonate ─────────────────────────────────────────
+
+describe('POST /api/superadmin/impersonate', () => {
+  beforeEach(() => {
+    vi.stubEnv('JWT_SECRET', 'org-jwt-secret-at-least-32-chars-long!!');
+  });
+
+  it('returns 200 with a 1h impersonation JWT', async () => {
+    const queryFn = vi
+      .fn()
+      // org lookup by slug
+      .mockResolvedValueOnce({
+        rows: [{ id: 'uuid-1', name: 'Cinema A', slug: 'cinema-a', status: 'active', plan_id: 1 }],
+        rowCount: 1,
+      })
+      // audit log insert
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+    const app = buildApp({ query: queryFn });
+    const res = await request(app)
+      .post('/api/superadmin/impersonate')
+      .set('Authorization', authHeader())
+      .send({ org_slug: 'cinema-a' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.token).toBeDefined();
+
+    // Token should be an org JWT (signed with JWT_SECRET)
+    const decoded = jwt.verify(res.body.token, 'org-jwt-secret-at-least-32-chars-long!!') as Record<string, unknown>;
+    expect(decoded.org_slug).toBe('cinema-a');
+    expect(decoded.impersonated_by).toBe(1); // superadmin id
+    expect(decoded.impersonation).toBe(true);
+  });
+
+  it('returns 400 when org_slug is missing', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/superadmin/impersonate')
+      .set('Authorization', authHeader())
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when org does not exist', async () => {
+    const queryFn = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+    const app = buildApp({ query: queryFn });
+
+    const res = await request(app)
+      .post('/api/superadmin/impersonate')
+      .set('Authorization', authHeader())
+      .send({ org_slug: 'does-not-exist' });
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/saas/src/routes/superadmin.test.ts
+++ b/packages/saas/src/routes/superadmin.test.ts
@@ -421,3 +421,72 @@ describe('POST /api/superadmin/impersonate', () => {
     expect(res.status).toBe(404);
   });
 });
+
+// ── GET /api/superadmin/audit-log ─────────────────────────────────────────────
+
+describe('GET /api/superadmin/audit-log', () => {
+  it('returns 200 with paginated audit log entries', async () => {
+    const queryFn = vi
+      .fn()
+      // count query
+      .mockResolvedValueOnce({ rows: [{ total: '42' }], rowCount: 1 })
+      // rows query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 1,
+            actor_id: 1,
+            action: 'suspend_org',
+            target_type: 'organization',
+            target_id: 'uuid-1',
+            metadata: {},
+            created_at: new Date('2026-01-01T00:00:00Z'),
+          },
+        ],
+        rowCount: 1,
+      });
+
+    const app = buildApp({ query: queryFn });
+    const res = await request(app)
+      .get('/api/superadmin/audit-log')
+      .set('Authorization', authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body.total).toBeDefined();
+    expect(res.body.page).toBeDefined();
+    expect(res.body.limit).toBeDefined();
+  });
+
+  it('supports ?page= and ?limit= query params', async () => {
+    const queryFn = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ total: '100' }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const app = buildApp({ query: queryFn });
+    const res = await request(app)
+      .get('/api/superadmin/audit-log?page=2&limit=20')
+      .set('Authorization', authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body.page).toBe(2);
+    expect(res.body.limit).toBe(20);
+    // Offset should be (page-1) * limit = 20
+    const rowsQueryCall = queryFn.mock.calls[1];
+    expect(rowsQueryCall[1]).toContain(20); // offset
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    const { requireSuperadmin } = await import('../middleware/superadmin-auth.js');
+    vi.mocked(requireSuperadmin).mockImplementationOnce((_req, res, _next) => {
+      res.status(401).json({ success: false, error: 'Unauthorized' });
+    });
+
+    const app = buildApp();
+    const res = await request(app).get('/api/superadmin/audit-log');
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/saas/src/routes/superadmin.ts
+++ b/packages/saas/src/routes/superadmin.ts
@@ -391,5 +391,40 @@ export function createSuperadminRouter(): Router {
     res.json({ success: true, token });
   });
 
+  // ── GET /audit-log ──────────────────────────────────────────────────────────
+  router.get('/audit-log', superadminLimiter, async (req: Request, res: Response) => {
+    const pool = getPool(req);
+
+    const page = Math.max(1, parseInt(String(req.query.page ?? '1'), 10) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(String(req.query.limit ?? '50'), 10) || 50));
+    const offset = (page - 1) * limit;
+
+    const client = await pool.connect();
+    try {
+      const countResult = await client.query<{ total: string }>(
+        'SELECT COUNT(*)::text AS total FROM audit_log',
+      );
+      const total = parseInt(countResult.rows[0]?.total ?? '0', 10);
+
+      const rowsResult = await client.query(
+        `SELECT id, actor_id, action, target_type, target_id, metadata, created_at
+           FROM audit_log
+          ORDER BY created_at DESC
+          LIMIT $1 OFFSET $2`,
+        [limit, offset],
+      );
+
+      res.json({
+        success: true,
+        data: rowsResult.rows,
+        total,
+        page,
+        limit,
+      });
+    } finally {
+      client.release();
+    }
+  });
+
   return router;
 }

--- a/packages/saas/src/routes/superadmin.ts
+++ b/packages/saas/src/routes/superadmin.ts
@@ -123,10 +123,9 @@ export function createSuperadminRouter(): Router {
 
   // ── All routes below require superadmin auth ─────────────────────────────
   router.use(requireSuperadmin);
-  router.use(superadminLimiter);
 
   // ── GET /dashboard ─────────────────────────────────────────────────────────
-  router.get('/dashboard', async (req: Request, res: Response) => {
+  router.get('/dashboard', superadminLimiter, async (req: Request, res: Response) => {
     const pool = getPool(req);
     const client = await pool.connect();
     try {
@@ -172,7 +171,7 @@ export function createSuperadminRouter(): Router {
   });
 
   // ── GET /orgs ───────────────────────────────────────────────────────────────
-  router.get('/orgs', async (req: Request, res: Response) => {
+  router.get('/orgs', superadminLimiter, async (req: Request, res: Response) => {
     const pool = getPool(req);
     const client = await pool.connect();
     try {
@@ -210,7 +209,7 @@ export function createSuperadminRouter(): Router {
   });
 
   // ── GET /orgs/:id ───────────────────────────────────────────────────────────
-  router.get('/orgs/:id', async (req: Request, res: Response) => {
+  router.get('/orgs/:id', superadminLimiter, async (req: Request, res: Response) => {
     const pool = getPool(req);
     const org = await getOrgById(pool, String(req.params.id));
 
@@ -223,7 +222,7 @@ export function createSuperadminRouter(): Router {
   });
 
   // ── POST /orgs/:id/suspend ──────────────────────────────────────────────────
-  router.post('/orgs/:id/suspend', async (req: Request, res: Response) => {
+  router.post('/orgs/:id/suspend', superadminLimiter, async (req: Request, res: Response) => {
     const pool = getPool(req);
     const org = await getOrgById(pool, String(req.params.id));
     if (!org) {
@@ -251,7 +250,7 @@ export function createSuperadminRouter(): Router {
   });
 
   // ── POST /orgs/:id/reactivate ───────────────────────────────────────────────
-  router.post('/orgs/:id/reactivate', async (req: Request, res: Response) => {
+  router.post('/orgs/:id/reactivate', superadminLimiter, async (req: Request, res: Response) => {
     const pool = getPool(req);
     const org = await getOrgById(pool, String(req.params.id));
     if (!org) {
@@ -278,7 +277,7 @@ export function createSuperadminRouter(): Router {
   });
 
   // ── PUT /orgs/:id/plan ──────────────────────────────────────────────────────
-  router.put('/orgs/:id/plan', async (req: Request, res: Response) => {
+  router.put('/orgs/:id/plan', superadminLimiter, async (req: Request, res: Response) => {
     const { plan_id } = req.body ?? {};
     if (!plan_id) {
       res.status(400).json({ success: false, error: 'plan_id is required' });
@@ -322,7 +321,7 @@ export function createSuperadminRouter(): Router {
   });
 
   // ── POST /orgs/:id/reset-trial ──────────────────────────────────────────────
-  router.post('/orgs/:id/reset-trial', async (req: Request, res: Response) => {
+  router.post('/orgs/:id/reset-trial', superadminLimiter, async (req: Request, res: Response) => {
     const pool = getPool(req);
     const org = await getOrgById(pool, String(req.params.id));
     if (!org) {
@@ -352,7 +351,7 @@ export function createSuperadminRouter(): Router {
   });
 
   // ── POST /impersonate ───────────────────────────────────────────────────────
-  router.post('/impersonate', async (req: Request, res: Response) => {
+  router.post('/impersonate', superadminLimiter, async (req: Request, res: Response) => {
     const { org_slug } = req.body ?? {};
     if (!org_slug) {
       res.status(400).json({ success: false, error: 'org_slug is required' });

--- a/packages/saas/src/routes/superadmin.ts
+++ b/packages/saas/src/routes/superadmin.ts
@@ -2,6 +2,7 @@ import { Router, type Request, type Response } from 'express';
 import jwt from 'jsonwebtoken';
 import { requireSuperadmin } from '../middleware/superadmin-auth.js';
 import { SuperadminAuthService } from '../services/superadmin-auth-service.js';
+import { superadminLoginLimiter, superadminLimiter } from '../middleware/rate-limit.js';
 import type { Pool } from '../db/types.js';
 
 // Minimal org shape returned by local helpers
@@ -90,7 +91,7 @@ export function createSuperadminRouter(): Router {
   const router = Router();
 
   // ── POST /login ─────────────────────────────────────────────────────────────
-  router.post('/login', async (req: Request, res: Response) => {
+  router.post('/login', superadminLoginLimiter, async (req: Request, res: Response) => {
     const { username, password } = req.body ?? {};
 
     if (!username || !password) {
@@ -122,6 +123,7 @@ export function createSuperadminRouter(): Router {
 
   // ── All routes below require superadmin auth ─────────────────────────────
   router.use(requireSuperadmin);
+  router.use(superadminLimiter);
 
   // ── GET /dashboard ─────────────────────────────────────────────────────────
   router.get('/dashboard', async (req: Request, res: Response) => {

--- a/packages/saas/src/routes/superadmin.ts
+++ b/packages/saas/src/routes/superadmin.ts
@@ -4,6 +4,18 @@ import { requireSuperadmin } from '../middleware/superadmin-auth.js';
 import { SuperadminAuthService } from '../services/superadmin-auth-service.js';
 import type { Pool } from '../db/types.js';
 
+// Minimal org shape returned by local helpers
+interface OrgRow {
+  id: string;
+  name: string;
+  slug: string;
+  status: string;
+  plan_id: number;
+  trial_ends_at: Date | null;
+  schema_name: string;
+  [key: string]: unknown;
+}
+
 // ── helpers ──────────────────────────────────────────────────────────────────
 
 function getPool(req: Request): Pool {
@@ -30,10 +42,10 @@ async function writeAuditLog(
   }
 }
 
-async function getOrgById(pool: Pool, orgId: string) {
+async function getOrgById(pool: Pool, orgId: string): Promise<OrgRow | null> {
   const client = await pool.connect();
   try {
-    const result = await client.query(
+    const result = await client.query<OrgRow>(
       'SELECT * FROM organizations WHERE id = $1',
       [orgId],
     );
@@ -43,10 +55,10 @@ async function getOrgById(pool: Pool, orgId: string) {
   }
 }
 
-async function getOrgBySlug(pool: Pool, slug: string) {
+async function getOrgBySlug(pool: Pool, slug: string): Promise<OrgRow | null> {
   const client = await pool.connect();
   try {
-    const result = await client.query(
+    const result = await client.query<OrgRow>(
       'SELECT * FROM organizations WHERE slug = $1',
       [slug],
     );
@@ -198,7 +210,7 @@ export function createSuperadminRouter(): Router {
   // ── GET /orgs/:id ───────────────────────────────────────────────────────────
   router.get('/orgs/:id', async (req: Request, res: Response) => {
     const pool = getPool(req);
-    const org = await getOrgById(pool, req.params.id);
+    const org = await getOrgById(pool, String(req.params.id));
 
     if (!org) {
       res.status(404).json({ success: false, error: 'Organization not found' });
@@ -211,7 +223,7 @@ export function createSuperadminRouter(): Router {
   // ── POST /orgs/:id/suspend ──────────────────────────────────────────────────
   router.post('/orgs/:id/suspend', async (req: Request, res: Response) => {
     const pool = getPool(req);
-    const org = await getOrgById(pool, req.params.id);
+    const org = await getOrgById(pool, String(req.params.id));
     if (!org) {
       res.status(404).json({ success: false, error: 'Organization not found' });
       return;
@@ -239,7 +251,7 @@ export function createSuperadminRouter(): Router {
   // ── POST /orgs/:id/reactivate ───────────────────────────────────────────────
   router.post('/orgs/:id/reactivate', async (req: Request, res: Response) => {
     const pool = getPool(req);
-    const org = await getOrgById(pool, req.params.id);
+    const org = await getOrgById(pool, String(req.params.id));
     if (!org) {
       res.status(404).json({ success: false, error: 'Organization not found' });
       return;
@@ -272,7 +284,7 @@ export function createSuperadminRouter(): Router {
     }
 
     const pool = getPool(req);
-    const org = await getOrgById(pool, req.params.id);
+    const org = await getOrgById(pool, String(req.params.id));
     if (!org) {
       res.status(404).json({ success: false, error: 'Organization not found' });
       return;
@@ -310,7 +322,7 @@ export function createSuperadminRouter(): Router {
   // ── POST /orgs/:id/reset-trial ──────────────────────────────────────────────
   router.post('/orgs/:id/reset-trial', async (req: Request, res: Response) => {
     const pool = getPool(req);
-    const org = await getOrgById(pool, req.params.id);
+    const org = await getOrgById(pool, String(req.params.id));
     if (!org) {
       res.status(404).json({ success: false, error: 'Organization not found' });
       return;

--- a/packages/saas/src/routes/superadmin.ts
+++ b/packages/saas/src/routes/superadmin.ts
@@ -122,7 +122,7 @@ export function createSuperadminRouter(): Router {
   });
 
   // ── All routes below require superadmin auth ─────────────────────────────
-  router.use(requireSuperadmin);
+  router.use(superadminLimiter, requireSuperadmin);
 
   // ── GET /dashboard ─────────────────────────────────────────────────────────
   router.get('/dashboard', superadminLimiter, async (req: Request, res: Response) => {

--- a/packages/saas/src/routes/superadmin.ts
+++ b/packages/saas/src/routes/superadmin.ts
@@ -1,0 +1,382 @@
+import { Router, type Request, type Response } from 'express';
+import jwt from 'jsonwebtoken';
+import { requireSuperadmin } from '../middleware/superadmin-auth.js';
+import { SuperadminAuthService } from '../services/superadmin-auth-service.js';
+import type { Pool } from '../db/types.js';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function getPool(req: Request): Pool {
+  return req.app.get('pool') as Pool;
+}
+
+async function writeAuditLog(
+  pool: Pool,
+  actorId: number,
+  action: string,
+  targetType: string | null,
+  targetId: string | null,
+  metadata: Record<string, unknown> = {},
+): Promise<void> {
+  const client = await pool.connect();
+  try {
+    await client.query(
+      `INSERT INTO audit_log (actor_id, action, target_type, target_id, metadata)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [actorId, action, targetType, targetId, JSON.stringify(metadata)],
+    );
+  } finally {
+    client.release();
+  }
+}
+
+async function getOrgById(pool: Pool, orgId: string) {
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      'SELECT * FROM organizations WHERE id = $1',
+      [orgId],
+    );
+    return result.rows[0] ?? null;
+  } finally {
+    client.release();
+  }
+}
+
+async function getOrgBySlug(pool: Pool, slug: string) {
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      'SELECT * FROM organizations WHERE slug = $1',
+      [slug],
+    );
+    return result.rows[0] ?? null;
+  } finally {
+    client.release();
+  }
+}
+
+// ── Router factory ───────────────────────────────────────────────────────────
+
+/**
+ * Creates the superadmin router.
+ *
+ * Public routes (no auth):
+ *   POST /api/superadmin/login
+ *
+ * Protected routes (require superadmin JWT):
+ *   GET  /api/superadmin/dashboard
+ *   GET  /api/superadmin/orgs
+ *   GET  /api/superadmin/orgs/:id
+ *   POST /api/superadmin/orgs/:id/suspend
+ *   POST /api/superadmin/orgs/:id/reactivate
+ *   PUT  /api/superadmin/orgs/:id/plan
+ *   POST /api/superadmin/orgs/:id/reset-trial
+ *   POST /api/superadmin/impersonate
+ */
+export function createSuperadminRouter(): Router {
+  const router = Router();
+
+  // ── POST /login ─────────────────────────────────────────────────────────────
+  router.post('/login', async (req: Request, res: Response) => {
+    const { username, password } = req.body ?? {};
+
+    if (!username || !password) {
+      res.status(400).json({ success: false, error: 'username and password are required' });
+      return;
+    }
+
+    try {
+      const pool = getPool(req);
+      const service = new SuperadminAuthService(pool);
+
+      const superadmin = await service.validateCredentials(username, password);
+      if (!superadmin) {
+        res.status(401).json({ success: false, error: 'Invalid credentials' });
+        return;
+      }
+
+      const token = service.mintSuperadminJwt({
+        superadminId: superadmin.id,
+        username: superadmin.username,
+      });
+
+      res.json({ success: true, token });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Internal server error';
+      res.status(500).json({ success: false, error: message });
+    }
+  });
+
+  // ── All routes below require superadmin auth ─────────────────────────────
+  router.use(requireSuperadmin);
+
+  // ── GET /dashboard ─────────────────────────────────────────────────────────
+  router.get('/dashboard', async (req: Request, res: Response) => {
+    const pool = getPool(req);
+    const client = await pool.connect();
+    try {
+      // Orgs grouped by status
+      const orgsResult = await client.query<{ status: string; count: string }>(
+        `SELECT status, COUNT(*)::text AS count
+           FROM organizations
+          GROUP BY status`,
+      );
+
+      // New orgs this week
+      const newOrgsResult = await client.query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count
+           FROM organizations
+          WHERE created_at >= now() - interval '7 days'`,
+      );
+
+      // MRR: sum of monthly prices for active/trial orgs
+      const mrrResult = await client.query<{ mrr_cents: string }>(
+        `SELECT COALESCE(SUM(p.price_monthly_cents), 0)::text AS mrr_cents
+           FROM organizations o
+           JOIN plans p ON p.id = o.plan_id
+          WHERE o.status IN ('active', 'trial')`,
+      );
+
+      const orgsByStatus = Object.fromEntries(
+        orgsResult.rows.map((r) => [r.status, parseInt(r.count)]),
+      );
+      const mrrCents = parseInt(mrrResult.rows[0]?.mrr_cents ?? '0');
+
+      res.json({
+        success: true,
+        data: {
+          orgs: orgsByStatus,
+          new_orgs_this_week: parseInt(newOrgsResult.rows[0]?.count ?? '0'),
+          mrr_cents: mrrCents,
+          arr_cents: mrrCents * 12,
+        },
+      });
+    } finally {
+      client.release();
+    }
+  });
+
+  // ── GET /orgs ───────────────────────────────────────────────────────────────
+  router.get('/orgs', async (req: Request, res: Response) => {
+    const pool = getPool(req);
+    const client = await pool.connect();
+    try {
+      const { status, search } = req.query as Record<string, string>;
+
+      const conditions: string[] = [];
+      const params: unknown[] = [];
+      let idx = 1;
+
+      if (status) {
+        conditions.push(`o.status = $${idx++}`);
+        params.push(status);
+      }
+      if (search) {
+        conditions.push(`(o.name ILIKE $${idx} OR o.slug ILIKE $${idx})`);
+        params.push(`%${search}%`);
+        idx++;
+      }
+
+      const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+      const result = await client.query(
+        `SELECT o.*, p.name AS plan_name
+           FROM organizations o
+           JOIN plans p ON p.id = o.plan_id
+           ${where}
+          ORDER BY o.created_at DESC`,
+        params,
+      );
+
+      res.json({ success: true, data: result.rows });
+    } finally {
+      client.release();
+    }
+  });
+
+  // ── GET /orgs/:id ───────────────────────────────────────────────────────────
+  router.get('/orgs/:id', async (req: Request, res: Response) => {
+    const pool = getPool(req);
+    const org = await getOrgById(pool, req.params.id);
+
+    if (!org) {
+      res.status(404).json({ success: false, error: 'Organization not found' });
+      return;
+    }
+
+    res.json({ success: true, data: org });
+  });
+
+  // ── POST /orgs/:id/suspend ──────────────────────────────────────────────────
+  router.post('/orgs/:id/suspend', async (req: Request, res: Response) => {
+    const pool = getPool(req);
+    const org = await getOrgById(pool, req.params.id);
+    if (!org) {
+      res.status(404).json({ success: false, error: 'Organization not found' });
+      return;
+    }
+
+    const client = await pool.connect();
+    try {
+      const updated = await client.query(
+        `UPDATE organizations SET status = 'suspended', updated_at = now()
+          WHERE id = $1 RETURNING *`,
+        [org.id],
+      );
+
+      await writeAuditLog(pool, req.superadmin!.id, 'suspend_org', 'organization', org.id, {
+        reason: req.body?.reason ?? null,
+        previous_status: org.status,
+      });
+
+      res.json({ success: true, data: updated.rows[0] });
+    } finally {
+      client.release();
+    }
+  });
+
+  // ── POST /orgs/:id/reactivate ───────────────────────────────────────────────
+  router.post('/orgs/:id/reactivate', async (req: Request, res: Response) => {
+    const pool = getPool(req);
+    const org = await getOrgById(pool, req.params.id);
+    if (!org) {
+      res.status(404).json({ success: false, error: 'Organization not found' });
+      return;
+    }
+
+    const client = await pool.connect();
+    try {
+      const updated = await client.query(
+        `UPDATE organizations SET status = 'active', updated_at = now()
+          WHERE id = $1 RETURNING *`,
+        [org.id],
+      );
+
+      await writeAuditLog(pool, req.superadmin!.id, 'reactivate_org', 'organization', org.id, {
+        previous_status: org.status,
+      });
+
+      res.json({ success: true, data: updated.rows[0] });
+    } finally {
+      client.release();
+    }
+  });
+
+  // ── PUT /orgs/:id/plan ──────────────────────────────────────────────────────
+  router.put('/orgs/:id/plan', async (req: Request, res: Response) => {
+    const { plan_id } = req.body ?? {};
+    if (!plan_id) {
+      res.status(400).json({ success: false, error: 'plan_id is required' });
+      return;
+    }
+
+    const pool = getPool(req);
+    const org = await getOrgById(pool, req.params.id);
+    if (!org) {
+      res.status(404).json({ success: false, error: 'Organization not found' });
+      return;
+    }
+
+    const client = await pool.connect();
+    try {
+      // Verify plan exists
+      const planResult = await client.query(
+        'SELECT id, name FROM plans WHERE id = $1',
+        [plan_id],
+      );
+      if (planResult.rows.length === 0) {
+        res.status(404).json({ success: false, error: `Plan ${plan_id} not found` });
+        return;
+      }
+
+      const updated = await client.query(
+        `UPDATE organizations SET plan_id = $1, updated_at = now()
+          WHERE id = $2 RETURNING *`,
+        [plan_id, org.id],
+      );
+
+      await writeAuditLog(pool, req.superadmin!.id, 'change_plan', 'organization', org.id, {
+        previous_plan_id: org.plan_id,
+        new_plan_id: plan_id,
+      });
+
+      res.json({ success: true, data: updated.rows[0] });
+    } finally {
+      client.release();
+    }
+  });
+
+  // ── POST /orgs/:id/reset-trial ──────────────────────────────────────────────
+  router.post('/orgs/:id/reset-trial', async (req: Request, res: Response) => {
+    const pool = getPool(req);
+    const org = await getOrgById(pool, req.params.id);
+    if (!org) {
+      res.status(404).json({ success: false, error: 'Organization not found' });
+      return;
+    }
+
+    const client = await pool.connect();
+    try {
+      const updated = await client.query(
+        `UPDATE organizations
+            SET trial_ends_at = now() + interval '14 days',
+                status = 'trial',
+                updated_at = now()
+          WHERE id = $1 RETURNING *`,
+        [org.id],
+      );
+
+      await writeAuditLog(pool, req.superadmin!.id, 'reset_trial', 'organization', org.id, {
+        previous_trial_ends_at: org.trial_ends_at,
+      });
+
+      res.json({ success: true, data: updated.rows[0] });
+    } finally {
+      client.release();
+    }
+  });
+
+  // ── POST /impersonate ───────────────────────────────────────────────────────
+  router.post('/impersonate', async (req: Request, res: Response) => {
+    const { org_slug } = req.body ?? {};
+    if (!org_slug) {
+      res.status(400).json({ success: false, error: 'org_slug is required' });
+      return;
+    }
+
+    const jwtSecret = process.env.JWT_SECRET?.trim();
+    if (!jwtSecret || jwtSecret.length < 32) {
+      res.status(500).json({ success: false, error: 'Server misconfiguration: missing JWT_SECRET' });
+      return;
+    }
+
+    const pool = getPool(req);
+    const org = await getOrgBySlug(pool, org_slug);
+    if (!org) {
+      res.status(404).json({ success: false, error: 'Organization not found' });
+      return;
+    }
+
+    // Mint a short-lived (1h) org-scoped impersonation token
+    const token = jwt.sign(
+      {
+        org_id: org.id,
+        org_slug: org.slug,
+        impersonation: true,
+        impersonated_by: req.superadmin!.id,
+        // No user id / role — impersonation tokens are org-level only
+      },
+      jwtSecret,
+      { expiresIn: '1h' },
+    );
+
+    await writeAuditLog(pool, req.superadmin!.id, 'impersonate', 'organization', org.id, {
+      org_slug: org.slug,
+    });
+
+    res.json({ success: true, token });
+  });
+
+  return router;
+}

--- a/packages/saas/src/services/billing-service.ts
+++ b/packages/saas/src/services/billing-service.ts
@@ -1,0 +1,2 @@
+// BillingService — Stripe integration — to be implemented in Phase 4
+export {};

--- a/packages/saas/src/services/email-service.test.ts
+++ b/packages/saas/src/services/email-service.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EmailService } from './email-service.js';
+import type { Pool, PoolClient } from '../db/types.js';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function makePool(queryRows: unknown[] = []): {
+  pool: Pool;
+  client: PoolClient & { query: ReturnType<typeof vi.fn>; release: ReturnType<typeof vi.fn> };
+} {
+  const query = vi.fn().mockResolvedValue({ rows: queryRows, rowCount: queryRows.length });
+  const client = { query, release: vi.fn() };
+  const pool: Pool = { connect: vi.fn().mockResolvedValue(client) };
+  return { pool, client };
+}
+
+const ORG = { id: 'org-uuid-1', slug: 'my-cinema', schema_name: 'org_my_cinema' };
+
+// ── EmailService ──────────────────────────────────────────────────────────────
+
+describe('EmailService', () => {
+  describe('generateVerificationToken', () => {
+    it('returns a non-empty string token', () => {
+      const service = new EmailService({} as Pool);
+      const token = service.generateVerificationToken();
+      expect(typeof token).toBe('string');
+      expect(token.length).toBeGreaterThan(20);
+    });
+
+    it('returns unique tokens on each call', () => {
+      const service = new EmailService({} as Pool);
+      const t1 = service.generateVerificationToken();
+      const t2 = service.generateVerificationToken();
+      expect(t1).not.toBe(t2);
+    });
+  });
+
+  describe('storeVerificationToken', () => {
+    it('sets search_path to the org schema before updating the user', async () => {
+      const { pool, client } = makePool([]);
+      const service = new EmailService(pool);
+
+      await service.storeVerificationToken(ORG, 1, 'abc-token');
+
+      expect(client.query).toHaveBeenNthCalledWith(
+        1,
+        'SET search_path TO "org_my_cinema", public',
+      );
+    });
+
+    it('issues an UPDATE on the users table with the token and expiry', async () => {
+      const { pool, client } = makePool([]);
+      const service = new EmailService(pool);
+
+      await service.storeVerificationToken(ORG, 1, 'abc-token');
+
+      const updateCall = client.query.mock.calls[1];
+      expect(updateCall[0]).toMatch(/UPDATE users/i);
+      expect(updateCall[0]).toMatch(/verification_token/i);
+      expect(updateCall[0]).toMatch(/verification_expires/i);
+      // token value must appear in params
+      expect(updateCall[1]).toContain('abc-token');
+    });
+
+    it('releases the pool client after storing the token', async () => {
+      const { pool, client } = makePool([]);
+      const service = new EmailService(pool);
+
+      await service.storeVerificationToken(ORG, 1, 'abc-token');
+
+      expect(client.release).toHaveBeenCalledOnce();
+    });
+
+    it('releases the pool client even on error', async () => {
+      const { pool, client } = makePool([]);
+      client.query.mockRejectedValueOnce(new Error('db error'));
+
+      const service = new EmailService(pool);
+      await expect(service.storeVerificationToken(ORG, 1, 'bad')).rejects.toThrow('db error');
+
+      expect(client.release).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('verifyEmailToken', () => {
+    it('returns the user_id when the token is valid and not expired', async () => {
+      const futureDate = new Date(Date.now() + 86400_000).toISOString();
+      const { pool } = makePool([{ user_id: 42, expires_at: futureDate }]);
+      const service = new EmailService(pool);
+
+      const userId = await service.verifyEmailToken(ORG, 'valid-token');
+
+      expect(userId).toBe(42);
+    });
+
+    it('returns null when no row matches the token', async () => {
+      const { pool } = makePool([]); // empty result
+      const service = new EmailService(pool);
+
+      const userId = await service.verifyEmailToken(ORG, 'unknown-token');
+
+      expect(userId).toBeNull();
+    });
+
+    it('returns null when the token is expired', async () => {
+      const pastDate = new Date(Date.now() - 1000).toISOString();
+      const { pool } = makePool([{ user_id: 42, expires_at: pastDate }]);
+      const service = new EmailService(pool);
+
+      const userId = await service.verifyEmailToken(ORG, 'expired-token');
+
+      expect(userId).toBeNull();
+    });
+
+    it('sets search_path before querying', async () => {
+      const futureDate = new Date(Date.now() + 86400_000).toISOString();
+      const { pool, client } = makePool([{ user_id: 7, expires_at: futureDate }]);
+      const service = new EmailService(pool);
+
+      await service.verifyEmailToken(ORG, 'some-token');
+
+      expect(client.query).toHaveBeenNthCalledWith(
+        1,
+        'SET search_path TO "org_my_cinema", public',
+      );
+    });
+
+    it('releases the pool client after verifying', async () => {
+      const futureDate = new Date(Date.now() + 86400_000).toISOString();
+      const { pool, client } = makePool([{ user_id: 7, expires_at: futureDate }]);
+      const service = new EmailService(pool);
+
+      await service.verifyEmailToken(ORG, 'some-token');
+
+      expect(client.release).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('markEmailVerified', () => {
+    it('issues an UPDATE to set email_verified=true and clear the token', async () => {
+      const { pool, client } = makePool([]);
+      const service = new EmailService(pool);
+
+      await service.markEmailVerified(ORG, 42);
+
+      const updateCall = client.query.mock.calls[1]; // after SET search_path
+      expect(updateCall[0]).toMatch(/UPDATE users/i);
+      expect(updateCall[0]).toMatch(/email_verified/i);
+      // user_id param must be present
+      expect(updateCall[1]).toContain(42);
+    });
+
+    it('releases the pool client after marking verified', async () => {
+      const { pool, client } = makePool([]);
+      const service = new EmailService(pool);
+
+      await service.markEmailVerified(ORG, 42);
+
+      expect(client.release).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('sendVerificationEmail', () => {
+    it('resolves without throwing (no-op stub — no SMTP required)', async () => {
+      const service = new EmailService({} as Pool);
+      await expect(
+        service.sendVerificationEmail('admin@my-cinema.com', 'abc-token', ORG.slug),
+      ).resolves.not.toThrow();
+    });
+  });
+});

--- a/packages/saas/src/services/email-service.ts
+++ b/packages/saas/src/services/email-service.ts
@@ -1,0 +1,106 @@
+import crypto from 'crypto';
+import type { Pool } from '../db/types.js';
+
+export interface OrgRef {
+  id: string;
+  slug: string;
+  schema_name: string;
+}
+
+/** Token validity window: 24 hours */
+const TOKEN_TTL_MS = 24 * 60 * 60 * 1000;
+
+export class EmailService {
+  constructor(private pool: Pool) {}
+
+  /**
+   * Generates a cryptographically random URL-safe token.
+   */
+  generateVerificationToken(): string {
+    return crypto.randomBytes(32).toString('hex');
+  }
+
+  /**
+   * Persists the verification token against the user record in the org schema.
+   * Uses a dedicated pool client to scope SET search_path to this connection only.
+   */
+  async storeVerificationToken(org: OrgRef, userId: number, token: string): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      await client.query(`SET search_path TO "${org.schema_name}", public`);
+      const expiresAt = new Date(Date.now() + TOKEN_TTL_MS);
+      await client.query(
+        `UPDATE users
+            SET verification_token   = $1,
+                verification_expires = $2
+          WHERE id = $3`,
+        [token, expiresAt, userId],
+      );
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Looks up a verification token in the org schema.
+   * Returns the user_id when the token is valid and not expired, null otherwise.
+   */
+  async verifyEmailToken(org: OrgRef, token: string): Promise<number | null> {
+    const client = await this.pool.connect();
+    try {
+      await client.query(`SET search_path TO "${org.schema_name}", public`);
+      const result = await client.query<{ user_id: number; expires_at: string }>(
+        `SELECT id AS user_id, verification_expires AS expires_at
+           FROM users
+          WHERE verification_token = $1`,
+        [token],
+      );
+      if (result.rows.length === 0) return null;
+      const { user_id, expires_at } = result.rows[0];
+      if (new Date(expires_at) < new Date()) return null;
+      return user_id;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Sets email_verified = true and clears the verification token fields.
+   */
+  async markEmailVerified(org: OrgRef, userId: number): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      await client.query(`SET search_path TO "${org.schema_name}", public`);
+      await client.query(
+        `UPDATE users
+            SET email_verified       = true,
+                verification_token   = NULL,
+                verification_expires = NULL
+          WHERE id = $1`,
+        [userId],
+      );
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Sends a verification email.
+   *
+   * This is a stub — no SMTP is configured yet.
+   * Phase 2 extension point: swap in nodemailer / Resend / SendGrid.
+   */
+  async sendVerificationEmail(
+    email: string,
+    token: string,
+    orgSlug: string,
+  ): Promise<void> {
+    // TODO (Phase 2 extension): integrate SMTP/transactional email provider
+    // For now log to console so the token is visible during development.
+    const verifyUrl = `/api/auth/verify-email/${token}`;
+    console.info(
+      `[EmailService] Verification email → ${email} (org: ${orgSlug})\n` +
+        `  URL: ${verifyUrl}`,
+    );
+  }
+}

--- a/packages/saas/src/services/invitation-service.test.ts
+++ b/packages/saas/src/services/invitation-service.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi } from 'vitest';
+import { InvitationService } from './invitation-service.js';
+import type { Pool, PoolClient } from '../db/types.js';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function makePool(queryRows: unknown[] = []): {
+  pool: Pool;
+  client: PoolClient & { query: ReturnType<typeof vi.fn>; release: ReturnType<typeof vi.fn> };
+} {
+  const query = vi.fn().mockResolvedValue({ rows: queryRows, rowCount: queryRows.length });
+  const client = { query, release: vi.fn() };
+  const pool: Pool = { connect: vi.fn().mockResolvedValue(client) };
+  return { pool, client };
+}
+
+const ORG = { id: 'org-uuid-1', slug: 'my-cinema', schema_name: 'org_my_cinema' };
+
+const MOCK_INVITE = {
+  id: 'inv-uuid-1',
+  email: 'bob@example.com',
+  role_id: 2,
+  token: 'secure-token-abc',
+  invited_by: 1,
+  accepted_at: null,
+  expires_at: new Date(Date.now() + 48 * 3600_000),
+  created_at: new Date(),
+};
+
+// ── InvitationService ─────────────────────────────────────────────────────────
+
+describe('InvitationService', () => {
+  describe('createInvitation', () => {
+    it('sets search_path before inserting the invitation', async () => {
+      const { pool, client } = makePool([MOCK_INVITE]);
+      const service = new InvitationService(pool);
+
+      await service.createInvitation(ORG, {
+        email: 'bob@example.com',
+        role_id: 2,
+        invited_by: 1,
+      });
+
+      expect(client.query).toHaveBeenNthCalledWith(
+        1,
+        'SET search_path TO "org_my_cinema", public',
+      );
+    });
+
+    it('inserts a row into the invitations table with a generated token', async () => {
+      const { pool, client } = makePool([MOCK_INVITE]);
+      const service = new InvitationService(pool);
+
+      await service.createInvitation(ORG, {
+        email: 'bob@example.com',
+        role_id: 2,
+        invited_by: 1,
+      });
+
+      const insertCall = client.query.mock.calls[1];
+      expect(insertCall[0]).toMatch(/INSERT INTO invitations/i);
+      expect(insertCall[1]).toContain('bob@example.com');
+    });
+
+    it('returns the created invitation row', async () => {
+      const { pool } = makePool([MOCK_INVITE]);
+      const service = new InvitationService(pool);
+
+      const result = await service.createInvitation(ORG, {
+        email: 'bob@example.com',
+        role_id: 2,
+        invited_by: 1,
+      });
+
+      expect(result).toMatchObject({
+        email: 'bob@example.com',
+        role_id: 2,
+        invited_by: 1,
+      });
+      expect(result.token).toBeDefined();
+    });
+
+    it('sets expiry to 48 hours from now', async () => {
+      const { pool, client } = makePool([MOCK_INVITE]);
+      const service = new InvitationService(pool);
+
+      const before = Date.now();
+      await service.createInvitation(ORG, { email: 'x@y.com', role_id: 2, invited_by: 1 });
+      const after = Date.now();
+
+      const insertCall = client.query.mock.calls[1];
+      const expiresParam = insertCall[1].find(
+        (p: unknown) => p instanceof Date,
+      ) as Date | undefined;
+
+      if (expiresParam) {
+        const diff = expiresParam.getTime() - before;
+        const diffMax = expiresParam.getTime() - after;
+        // Should be approx 48 hours
+        expect(diff).toBeGreaterThan(47 * 3600_000);
+        expect(diffMax).toBeLessThan(49 * 3600_000);
+      }
+    });
+
+    it('releases the pool client', async () => {
+      const { pool, client } = makePool([MOCK_INVITE]);
+      const service = new InvitationService(pool);
+
+      await service.createInvitation(ORG, { email: 'x@y.com', role_id: 2, invited_by: 1 });
+
+      expect(client.release).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('getInvitationByToken', () => {
+    it('sets search_path and queries invitations by token', async () => {
+      const { pool, client } = makePool([MOCK_INVITE]);
+      const service = new InvitationService(pool);
+
+      await service.getInvitationByToken(ORG, 'secure-token-abc');
+
+      expect(client.query).toHaveBeenNthCalledWith(
+        1,
+        'SET search_path TO "org_my_cinema", public',
+      );
+      const selectCall = client.query.mock.calls[1];
+      expect(selectCall[0]).toMatch(/SELECT/i);
+      expect(selectCall[0]).toMatch(/invitations/i);
+      expect(selectCall[1]).toContain('secure-token-abc');
+    });
+
+    it('returns null when no invitation matches the token', async () => {
+      const { pool } = makePool([]);
+      const service = new InvitationService(pool);
+
+      const result = await service.getInvitationByToken(ORG, 'no-such-token');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when the invitation is expired', async () => {
+      const expired = { ...MOCK_INVITE, expires_at: new Date(Date.now() - 1000) };
+      const { pool } = makePool([expired]);
+      const service = new InvitationService(pool);
+
+      const result = await service.getInvitationByToken(ORG, 'expired-token');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when the invitation is already accepted', async () => {
+      const accepted = { ...MOCK_INVITE, accepted_at: new Date() };
+      const { pool } = makePool([accepted]);
+      const service = new InvitationService(pool);
+
+      const result = await service.getInvitationByToken(ORG, 'used-token');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns the invitation when valid', async () => {
+      const { pool } = makePool([MOCK_INVITE]);
+      const service = new InvitationService(pool);
+
+      const result = await service.getInvitationByToken(ORG, 'secure-token-abc');
+
+      expect(result).toMatchObject({ email: 'bob@example.com', role_id: 2 });
+    });
+
+    it('releases the pool client', async () => {
+      const { pool, client } = makePool([MOCK_INVITE]);
+      const service = new InvitationService(pool);
+
+      await service.getInvitationByToken(ORG, 'secure-token-abc');
+
+      expect(client.release).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('acceptInvitation', () => {
+    it('sets search_path, inserts user, and marks invitation accepted', async () => {
+      const newUser = { id: 99, username: 'bob@example.com', role_id: 2, role_name: 'user' };
+      // First query (SET), second (INSERT user), third (UPDATE invitation)
+      const { pool, client } = makePool([newUser]);
+      client.query
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // SET search_path
+        .mockResolvedValueOnce({ rows: [newUser], rowCount: 1 }) // INSERT user
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 }); // UPDATE invitation
+
+      const service = new InvitationService(pool);
+
+      const result = await service.acceptInvitation(ORG, MOCK_INVITE, 'SecurePass1!');
+
+      expect(client.query).toHaveBeenNthCalledWith(
+        1,
+        'SET search_path TO "org_my_cinema", public',
+      );
+      const insertCall = client.query.mock.calls[1];
+      expect(insertCall[0]).toMatch(/INSERT INTO users/i);
+      const updateCall = client.query.mock.calls[2];
+      expect(updateCall[0]).toMatch(/UPDATE invitations/i);
+      expect(updateCall[0]).toMatch(/accepted_at/i);
+
+      expect(result).toMatchObject({ id: 99, username: 'bob@example.com' });
+    });
+
+    it('does not store plaintext password', async () => {
+      const newUser = { id: 99, username: 'bob@example.com', role_id: 2, role_name: 'user' };
+      const { pool, client } = makePool([]);
+      client.query
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+        .mockResolvedValueOnce({ rows: [newUser], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      const service = new InvitationService(pool);
+      await service.acceptInvitation(ORG, MOCK_INVITE, 'SecurePass1!');
+
+      const allArgs = JSON.stringify(client.query.mock.calls);
+      expect(allArgs).not.toContain('SecurePass1!');
+    });
+
+    it('releases the pool client', async () => {
+      const newUser = { id: 99, username: 'bob@example.com', role_id: 2, role_name: 'user' };
+      const { pool, client } = makePool([]);
+      client.query
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+        .mockResolvedValueOnce({ rows: [newUser], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      const service = new InvitationService(pool);
+      await service.acceptInvitation(ORG, MOCK_INVITE, 'SecurePass1!');
+
+      expect(client.release).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/packages/saas/src/services/invitation-service.ts
+++ b/packages/saas/src/services/invitation-service.ts
@@ -1,0 +1,132 @@
+import crypto from 'crypto';
+import bcrypt from 'bcryptjs';
+import type { Pool } from '../db/types.js';
+
+export interface OrgRef {
+  id: string;
+  slug: string;
+  schema_name: string;
+}
+
+export interface Invitation {
+  id: string;
+  email: string;
+  role_id: number;
+  token: string;
+  invited_by: number;
+  accepted_at: Date | null;
+  expires_at: Date;
+  created_at: Date;
+  /** Present when loaded via a join to public.organizations */
+  org_id?: string;
+  org_slug?: string;
+  org_schema_name?: string;
+}
+
+export interface CreateInvitationInput {
+  email: string;
+  role_id: number;
+  invited_by: number;
+  /** Optional: caller-supplied token (e.g. prefixed with orgSlug). If omitted, a random token is generated. */
+  token?: string;
+}
+
+export interface AcceptedUser {
+  id: number;
+  username: string;
+  role_id: number;
+  role_name: string;
+}
+
+/** Invitation validity window: 48 hours */
+const INVITE_TTL_MS = 48 * 60 * 60 * 1000;
+
+export class InvitationService {
+  constructor(private pool: Pool) {}
+
+  /**
+   * Creates a new pending invitation in the org schema.
+   * Generates a unique secure token valid for 48 hours.
+   */
+  async createInvitation(org: OrgRef, input: CreateInvitationInput): Promise<Invitation> {
+    const token = input.token ?? crypto.randomBytes(32).toString('hex');
+    const expiresAt = new Date(Date.now() + INVITE_TTL_MS);
+
+    const client = await this.pool.connect();
+    try {
+      await client.query(`SET search_path TO "${org.schema_name}", public`);
+      const result = await client.query<Invitation>(
+        `INSERT INTO invitations (email, role_id, token, invited_by, expires_at)
+         VALUES ($1, $2, $3, $4, $5)
+         RETURNING *`,
+        [input.email, input.role_id, token, input.invited_by, expiresAt],
+      );
+      return result.rows[0];
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Looks up a pending invitation by token.
+   * Returns null if not found, expired, or already accepted.
+   */
+  async getInvitationByToken(org: OrgRef, token: string): Promise<Invitation | null> {
+    const client = await this.pool.connect();
+    try {
+      await client.query(`SET search_path TO "${org.schema_name}", public`);
+      const result = await client.query<Invitation>(
+        `SELECT * FROM invitations WHERE token = $1`,
+        [token],
+      );
+      if (result.rows.length === 0) return null;
+
+      const invite = result.rows[0];
+      if (new Date(invite.expires_at) < new Date()) return null;
+      if (invite.accepted_at !== null) return null;
+
+      return invite;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Accepts an invitation:
+   *  1. Creates the user in the org schema with a bcrypt-hashed password
+   *  2. Marks the invitation as accepted
+   * All within a single dedicated pool client (same search_path).
+   */
+  async acceptInvitation(
+    org: OrgRef,
+    invitation: Invitation,
+    password: string,
+  ): Promise<AcceptedUser> {
+    const salt = await bcrypt.genSalt(10);
+    const passwordHash = await bcrypt.hash(password, salt);
+
+    const client = await this.pool.connect();
+    try {
+      await client.query(`SET search_path TO "${org.schema_name}", public`);
+
+      // Insert the new user with the invited role
+      const userResult = await client.query<AcceptedUser>(
+        `INSERT INTO users (username, password_hash, role_id)
+         VALUES ($1, $2, $3)
+         RETURNING id, username, role_id,
+                   (SELECT name FROM roles WHERE id = $3) AS role_name`,
+        [invitation.email, passwordHash, invitation.role_id],
+      );
+
+      // Mark invitation as accepted
+      await client.query(
+        `UPDATE invitations SET accepted_at = NOW() WHERE id = $1`,
+        [invitation.id],
+      );
+
+      return userResult.rows[0];
+    } finally {
+      client.release();
+    }
+  }
+}

--- a/packages/saas/src/services/org-export-service.test.ts
+++ b/packages/saas/src/services/org-export-service.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { PoolClient } from '../db/types.js';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function makeClient(rowsByCall: unknown[][] = [[]]): PoolClient & { query: ReturnType<typeof vi.fn> } {
+  let callCount = 0;
+  const query = vi.fn().mockImplementation(() => {
+    const rows = rowsByCall[callCount] ?? [];
+    callCount++;
+    return Promise.resolve({ rows, rowCount: rows.length });
+  });
+  return { query, release: vi.fn() } as unknown as PoolClient & { query: ReturnType<typeof vi.fn> };
+}
+
+const CINEMA_ROW = {
+  id: 'C0001',
+  name: 'Cinema Alpha',
+  source: 'allocine',
+  created_at: '2026-01-01T00:00:00.000Z',
+};
+
+const SHOWTIME_ROW = {
+  id: 1,
+  cinema_id: 'C0001',
+  film_id: 1,
+  show_time: '2026-04-01T20:00:00Z',
+};
+
+const SETTINGS_ROW = {
+  id: 1,
+  site_name: 'Cinéma Test',
+  color_primary: '#FECC00',
+};
+
+const ORG_INFO = {
+  id: 'uuid-1',
+  slug: 'cinema-test',
+  name: 'Cinéma Test',
+  schema_name: 'org_cinema_test',
+  status: 'active' as const,
+  plan: 'starter',
+  trial_ends_at: null,
+  created_at: new Date('2026-01-01'),
+};
+
+// ── OrgExportService ──────────────────────────────────────────────────────────
+
+describe('OrgExportService', async () => {
+  const { OrgExportService } = await import('./org-export-service.js');
+
+  it('exportOrg returns org metadata', async () => {
+    const client = makeClient([[CINEMA_ROW], [SHOWTIME_ROW], [SETTINGS_ROW]]);
+    const svc = new OrgExportService(client);
+
+    const result = await svc.exportOrg(ORG_INFO);
+
+    expect(result.org.slug).toBe('cinema-test');
+    expect(result.org.name).toBe('Cinéma Test');
+  });
+
+  it('exportOrg returns cinemas from the org schema', async () => {
+    const client = makeClient([[CINEMA_ROW], [SHOWTIME_ROW], [SETTINGS_ROW]]);
+    const svc = new OrgExportService(client);
+
+    const result = await svc.exportOrg(ORG_INFO);
+
+    expect(result.cinemas).toHaveLength(1);
+    expect(result.cinemas[0]).toMatchObject({ id: 'C0001', name: 'Cinema Alpha' });
+  });
+
+  it('exportOrg returns showtimes from the org schema', async () => {
+    const client = makeClient([[CINEMA_ROW], [SHOWTIME_ROW], [SETTINGS_ROW]]);
+    const svc = new OrgExportService(client);
+
+    const result = await svc.exportOrg(ORG_INFO);
+
+    expect(result.showtimes).toHaveLength(1);
+    expect(result.showtimes[0]).toMatchObject({ cinema_id: 'C0001' });
+  });
+
+  it('exportOrg returns org_settings', async () => {
+    const client = makeClient([[CINEMA_ROW], [SHOWTIME_ROW], [SETTINGS_ROW]]);
+    const svc = new OrgExportService(client);
+
+    const result = await svc.exportOrg(ORG_INFO);
+
+    expect(result.settings).toBeDefined();
+    expect(result.settings.site_name).toBe('Cinéma Test');
+  });
+
+  it('exportOrg includes an exported_at ISO timestamp', async () => {
+    const client = makeClient([[CINEMA_ROW], [SHOWTIME_ROW], [SETTINGS_ROW]]);
+    const svc = new OrgExportService(client);
+
+    const result = await svc.exportOrg(ORG_INFO);
+
+    expect(result.exported_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('exportOrg returns empty arrays when org has no cinemas or showtimes', async () => {
+    const client = makeClient([[], [], [SETTINGS_ROW]]);
+    const svc = new OrgExportService(client);
+
+    const result = await svc.exportOrg(ORG_INFO);
+
+    expect(result.cinemas).toHaveLength(0);
+    expect(result.showtimes).toHaveLength(0);
+  });
+});

--- a/packages/saas/src/services/org-export-service.ts
+++ b/packages/saas/src/services/org-export-service.ts
@@ -1,0 +1,55 @@
+import type { PoolClient } from '../db/types.js';
+import type { Organization } from '../db/org-queries.js';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface OrgExportData {
+  org: {
+    slug: string;
+    name: string;
+  };
+  cinemas: Record<string, unknown>[];
+  showtimes: Record<string, unknown>[];
+  settings: Record<string, unknown>;
+  exported_at: string;
+}
+
+// ── OrgExportService ──────────────────────────────────────────────────────────
+
+/**
+ * Exports a complete snapshot of an org's data as a JSON-serialisable object.
+ *
+ * Queries are issued against the already-scoped search_path (set by
+ * resolveTenant middleware) so no schema prefix is needed in SQL.
+ */
+export class OrgExportService {
+  constructor(private readonly client: PoolClient) {}
+
+  async exportOrg(org: Pick<Organization, 'id' | 'slug' | 'name'>): Promise<OrgExportData> {
+    // Fetch cinemas from org schema
+    const cinemasResult = await this.client.query<Record<string, unknown>>(
+      'SELECT * FROM cinemas ORDER BY id'
+    );
+
+    // Fetch showtimes from org schema
+    const showtimesResult = await this.client.query<Record<string, unknown>>(
+      'SELECT * FROM showtimes ORDER BY cinema_id, show_time'
+    );
+
+    // Fetch org settings from org schema
+    const settingsResult = await this.client.query<Record<string, unknown>>(
+      'SELECT * FROM org_settings LIMIT 1'
+    );
+
+    return {
+      org: {
+        slug: org.slug,
+        name: org.name,
+      },
+      cinemas: cinemasResult.rows,
+      showtimes: showtimesResult.rows,
+      settings: settingsResult.rows[0] ?? {},
+      exported_at: new Date().toISOString(),
+    };
+  }
+}

--- a/packages/saas/src/services/org-service.ts
+++ b/packages/saas/src/services/org-service.ts
@@ -24,8 +24,9 @@ async function bootstrapOrgSchema(db: DB, schemaName: string): Promise<void> {
 
   for (const file of files) {
     const sql = await fs.readFile(path.join(bootstrapDir, file), 'utf8');
-    // Set search_path for the duration of this statement batch
-    await db.query(`SET search_path TO ${schemaName}, public`);
+    // NOTE: PostgreSQL does not support $1 parameterized form for SET commands.
+    // schemaName is safe: derived from slugToSchemaName which produces [a-z0-9_] only.
+    await db.query(`SET search_path TO "${schemaName}", public`);
     await db.query(sql);
   }
 

--- a/packages/saas/src/services/org-service.ts
+++ b/packages/saas/src/services/org-service.ts
@@ -1,0 +1,2 @@
+// OrgService — create org schemas, manage orgs — to be implemented in Phase 1 Step 4
+export {};

--- a/packages/saas/src/services/org-service.ts
+++ b/packages/saas/src/services/org-service.ts
@@ -1,2 +1,70 @@
-// OrgService — create org schemas, manage orgs — to be implemented in Phase 1 Step 4
-export {};
+import path from 'path';
+import fs from 'fs/promises';
+import { fileURLToPath } from 'url';
+import type { DB } from '../db/types.js';
+import { insertOrg, isSlugAvailable, slugToSchemaName, type Organization } from '../db/org-queries.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function getOrgSchemaBootstrapDir(): string {
+  const isDocker = __dirname.startsWith('/app/');
+  return isDocker
+    ? path.join('/app', 'packages', 'saas', 'migrations', 'org_schema')
+    : path.join(__dirname, '../../migrations/org_schema');
+}
+
+/**
+ * Run all SQL files in org_schema/ within the new org's schema.
+ * Files are sorted by filename and run in order.
+ */
+async function bootstrapOrgSchema(db: DB, schemaName: string): Promise<void> {
+  const bootstrapDir = getOrgSchemaBootstrapDir();
+  const files = (await fs.readdir(bootstrapDir)).filter(f => f.endsWith('.sql')).sort();
+
+  for (const file of files) {
+    const sql = await fs.readFile(path.join(bootstrapDir, file), 'utf8');
+    // Set search_path for the duration of this statement batch
+    await db.query(`SET search_path TO ${schemaName}, public`);
+    await db.query(sql);
+  }
+
+  // Reset to public after bootstrapping
+  await db.query('SET search_path TO public');
+}
+
+export interface CreateOrgInput {
+  name: string;
+  slug: string;
+  plan_id?: number;
+}
+
+export interface OrgCreationResult {
+  org: Organization;
+  schemaCreated: boolean;
+}
+
+/**
+ * Full org creation flow:
+ *  1. Validate slug availability
+ *  2. INSERT into public.organizations
+ *  3. CREATE SCHEMA org_{slug}
+ *  4. Bootstrap org schema tables (users, cinemas, showtimes, etc.)
+ */
+export async function createOrg(db: DB, input: CreateOrgInput): Promise<OrgCreationResult> {
+  const slugAvailable = await isSlugAvailable(db, input.slug);
+  if (!slugAvailable) {
+    throw new Error(`Slug "${input.slug}" is already taken`);
+  }
+
+  const org = await insertOrg(db, input);
+  const schemaName = slugToSchemaName(input.slug);
+
+  // Create the PostgreSQL schema for this org
+  await db.query(`CREATE SCHEMA IF NOT EXISTS ${schemaName}`);
+
+  // Bootstrap all org-level tables
+  await bootstrapOrgSchema(db, schemaName);
+
+  return { org, schemaCreated: true };
+}

--- a/packages/saas/src/services/org-settings-service.test.ts
+++ b/packages/saas/src/services/org-settings-service.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { PoolClient } from '../db/types.js';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function makeClient(rows: unknown[] = []): PoolClient & { query: ReturnType<typeof vi.fn> } {
+  const query = vi.fn().mockResolvedValue({ rows, rowCount: rows.length });
+  return { query, release: vi.fn() } as unknown as PoolClient & { query: ReturnType<typeof vi.fn> };
+}
+
+const SETTINGS_ROW = {
+  id: 1,
+  site_name: 'My Cinema',
+  logo_base64: null,
+  favicon_base64: null,
+  color_primary: '#FECC00',
+  color_secondary: '#1F2937',
+  color_accent: '#F59E0B',
+  color_background: '#FFFFFF',
+  color_surface: '#F3F4F6',
+  color_text_primary: '#111827',
+  color_text_secondary: '#6B7280',
+  color_success: '#10B981',
+  color_error: '#EF4444',
+  font_primary: 'Inter',
+  font_secondary: 'Roboto',
+  footer_text: 'Footer here',
+  footer_links: '[]',
+  email_from_name: 'My Cinema',
+  email_from_address: 'no-reply@mycinema.com',
+  scrape_mode: 'weekly',
+  scrape_days: 7,
+  updated_at: '2026-01-01T00:00:00.000Z',
+  updated_by: null,
+};
+
+// ── OrgSettingsService ────────────────────────────────────────────────────────
+
+describe('OrgSettingsService', async () => {
+  // Import here (after mocks if any) — will fail until the file exists
+  const { OrgSettingsService } = await import('./org-settings-service.js');
+
+  describe('getSettings', () => {
+    it('returns full settings from org_settings table', async () => {
+      const client = makeClient([SETTINGS_ROW]);
+      const svc = new OrgSettingsService(client);
+
+      const result = await svc.getSettings();
+
+      expect(result).toBeDefined();
+      expect(result!.site_name).toBe('My Cinema');
+      expect(client.query).toHaveBeenCalledWith(
+        expect.stringMatching(/SELECT \* FROM org_settings WHERE id = 1/i),
+      );
+    });
+
+    it('returns undefined when no row exists', async () => {
+      const client = makeClient([]);
+      const svc = new OrgSettingsService(client);
+
+      const result = await svc.getSettings();
+
+      expect(result).toBeUndefined();
+    });
+
+    it('parses footer_links from JSON string', async () => {
+      const row = { ...SETTINGS_ROW, footer_links: '[{"label":"Home","url":"/"}]' };
+      const client = makeClient([row]);
+      const svc = new OrgSettingsService(client);
+
+      const result = await svc.getSettings();
+
+      expect(Array.isArray(result!.footer_links)).toBe(true);
+      expect(result!.footer_links[0]).toEqual({ label: 'Home', url: '/' });
+    });
+
+    it('handles footer_links already parsed as array (JSONB)', async () => {
+      const row = { ...SETTINGS_ROW, footer_links: [{ label: 'Home', url: '/' }] };
+      const client = makeClient([row]);
+      const svc = new OrgSettingsService(client);
+
+      const result = await svc.getSettings();
+
+      expect(Array.isArray(result!.footer_links)).toBe(true);
+    });
+  });
+
+  describe('getPublicSettings', () => {
+    it('returns public settings without sensitive fields', async () => {
+      const client = makeClient([SETTINGS_ROW]);
+      const svc = new OrgSettingsService(client);
+
+      const result = await svc.getPublicSettings();
+
+      expect(result).toBeDefined();
+      expect((result as Record<string, unknown>).email_from_name).toBeUndefined();
+      expect((result as Record<string, unknown>).email_from_address).toBeUndefined();
+      expect((result as Record<string, unknown>).updated_at).toBeUndefined();
+      expect((result as Record<string, unknown>).id).toBeUndefined();
+      expect(result!.site_name).toBe('My Cinema');
+    });
+
+    it('returns undefined when no row exists', async () => {
+      const client = makeClient([]);
+      const svc = new OrgSettingsService(client);
+
+      const result = await svc.getPublicSettings();
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('updateSettings', () => {
+    it('builds a dynamic UPDATE query for provided fields', async () => {
+      const updated = { ...SETTINGS_ROW, site_name: 'Updated Cinema' };
+      const client = makeClient([updated]);
+      const svc = new OrgSettingsService(client);
+
+      const result = await svc.updateSettings({ site_name: 'Updated Cinema' }, 42);
+
+      expect(result!.site_name).toBe('Updated Cinema');
+      const call = client.query.mock.calls[0];
+      expect(call[0]).toMatch(/UPDATE org_settings/i);
+      expect(call[0]).toMatch(/site_name/i);
+    });
+
+    it('stringifies footer_links as JSONB', async () => {
+      const client = makeClient([SETTINGS_ROW]);
+      const svc = new OrgSettingsService(client);
+
+      await svc.updateSettings({ footer_links: [{ label: 'A', url: 'https://a.com' }] }, 1);
+
+      const call = client.query.mock.calls[0];
+      // Param should contain stringified JSON
+      const params: unknown[] = call[1];
+      expect(params.some((p) => typeof p === 'string' && p.includes('"label"'))).toBe(true);
+    });
+
+    it('always updates updated_at and updated_by', async () => {
+      const client = makeClient([SETTINGS_ROW]);
+      const svc = new OrgSettingsService(client);
+
+      await svc.updateSettings({ site_name: 'X' }, 7);
+
+      const call = client.query.mock.calls[0];
+      expect(call[0]).toMatch(/updated_at/i);
+      expect(call[0]).toMatch(/updated_by/i);
+      expect(call[1]).toContain(7);
+    });
+
+    it('returns undefined when row is not found after update', async () => {
+      const client = makeClient([]);
+      const svc = new OrgSettingsService(client);
+
+      const result = await svc.updateSettings({ site_name: 'X' }, 1);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('resetSettings', () => {
+    it('resets all columns to default values', async () => {
+      const client = makeClient([SETTINGS_ROW]);
+      const svc = new OrgSettingsService(client);
+
+      const result = await svc.resetSettings(5);
+
+      expect(result).toBeDefined();
+      const call = client.query.mock.calls[0];
+      expect(call[0]).toMatch(/UPDATE org_settings/i);
+      expect(call[0]).toMatch(/site_name\s*=\s*'Allo-Scrapper'/i);
+      expect(call[1]).toContain(5); // userId param
+    });
+
+    it('returns undefined when row not found', async () => {
+      const client = makeClient([]);
+      const svc = new OrgSettingsService(client);
+
+      const result = await svc.resetSettings(1);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('exportSettings', () => {
+    it('returns an export object with version 1.0 and settings', async () => {
+      const client = makeClient([SETTINGS_ROW]);
+      const svc = new OrgSettingsService(client);
+
+      const result = await svc.exportSettings();
+
+      expect(result).toBeDefined();
+      expect(result!.version).toBe('1.0');
+      expect(result!.exported_at).toBeDefined();
+      expect(result!.settings.site_name).toBe('My Cinema');
+      // Export must not include id / updated_at / updated_by
+      expect((result!.settings as Record<string, unknown>).id).toBeUndefined();
+      expect((result!.settings as Record<string, unknown>).updated_at).toBeUndefined();
+    });
+
+    it('returns undefined when no settings row exists', async () => {
+      const client = makeClient([]);
+      const svc = new OrgSettingsService(client);
+
+      expect(await svc.exportSettings()).toBeUndefined();
+    });
+  });
+
+  describe('importSettings', () => {
+    it('applies exported settings via updateSettings', async () => {
+      const client = makeClient([SETTINGS_ROW]);
+      const svc = new OrgSettingsService(client);
+
+      const exportData = {
+        version: '1.0',
+        exported_at: '2026-01-01T00:00:00.000Z',
+        settings: {
+          site_name: 'Imported Cinema',
+          color_primary: '#FECC00',
+          color_secondary: '#1F2937',
+          color_accent: '#F59E0B',
+          color_background: '#FFFFFF',
+          color_surface: '#F3F4F6',
+          color_text_primary: '#111827',
+          color_text_secondary: '#6B7280',
+          color_success: '#10B981',
+          color_error: '#EF4444',
+          font_primary: 'Inter',
+          font_secondary: 'Roboto',
+          email_from_name: 'Imported',
+          email_from_address: 'import@example.com',
+          logo_base64: null,
+          favicon_base64: null,
+          footer_text: null,
+          footer_links: [],
+          scrape_mode: 'weekly' as const,
+          scrape_days: 7,
+        },
+      };
+
+      const result = await svc.importSettings(exportData, 1);
+
+      expect(result).toBeDefined();
+    });
+
+    it('throws when version is not 1.0', async () => {
+      const client = makeClient([]);
+      const svc = new OrgSettingsService(client);
+
+      await expect(
+        svc.importSettings(
+          {
+            version: '2.0',
+            exported_at: new Date().toISOString(),
+            settings: {} as never,
+          },
+          1,
+        ),
+      ).rejects.toThrow(/incompatible version/i);
+    });
+
+    it('throws when required fields are missing', async () => {
+      const client = makeClient([]);
+      const svc = new OrgSettingsService(client);
+
+      await expect(
+        svc.importSettings(
+          {
+            version: '1.0',
+            exported_at: new Date().toISOString(),
+            settings: { site_name: 'only-one-field' } as never,
+          },
+          1,
+        ),
+      ).rejects.toThrow(/missing required field/i);
+    });
+  });
+});

--- a/packages/saas/src/services/org-settings-service.ts
+++ b/packages/saas/src/services/org-settings-service.ts
@@ -1,0 +1,331 @@
+import type { PoolClient } from '../db/types.js';
+
+// ── Types (mirroring server/src/types/settings.ts) ────────────────────────────
+
+export type ScrapeMode = 'weekly' | 'from_today' | 'from_today_limited';
+
+export interface FooterLink {
+  label: string;
+  url: string;
+}
+
+export interface OrgSettings {
+  id: number;
+  site_name: string;
+  logo_base64: string | null;
+  favicon_base64: string | null;
+  color_primary: string;
+  color_secondary: string;
+  color_accent: string;
+  color_background: string;
+  color_surface: string;
+  color_text_primary: string;
+  color_text_secondary: string;
+  color_success: string;
+  color_error: string;
+  font_primary: string;
+  font_secondary: string;
+  footer_text: string | null;
+  footer_links: FooterLink[];
+  email_from_name: string;
+  email_from_address: string;
+  scrape_mode: ScrapeMode;
+  scrape_days: number;
+  updated_at: string;
+  updated_by: number | null;
+}
+
+export interface OrgSettingsPublic {
+  site_name: string;
+  logo_base64: string | null;
+  favicon_base64: string | null;
+  color_primary: string;
+  color_secondary: string;
+  color_accent: string;
+  color_background: string;
+  color_surface: string;
+  color_text_primary: string;
+  color_text_secondary: string;
+  color_success: string;
+  color_error: string;
+  font_primary: string;
+  font_secondary: string;
+  footer_text: string | null;
+  footer_links: FooterLink[];
+}
+
+export interface OrgSettingsUpdate {
+  site_name?: string;
+  logo_base64?: string | null;
+  favicon_base64?: string | null;
+  color_primary?: string;
+  color_secondary?: string;
+  color_accent?: string;
+  color_background?: string;
+  color_surface?: string;
+  color_text_primary?: string;
+  color_text_secondary?: string;
+  color_success?: string;
+  color_error?: string;
+  font_primary?: string;
+  font_secondary?: string;
+  footer_text?: string | null;
+  footer_links?: FooterLink[];
+  email_from_name?: string;
+  email_from_address?: string;
+  scrape_mode?: ScrapeMode;
+  scrape_days?: number;
+}
+
+export interface OrgSettingsExport {
+  version: string;
+  exported_at: string;
+  settings: Omit<OrgSettings, 'id' | 'updated_at' | 'updated_by'>;
+}
+
+// ── DB row interface ──────────────────────────────────────────────────────────
+
+interface OrgSettingsRow {
+  id: number;
+  site_name: string;
+  logo_base64: string | null;
+  favicon_base64: string | null;
+  color_primary: string;
+  color_secondary: string;
+  color_accent: string;
+  color_background: string;
+  color_surface: string;
+  color_text_primary: string;
+  color_text_secondary: string;
+  color_success: string;
+  color_error: string;
+  font_primary: string;
+  font_secondary: string;
+  footer_text: string | null;
+  footer_links: string | FooterLink[];
+  email_from_name: string;
+  email_from_address: string;
+  scrape_mode: string;
+  scrape_days: number;
+  updated_at: string;
+  updated_by: number | null;
+}
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+function rowToSettings(row: OrgSettingsRow): OrgSettings {
+  return {
+    ...row,
+    footer_links:
+      typeof row.footer_links === 'string'
+        ? (JSON.parse(row.footer_links) as FooterLink[])
+        : row.footer_links,
+    scrape_mode: row.scrape_mode as ScrapeMode,
+  };
+}
+
+function toPublicSettings(settings: OrgSettings): OrgSettingsPublic {
+  const {
+    id: _id,
+    email_from_name: _efn,
+    email_from_address: _efa,
+    updated_at: _uat,
+    updated_by: _uby,
+    scrape_mode: _sm,
+    scrape_days: _sd,
+    ...publicFields
+  } = settings;
+  return publicFields;
+}
+
+// ── Field map (same columns as app_settings) ──────────────────────────────────
+
+const FIELD_MAP: Record<keyof OrgSettingsUpdate, string> = {
+  site_name: 'site_name',
+  logo_base64: 'logo_base64',
+  favicon_base64: 'favicon_base64',
+  color_primary: 'color_primary',
+  color_secondary: 'color_secondary',
+  color_accent: 'color_accent',
+  color_background: 'color_background',
+  color_surface: 'color_surface',
+  color_text_primary: 'color_text_primary',
+  color_text_secondary: 'color_text_secondary',
+  color_success: 'color_success',
+  color_error: 'color_error',
+  font_primary: 'font_primary',
+  font_secondary: 'font_secondary',
+  footer_text: 'footer_text',
+  footer_links: 'footer_links',
+  email_from_name: 'email_from_name',
+  email_from_address: 'email_from_address',
+  scrape_mode: 'scrape_mode',
+  scrape_days: 'scrape_days',
+};
+
+const REQUIRED_IMPORT_FIELDS: (keyof OrgSettingsUpdate)[] = [
+  'site_name',
+  'color_primary',
+  'color_secondary',
+  'color_accent',
+  'color_background',
+  'color_surface',
+  'color_text_primary',
+  'color_text_secondary',
+  'color_success',
+  'color_error',
+  'font_primary',
+  'font_secondary',
+  'email_from_name',
+  'email_from_address',
+];
+
+// ── Service ───────────────────────────────────────────────────────────────────
+
+/**
+ * Per-tenant settings service.
+ * Operates on the `org_settings` table inside the org's schema.
+ * Accepts a `PoolClient` whose `search_path` is already scoped to the org
+ * schema by the `resolveTenant` middleware.
+ */
+export class OrgSettingsService {
+  constructor(private readonly client: PoolClient) {}
+
+  /**
+   * Get full settings (admin only).
+   */
+  async getSettings(): Promise<OrgSettings | undefined> {
+    const result = await this.client.query<OrgSettingsRow>(
+      'SELECT * FROM org_settings WHERE id = 1',
+    );
+    if (result.rows.length === 0) return undefined;
+    return rowToSettings(result.rows[0]);
+  }
+
+  /**
+   * Get public settings (no authentication required).
+   */
+  async getPublicSettings(): Promise<OrgSettingsPublic | undefined> {
+    const settings = await this.getSettings();
+    if (!settings) return undefined;
+    return toPublicSettings(settings);
+  }
+
+  /**
+   * Update settings fields.
+   */
+  async updateSettings(
+    updates: OrgSettingsUpdate,
+    userId: number,
+  ): Promise<OrgSettings | undefined> {
+    const fields: string[] = [];
+    const values: unknown[] = [];
+    let paramIndex = 1;
+
+    for (const [key, dbColumn] of Object.entries(FIELD_MAP)) {
+      if (key in updates) {
+        const value = updates[key as keyof OrgSettingsUpdate];
+        if (key === 'footer_links') {
+          fields.push(`${dbColumn} = $${paramIndex}::jsonb`);
+          values.push(JSON.stringify(value));
+        } else {
+          fields.push(`${dbColumn} = $${paramIndex}`);
+          values.push(value);
+        }
+        paramIndex++;
+      }
+    }
+
+    fields.push(`updated_at = NOW()`);
+    fields.push(`updated_by = $${paramIndex}`);
+    values.push(userId);
+
+    const query = `
+      UPDATE org_settings
+      SET ${fields.join(', ')}
+      WHERE id = 1
+      RETURNING *
+    `;
+
+    const result = await this.client.query<OrgSettingsRow>(query, values);
+    if (result.rows.length === 0) return undefined;
+    return rowToSettings(result.rows[0]);
+  }
+
+  /**
+   * Reset to default values.
+   */
+  async resetSettings(userId: number): Promise<OrgSettings | undefined> {
+    const query = `
+      UPDATE org_settings
+      SET
+        site_name = 'Allo-Scrapper',
+        logo_base64 = NULL,
+        favicon_base64 = NULL,
+        color_primary = '#FECC00',
+        color_secondary = '#1F2937',
+        color_accent = '#F59E0B',
+        color_background = '#FFFFFF',
+        color_surface = '#F3F4F6',
+        color_text_primary = '#111827',
+        color_text_secondary = '#6B7280',
+        color_success = '#10B981',
+        color_error = '#EF4444',
+        font_primary = 'Inter',
+        font_secondary = 'Roboto',
+        footer_text = NULL,
+        footer_links = '[]'::jsonb,
+        email_from_name = 'Allo-Scrapper',
+        email_from_address = 'no-reply@allocine-scrapper.com',
+        scrape_mode = 'weekly',
+        scrape_days = 7,
+        updated_at = NOW(),
+        updated_by = $1
+      WHERE id = 1
+      RETURNING *
+    `;
+
+    const result = await this.client.query<OrgSettingsRow>(query, [userId]);
+    if (result.rows.length === 0) return undefined;
+    return rowToSettings(result.rows[0]);
+  }
+
+  /**
+   * Export settings for backup.
+   */
+  async exportSettings(): Promise<OrgSettingsExport | undefined> {
+    const settings = await this.getSettings();
+    if (!settings) return undefined;
+
+    const { id: _id, updated_at: _uat, updated_by: _uby, ...exportable } = settings;
+
+    return {
+      version: '1.0',
+      exported_at: new Date().toISOString(),
+      settings: exportable,
+    };
+  }
+
+  /**
+   * Import settings from a backup.
+   * @throws Error if version is incompatible or required fields are missing.
+   */
+  async importSettings(
+    exportData: OrgSettingsExport,
+    userId: number,
+  ): Promise<OrgSettings | undefined> {
+    if (exportData.version !== '1.0') {
+      throw new Error(
+        `Incompatible version: ${exportData.version}. Expected 1.0`,
+      );
+    }
+
+    for (const field of REQUIRED_IMPORT_FIELDS) {
+      if (!(field in exportData.settings)) {
+        throw new Error(`Missing required field in import data: ${field}`);
+      }
+    }
+
+    return this.updateSettings(exportData.settings as OrgSettingsUpdate, userId);
+  }
+}

--- a/packages/saas/src/services/quota-service.test.ts
+++ b/packages/saas/src/services/quota-service.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi } from 'vitest';
+import { QuotaService } from './quota-service.js';
+import type { DB } from '../db/types.js';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function makeDb(rows: unknown[] = []): DB {
+  return {
+    query: vi.fn().mockResolvedValue({ rows, rowCount: rows.length }),
+  };
+}
+
+const ORG_ID = 'org-uuid-1';
+
+const CURRENT_MONTH = new Date();
+CURRENT_MONTH.setDate(1);
+CURRENT_MONTH.setHours(0, 0, 0, 0);
+
+const USAGE_ROW = {
+  id: 1,
+  org_id: ORG_ID,
+  month: CURRENT_MONTH.toISOString(),
+  cinemas_count: 2,
+  scrapes_count: 10,
+  api_calls_count: 500,
+};
+
+// ── QuotaService ──────────────────────────────────────────────────────────────
+
+describe('QuotaService', () => {
+  describe('getOrCreateUsage', () => {
+    it('queries org_usage for the current month', async () => {
+      const db = makeDb([USAGE_ROW]);
+      const service = new QuotaService(db);
+
+      await service.getOrCreateUsage(ORG_ID);
+
+      const call = (db.query as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(call[0]).toMatch(/org_usage/i);
+      expect(call[0]).toMatch(/org_id/i);
+      expect(call[1]).toContain(ORG_ID);
+    });
+
+    it('returns the existing usage row when found', async () => {
+      const db = makeDb([USAGE_ROW]);
+      const service = new QuotaService(db);
+
+      const result = await service.getOrCreateUsage(ORG_ID);
+
+      expect(result.cinemas_count).toBe(2);
+      expect(result.scrapes_count).toBe(10);
+    });
+
+    it('inserts a new usage row when none exists for current month', async () => {
+      const newRow = { ...USAGE_ROW, cinemas_count: 0, scrapes_count: 0 };
+      const db = makeDb([]);
+      // First SELECT returns empty, INSERT returns new row
+      (db.query as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+        .mockResolvedValueOnce({ rows: [newRow], rowCount: 1 });
+      const service = new QuotaService(db);
+
+      const result = await service.getOrCreateUsage(ORG_ID);
+
+      expect(result.cinemas_count).toBe(0);
+      expect(result.scrapes_count).toBe(0);
+      const insertCall = (db.query as ReturnType<typeof vi.fn>).mock.calls[1];
+      expect(insertCall[0]).toMatch(/INSERT INTO org_usage/i);
+    });
+  });
+
+  describe('incrementUsage', () => {
+    it('increments cinemas_count by 1', async () => {
+      const db = makeDb([]);
+      const service = new QuotaService(db);
+
+      await service.incrementUsage(ORG_ID, 'cinemas');
+
+      const call = (db.query as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(call[0]).toMatch(/cinemas_count/i);
+      expect(call[0]).toMatch(/\+\s*1/);
+      expect(call[1]).toContain(ORG_ID);
+    });
+
+    it('increments scrapes_count by 1', async () => {
+      const db = makeDb([]);
+      const service = new QuotaService(db);
+
+      await service.incrementUsage(ORG_ID, 'scrapes');
+
+      const call = (db.query as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(call[0]).toMatch(/scrapes_count/i);
+      expect(call[0]).toMatch(/\+\s*1/);
+    });
+
+    it('increments users_count by 1', async () => {
+      const db = makeDb([]);
+      const service = new QuotaService(db);
+
+      await service.incrementUsage(ORG_ID, 'users');
+
+      const call = (db.query as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(call[0]).toMatch(/users_count/i);
+      expect(call[0]).toMatch(/\+\s*1/);
+    });
+
+    it('uses UPSERT so it creates the row if missing', async () => {
+      const db = makeDb([]);
+      const service = new QuotaService(db);
+
+      await service.incrementUsage(ORG_ID, 'cinemas');
+
+      const call = (db.query as ReturnType<typeof vi.fn>).mock.calls[0];
+      // Should use INSERT ... ON CONFLICT ... DO UPDATE
+      expect(call[0]).toMatch(/ON CONFLICT/i);
+    });
+  });
+
+  describe('decrementUsage', () => {
+    it('decrements cinemas_count by 1, floored at 0', async () => {
+      const db = makeDb([]);
+      const service = new QuotaService(db);
+
+      await service.decrementUsage(ORG_ID, 'cinemas');
+
+      const call = (db.query as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(call[0]).toMatch(/cinemas_count/i);
+      // GREATEST(0, ...) ensures floor at 0
+      expect(call[0]).toMatch(/GREATEST/i);
+      expect(call[1]).toContain(ORG_ID);
+    });
+  });
+
+  describe('resetMonthlyUsage', () => {
+    it('resets scrapes_count and api_calls_count to 0 for the given org', async () => {
+      const db = makeDb([]);
+      const service = new QuotaService(db);
+
+      await service.resetMonthlyUsage(ORG_ID);
+
+      const call = (db.query as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(call[0]).toMatch(/UPDATE org_usage/i);
+      expect(call[0]).toMatch(/scrapes_count\s*=\s*0/i);
+      expect(call[0]).toMatch(/api_calls_count\s*=\s*0/i);
+      expect(call[1]).toContain(ORG_ID);
+    });
+  });
+});

--- a/packages/saas/src/services/quota-service.ts
+++ b/packages/saas/src/services/quota-service.ts
@@ -1,0 +1,98 @@
+import type { DB } from '../db/types.js';
+
+export type QuotaResource = 'cinemas' | 'users' | 'scrapes';
+
+export interface OrgUsage {
+  id: number;
+  org_id: string;
+  month: string;
+  cinemas_count: number;
+  users_count: number;
+  scrapes_count: number;
+  api_calls_count: number;
+}
+
+/** Returns the first day of the current month as a DATE string (YYYY-MM-01). */
+function currentMonthDate(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-01`;
+}
+
+const COLUMN_MAP: Record<QuotaResource, string> = {
+  cinemas: 'cinemas_count',
+  users:   'users_count',
+  scrapes: 'scrapes_count',
+};
+
+export class QuotaService {
+  constructor(private db: DB) {}
+
+  /**
+   * Returns the usage row for the current month, creating it (all zeros) if absent.
+   */
+  async getOrCreateUsage(orgId: string): Promise<OrgUsage> {
+    const month = currentMonthDate();
+
+    const existing = await this.db.query<OrgUsage>(
+      `SELECT * FROM org_usage WHERE org_id = $1 AND month = $2`,
+      [orgId, month],
+    );
+    if (existing.rows.length > 0) return existing.rows[0];
+
+    const inserted = await this.db.query<OrgUsage>(
+      `INSERT INTO org_usage (org_id, month)
+       VALUES ($1, $2)
+       RETURNING *`,
+      [orgId, month],
+    );
+    return inserted.rows[0];
+  }
+
+  /**
+   * Atomically increments the named resource counter for the current month.
+   * Uses UPSERT so the row is created on first increment if missing.
+   */
+  async incrementUsage(orgId: string, resource: QuotaResource): Promise<void> {
+    const col = COLUMN_MAP[resource];
+    const month = currentMonthDate();
+
+    await this.db.query(
+      `INSERT INTO org_usage (org_id, month, ${col})
+       VALUES ($1, $2, 1)
+       ON CONFLICT (org_id, month) DO UPDATE
+         SET ${col} = org_usage.${col} + 1`,
+      [orgId, month],
+    );
+  }
+
+  /**
+   * Atomically decrements the named resource counter, floored at 0.
+   */
+  async decrementUsage(orgId: string, resource: QuotaResource): Promise<void> {
+    const col = COLUMN_MAP[resource];
+    const month = currentMonthDate();
+
+    await this.db.query(
+      `UPDATE org_usage
+          SET ${col} = GREATEST(0, ${col} - 1)
+        WHERE org_id = $1 AND month = $2`,
+      [orgId, month],
+    );
+  }
+
+  /**
+   * Resets scrapes_count and api_calls_count to 0 for the current month.
+   * Called on the 1st of each month (cron job).
+   */
+  async resetMonthlyUsage(orgId: string): Promise<void> {
+    const month = currentMonthDate();
+
+    await this.db.query(
+      `UPDATE org_usage
+          SET scrapes_count   = 0,
+              api_calls_count = 0
+        WHERE org_id = $1 AND month = $2`,
+      [orgId, month],
+    );
+  }
+}

--- a/packages/saas/src/services/saas-auth-service.test.ts
+++ b/packages/saas/src/services/saas-auth-service.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SaasAuthService } from './saas-auth-service.js';
+import type { Pool, PoolClient } from '../db/types.js';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function makePool(queryRows: unknown[] = []): { pool: Pool; client: PoolClient & { query: ReturnType<typeof vi.fn>; release: ReturnType<typeof vi.fn> } } {
+  const query = vi.fn().mockResolvedValue({ rows: queryRows, rowCount: queryRows.length });
+  const client = { query, release: vi.fn() };
+  const pool: Pool = { connect: vi.fn().mockResolvedValue(client) };
+  return { pool, client };
+}
+
+const ORG = {
+  id: 'org-uuid-1',
+  slug: 'my-cinema',
+  schema_name: 'org_my_cinema',
+};
+
+const VALID_JWT_SECRET = 'test-secret-that-is-at-least-32-chars-long!!';
+
+// ── SaasAuthService ──────────────────────────────────────────────────────────
+
+describe('SaasAuthService', () => {
+  beforeEach(() => {
+    vi.stubEnv('JWT_SECRET', VALID_JWT_SECRET);
+    vi.stubEnv('JWT_EXPIRES_IN', '24h');
+  });
+
+  describe('createAdminUser', () => {
+    it('sets search_path to the org schema before inserting user', async () => {
+      // The INSERT query returns the new user row
+      const newUser = { id: 1, username: 'admin@my-cinema.com', role_id: 1, role_name: 'admin' };
+      const { pool, client } = makePool([newUser]);
+
+      const service = new SaasAuthService(pool);
+      await service.createAdminUser(ORG, 'admin@my-cinema.com', 'Password1!');
+
+      // First query must set the search_path to the org schema
+      expect(client.query).toHaveBeenNthCalledWith(
+        1,
+        'SET search_path TO "org_my_cinema", public',
+      );
+    });
+
+    it('inserts user into the org schema with a hashed password', async () => {
+      const newUser = { id: 1, username: 'admin@my-cinema.com', role_id: 1, role_name: 'admin' };
+      const { pool, client } = makePool([newUser]);
+
+      const service = new SaasAuthService(pool);
+      await service.createAdminUser(ORG, 'admin@my-cinema.com', 'Password1!');
+
+      // Second call should be an INSERT on the users table
+      const insertCall = client.query.mock.calls[1];
+      expect(insertCall[0]).toMatch(/INSERT INTO users/i);
+      // The plaintext password must NOT appear in the query
+      expect(JSON.stringify(insertCall)).not.toContain('Password1!');
+    });
+
+    it('releases the pool client when done', async () => {
+      const newUser = { id: 1, username: 'admin@my-cinema.com', role_id: 1, role_name: 'admin' };
+      const { pool, client } = makePool([newUser]);
+
+      const service = new SaasAuthService(pool);
+      await service.createAdminUser(ORG, 'admin@my-cinema.com', 'Password1!');
+
+      expect(client.release).toHaveBeenCalledOnce();
+    });
+
+    it('releases the pool client even when an error is thrown', async () => {
+      const { pool, client } = makePool();
+      client.query.mockRejectedValueOnce(new Error('db error'));
+
+      const service = new SaasAuthService(pool);
+      await expect(
+        service.createAdminUser(ORG, 'admin@my-cinema.com', 'Password1!'),
+      ).rejects.toThrow('db error');
+
+      expect(client.release).toHaveBeenCalledOnce();
+    });
+
+    it('returns the created user with id, username, role_id, role_name', async () => {
+      const newUser = { id: 42, username: 'admin@test.com', role_id: 1, role_name: 'admin' };
+      const { pool } = makePool([newUser]);
+
+      const service = new SaasAuthService(pool);
+      const result = await service.createAdminUser(ORG, 'admin@test.com', 'Secure!Pass1');
+
+      expect(result).toMatchObject({
+        id: 42,
+        username: 'admin@test.com',
+        role_id: 1,
+        role_name: 'admin',
+      });
+    });
+  });
+
+  describe('mintJwt', () => {
+    it('returns a JWT string', () => {
+      const service = new SaasAuthService({} as Pool);
+      const token = service.mintJwt({
+        userId: 1,
+        username: 'admin@my-cinema.com',
+        orgId: ORG.id,
+        orgSlug: ORG.slug,
+        roleId: 1,
+        roleName: 'admin',
+        permissions: [],
+      });
+
+      expect(typeof token).toBe('string');
+      expect(token.split('.')).toHaveLength(3); // header.payload.signature
+    });
+
+    it('JWT payload contains org_id and org_slug', () => {
+      const service = new SaasAuthService({} as Pool);
+      const token = service.mintJwt({
+        userId: 1,
+        username: 'admin@my-cinema.com',
+        orgId: ORG.id,
+        orgSlug: ORG.slug,
+        roleId: 1,
+        roleName: 'admin',
+        permissions: [],
+      });
+
+      // Decode payload (base64url)
+      const payloadB64 = token.split('.')[1];
+      const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf8'));
+
+      expect(payload.org_id).toBe(ORG.id);
+      expect(payload.org_slug).toBe(ORG.slug);
+      expect(payload.id).toBe(1);
+      expect(payload.username).toBe('admin@my-cinema.com');
+    });
+
+    it('throws when JWT_SECRET is missing', () => {
+      vi.stubEnv('JWT_SECRET', '');
+
+      const service = new SaasAuthService({} as Pool);
+      expect(() =>
+        service.mintJwt({
+          userId: 1,
+          username: 'u',
+          orgId: 'o',
+          orgSlug: 's',
+          roleId: 1,
+          roleName: 'admin',
+          permissions: [],
+        }),
+      ).toThrow();
+    });
+  });
+});

--- a/packages/saas/src/services/saas-auth-service.ts
+++ b/packages/saas/src/services/saas-auth-service.ts
@@ -1,0 +1,103 @@
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import type { Pool } from '../db/types.js';
+
+export interface OrgRef {
+  id: string;
+  slug: string;
+  schema_name: string;
+}
+
+export interface AdminUserRow {
+  id: number;
+  username: string;
+  role_id: number;
+  role_name: string;
+}
+
+export interface MintJwtInput {
+  userId: number;
+  username: string;
+  orgId: string;
+  orgSlug: string;
+  roleId: number;
+  roleName: string;
+  permissions: string[];
+}
+
+/**
+ * SaaS-specific auth service.
+ *
+ * Differs from the core AuthService by:
+ *  - Targeting a tenant schema (uses pool.connect() + SET search_path)
+ *  - Including org_id / org_slug in the JWT payload
+ */
+export class SaasAuthService {
+  constructor(private pool: Pool) {}
+
+  /**
+   * Creates the initial admin user inside the org's private schema.
+   *
+   * Uses a dedicated pool client so that SET search_path is scoped to
+   * this connection only and does not bleed into other queries.
+   */
+  async createAdminUser(
+    org: OrgRef,
+    email: string,
+    password: string,
+  ): Promise<AdminUserRow> {
+    const client = await this.pool.connect();
+    try {
+      // NOTE: PostgreSQL does not support $1 parameterized form for SET.
+      // schema_name is guaranteed safe: slugToSchemaName produces [a-z0-9_] only.
+      await client.query(`SET search_path TO "${org.schema_name}", public`);
+
+      const salt = await bcrypt.genSalt(10);
+      const passwordHash = await bcrypt.hash(password, salt);
+
+      // role_id = 1 assumes the 'admin' system role seeded in 000_bootstrap.sql
+      const result = await client.query<AdminUserRow>(
+        `INSERT INTO users (username, password_hash, role_id)
+         VALUES ($1, $2, 1)
+         RETURNING id, username, role_id,
+                   (SELECT name FROM roles WHERE id = 1) AS role_name`,
+        [email, passwordHash],
+      );
+
+      return result.rows[0];
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Mints a JWT for the newly created admin user.
+   * The payload includes org_id and org_slug so downstream middleware
+   * can resolve the tenant without a DB round-trip.
+   */
+  mintJwt(input: MintJwtInput): string {
+    const secret = process.env.JWT_SECRET?.trim();
+    if (!secret || secret.length < 32) {
+      throw new Error(
+        'FATAL: JWT_SECRET is missing or too short. ' +
+          'Generate a secure secret with: openssl rand -base64 64',
+      );
+    }
+
+    const expiresIn = (process.env.JWT_EXPIRES_IN ?? '24h') as string;
+
+    return jwt.sign(
+      {
+        id: input.userId,
+        username: input.username,
+        org_id: input.orgId,
+        org_slug: input.orgSlug,
+        role_id: input.roleId,
+        role_name: input.roleName,
+        permissions: input.permissions,
+      },
+      secret,
+      { expiresIn: expiresIn as any },
+    );
+  }
+}

--- a/packages/saas/src/services/superadmin-auth-service.test.ts
+++ b/packages/saas/src/services/superadmin-auth-service.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SuperadminAuthService } from './superadmin-auth-service.js';
+import type { Pool, PoolClient } from '../db/types.js';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function makePool(
+  queryRows: unknown[] = [],
+): { pool: Pool; client: PoolClient & { query: ReturnType<typeof vi.fn>; release: ReturnType<typeof vi.fn> } } {
+  const query = vi.fn().mockResolvedValue({ rows: queryRows, rowCount: queryRows.length });
+  const client = { query, release: vi.fn() };
+  const pool: Pool = { connect: vi.fn().mockResolvedValue(client) };
+  return { pool, client };
+}
+
+const VALID_SUPERADMIN_SECRET = 'superadmin-secret-at-least-32-chars-long!!';
+
+// ── SuperadminAuthService ─────────────────────────────────────────────────────
+
+describe('SuperadminAuthService', () => {
+  beforeEach(() => {
+    vi.stubEnv('SUPERADMIN_JWT_SECRET', VALID_SUPERADMIN_SECRET);
+  });
+
+  // ── createSuperadmin ──────────────────────────────────────────────────────
+
+  describe('createSuperadmin', () => {
+    it('inserts a superadmin with a hashed password', async () => {
+      const row = { id: 1, username: 'root' };
+      const { pool, client } = makePool([row]);
+
+      const service = new SuperadminAuthService(pool);
+      await service.createSuperadmin('root', 'Password1!');
+
+      const insertCall = client.query.mock.calls[0];
+      expect(insertCall[0]).toMatch(/INSERT INTO superadmins/i);
+      // Plaintext password must NOT appear in query
+      expect(JSON.stringify(insertCall)).not.toContain('Password1!');
+    });
+
+    it('returns the created superadmin row', async () => {
+      const { pool } = makePool([{ id: 1, username: 'root' }]);
+
+      const service = new SuperadminAuthService(pool);
+      const result = await service.createSuperadmin('root', 'Password1!');
+
+      expect(result).toMatchObject({ id: 1, username: 'root' });
+    });
+
+    it('releases the pool client when done', async () => {
+      const { pool, client } = makePool([{ id: 1, username: 'root' }]);
+
+      const service = new SuperadminAuthService(pool);
+      await service.createSuperadmin('root', 'Password1!');
+
+      expect(client.release).toHaveBeenCalledOnce();
+    });
+
+    it('releases the pool client on error', async () => {
+      const { pool, client } = makePool();
+      client.query.mockRejectedValueOnce(new Error('db error'));
+
+      const service = new SuperadminAuthService(pool);
+      await expect(service.createSuperadmin('root', 'P@ssw0rd!')).rejects.toThrow('db error');
+
+      expect(client.release).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ── validateCredentials ───────────────────────────────────────────────────
+
+  describe('validateCredentials', () => {
+    it('returns the superadmin row when username and password are correct', async () => {
+      // bcrypt hash of 'Password1!' generated at cost 10
+      const hash = '$2b$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LPVImSEMhyS'; // placeholder — tested with real bcrypt in GREEN phase
+      const row = { id: 1, username: 'root', password_hash: hash };
+      const { pool } = makePool([row]);
+
+      // We can't easily test bcrypt equality in a unit test without real hash;
+      // test the "not found" and "wrong password" paths instead.
+      const service = new SuperadminAuthService(pool);
+
+      // If no row returned → null
+      const emptyPool = makePool([]).pool;
+      const emptyService = new SuperadminAuthService(emptyPool);
+      const result = await emptyService.validateCredentials('ghost', 'Password1!');
+      expect(result).toBeNull();
+    });
+
+    it('returns null when password does not match', async () => {
+      // Use a known bcrypt hash for 'correct-password'
+      const bcrypt = await import('bcryptjs');
+      const hash = await bcrypt.hash('correct-password', 1); // cost 1 for speed in tests
+      const row = { id: 1, username: 'root', password_hash: hash };
+      const { pool } = makePool([row]);
+
+      const service = new SuperadminAuthService(pool);
+      const result = await service.validateCredentials('root', 'wrong-password');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns the superadmin when credentials are valid', async () => {
+      const bcrypt = await import('bcryptjs');
+      const hash = await bcrypt.hash('correct-password', 1);
+      const row = { id: 1, username: 'root', password_hash: hash };
+      const { pool } = makePool([row]);
+
+      const service = new SuperadminAuthService(pool);
+      const result = await service.validateCredentials('root', 'correct-password');
+
+      expect(result).toMatchObject({ id: 1, username: 'root' });
+    });
+  });
+
+  // ── mintSuperadminJwt ─────────────────────────────────────────────────────
+
+  describe('mintSuperadminJwt', () => {
+    it('returns a JWT string with three segments', () => {
+      const service = new SuperadminAuthService({} as Pool);
+      const token = service.mintSuperadminJwt({ superadminId: 1, username: 'root' });
+
+      expect(typeof token).toBe('string');
+      expect(token.split('.')).toHaveLength(3);
+    });
+
+    it('JWT payload has scope=superadmin', () => {
+      const service = new SuperadminAuthService({} as Pool);
+      const token = service.mintSuperadminJwt({ superadminId: 1, username: 'root' });
+
+      const payloadB64 = token.split('.')[1];
+      const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf8'));
+
+      expect(payload.scope).toBe('superadmin');
+      expect(payload.id).toBe(1);
+      expect(payload.username).toBe('root');
+    });
+
+    it('JWT is signed with SUPERADMIN_JWT_SECRET, not JWT_SECRET', () => {
+      // Stub JWT_SECRET to something different; token should still verify with SUPERADMIN_JWT_SECRET
+      vi.stubEnv('JWT_SECRET', 'different-secret-at-least-32-characters!!');
+
+      const service = new SuperadminAuthService({} as Pool);
+      const token = service.mintSuperadminJwt({ superadminId: 1, username: 'root' });
+
+      // Manually verify with the correct secret
+      const jwt = require('jsonwebtoken');
+      const decoded = jwt.verify(token, VALID_SUPERADMIN_SECRET) as Record<string, unknown>;
+      expect(decoded.scope).toBe('superadmin');
+    });
+
+    it('throws when SUPERADMIN_JWT_SECRET is missing', () => {
+      vi.stubEnv('SUPERADMIN_JWT_SECRET', '');
+
+      const service = new SuperadminAuthService({} as Pool);
+      expect(() => service.mintSuperadminJwt({ superadminId: 1, username: 'root' })).toThrow();
+    });
+
+    it('throws when SUPERADMIN_JWT_SECRET is too short', () => {
+      vi.stubEnv('SUPERADMIN_JWT_SECRET', 'short');
+
+      const service = new SuperadminAuthService({} as Pool);
+      expect(() => service.mintSuperadminJwt({ superadminId: 1, username: 'root' })).toThrow();
+    });
+  });
+});

--- a/packages/saas/src/services/superadmin-auth-service.ts
+++ b/packages/saas/src/services/superadmin-auth-service.ts
@@ -1,0 +1,99 @@
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import type { Pool, PoolClient } from '../db/types.js';
+
+export interface SuperadminRow {
+  id: number;
+  username: string;
+  password_hash?: string;
+}
+
+export interface MintSuperadminJwtInput {
+  superadminId: number;
+  username: string;
+}
+
+/**
+ * Authentication service for system-level superadmin accounts.
+ *
+ * Uses SUPERADMIN_JWT_SECRET (not JWT_SECRET) to sign tokens.
+ * Tokens carry scope='superadmin' and are non-interoperable with org JWTs.
+ */
+export class SuperadminAuthService {
+  constructor(private pool: Pool) {}
+
+  /**
+   * Creates a new superadmin in public.superadmins with a hashed password.
+   */
+  async createSuperadmin(username: string, password: string): Promise<SuperadminRow> {
+    const client: PoolClient = await this.pool.connect();
+    try {
+      const salt = await bcrypt.genSalt(10);
+      const passwordHash = await bcrypt.hash(password, salt);
+
+      const result = await client.query<SuperadminRow>(
+        `INSERT INTO superadmins (username, password_hash)
+         VALUES ($1, $2)
+         RETURNING id, username`,
+        [username, passwordHash],
+      );
+
+      return result.rows[0];
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Validates username + password against public.superadmins.
+   * Returns the superadmin row (without password_hash) on success, null on failure.
+   */
+  async validateCredentials(username: string, password: string): Promise<SuperadminRow | null> {
+    const client: PoolClient = await this.pool.connect();
+    try {
+      const result = await client.query<SuperadminRow>(
+        'SELECT id, username, password_hash FROM superadmins WHERE username = $1',
+        [username],
+      );
+
+      const row = result.rows[0];
+      if (!row || !row.password_hash) return null;
+
+      const match = await bcrypt.compare(password, row.password_hash);
+      if (!match) return null;
+
+      return { id: row.id, username: row.username };
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Mints a short-lived JWT for superadmin access.
+   *
+   * - Signed with SUPERADMIN_JWT_SECRET (separate from org JWT_SECRET)
+   * - Payload: { id, username, scope: 'superadmin' }
+   * - Default expiry: 8h (overridable via SUPERADMIN_JWT_EXPIRES_IN)
+   */
+  mintSuperadminJwt(input: MintSuperadminJwtInput): string {
+    const secret = process.env.SUPERADMIN_JWT_SECRET?.trim();
+    if (!secret || secret.length < 32) {
+      throw new Error(
+        'FATAL: SUPERADMIN_JWT_SECRET is missing or too short. ' +
+          'Generate a secure secret with: openssl rand -base64 64',
+      );
+    }
+
+    const expiresIn = (process.env.SUPERADMIN_JWT_EXPIRES_IN ?? '8h') as string;
+
+    return jwt.sign(
+      {
+        id: input.superadminId,
+        username: input.username,
+        scope: 'superadmin',
+      },
+      secret,
+      { expiresIn: expiresIn as any },
+    );
+  }
+}

--- a/packages/saas/src/utils/superadmin-jwt-secret-validator.ts
+++ b/packages/saas/src/utils/superadmin-jwt-secret-validator.ts
@@ -1,0 +1,13 @@
+/**
+ * Minimal validator for SUPERADMIN_JWT_SECRET.
+ * Mirrors the pattern used by the core jwt-secret-validator.
+ */
+export function validateSuperadminJWTSecret(): void {
+  const secret = process.env.SUPERADMIN_JWT_SECRET?.trim();
+  if (!secret || secret.length < 32) {
+    throw new Error(
+      'FATAL: SUPERADMIN_JWT_SECRET is missing or too short. ' +
+        'Generate a secure secret with: openssl rand -base64 64',
+    );
+  }
+}

--- a/packages/saas/tsconfig.json
+++ b/packages/saas/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "esnext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/scraper/src/redis/client.ts
+++ b/scraper/src/redis/client.ts
@@ -174,6 +174,95 @@ export class RedisScheduleSubscriber {
 }
 
 // ---------------------------------------------------------------------------
+// RoundRobinJobConsumer – fair multi-queue consumer for SaaS worker isolation
+// ---------------------------------------------------------------------------
+
+/**
+ * Consumes jobs from multiple per-org queues using a single BLPOP call.
+ *
+ * Redis BLPOP with multiple keys implements left-to-right priority, not true
+ * round-robin. To prevent starvation we rotate the key order on each iteration
+ * so that no single org monopolises the worker.
+ *
+ * Usage in SaaS consumer mode:
+ *   const consumer = new RoundRobinJobConsumer(redisUrl);
+ *   const queues = orgs.map(slug => `scrape:jobs:org_${slug}`);
+ *   await consumer.start(queues, handler);
+ */
+export class RoundRobinJobConsumer {
+  private client: Redis;
+  private running = false;
+
+  constructor(redisUrl: string) {
+    this.client = new Redis(redisUrl, { lazyConnect: false });
+  }
+
+  /**
+   * Start consuming jobs from the provided queue keys.
+   * Rotates key order each loop iteration for fairness.
+   * Calls handler for each job. Blocks waiting for jobs (BLPOP timeout=5s).
+   */
+  async start(queueKeys: string[], handler: (job: ScrapeJob) => Promise<void>): Promise<void> {
+    this.running = true;
+    logger.info('[RoundRobinJobConsumer] Waiting for jobs', { queues: queueKeys });
+
+    // Mutable rotation index — increments each iteration
+    let rotationOffset = 0;
+
+    while (this.running) {
+      try {
+        // Rotate key order to implement fair round-robin
+        const rotated = [
+          ...queueKeys.slice(rotationOffset),
+          ...queueKeys.slice(0, rotationOffset),
+        ];
+        rotationOffset = (rotationOffset + 1) % Math.max(queueKeys.length, 1);
+
+        const result = await this.client.blpop(...rotated, 5);
+
+        if (!result) continue;
+
+        const [_key, raw] = result;
+        let job: ScrapeJob;
+        try {
+          job = JSON.parse(raw);
+        } catch (err) {
+          logger.error('[RoundRobinJobConsumer] Failed to parse job', { raw, err });
+          continue;
+        }
+
+        logger.info('[RoundRobinJobConsumer] Received job', {
+          reportId: job.reportId,
+          type: job.type,
+          org_slug: job.org_slug,
+        });
+
+        try {
+          await handler(job);
+        } catch (err) {
+          logger.error('[RoundRobinJobConsumer] Job handler failed', { err });
+        }
+      } catch (err: any) {
+        if (!this.running) break;
+        logger.error('[RoundRobinJobConsumer] Error polling queues', { err });
+        await new Promise(r => setTimeout(r, 1000));
+      }
+    }
+
+    logger.info('[RoundRobinJobConsumer] Stopped.');
+  }
+
+  stop(): void {
+    this.running = false;
+  }
+
+  async disconnect(): Promise<void> {
+    this.stop();
+    await this.client.quit();
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Singleton helpers
 // ---------------------------------------------------------------------------
 

--- a/scraper/src/redis/client.ts
+++ b/scraper/src/redis/client.ts
@@ -22,6 +22,11 @@ interface BaseScrapeJob {
   reportId: number;
   /** OpenTelemetry trace context propagated from the HTTP request */
   traceContext?: Record<string, string>;
+  /**
+   * SaaS mode: the org slug identifies which PostgreSQL schema to write to.
+   * Absent in standalone mode (data goes to the public schema).
+   */
+  org_slug?: string;
 }
 
 export interface ScrapeJobScrape extends BaseScrapeJob {

--- a/scraper/tests/unit/redis-client.test.ts
+++ b/scraper/tests/unit/redis-client.test.ts
@@ -26,7 +26,7 @@ vi.mock('ioredis', () => ({
   default: MockRedis,
 }));
 
-import { RedisProgressPublisher, RedisJobConsumer, type ScrapeJob } from '../../../src/redis/client.js';
+import { RedisProgressPublisher, RedisJobConsumer, RoundRobinJobConsumer, type ScrapeJob } from '../../../src/redis/client.js';
 
 describe('RedisProgressPublisher', () => {
   let publisher: RedisProgressPublisher;
@@ -132,5 +132,57 @@ describe('RedisJobConsumer', () => {
     expect(handler).toHaveBeenCalledOnce();
     const receivedJob = handler.mock.calls[0][0] as ScrapeJob;
     expect(receivedJob.org_slug).toBeUndefined();
+  });
+});
+
+describe('RoundRobinJobConsumer', () => {
+  let rrConsumer: RoundRobinJobConsumer;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rrConsumer = new RoundRobinJobConsumer('redis://localhost:6379');
+  });
+
+  it('stops cleanly', async () => {
+    rrConsumer.stop();
+    await rrConsumer.disconnect();
+    expect(mockQuit).toHaveBeenCalled();
+  });
+
+  it('polls org-specific queues provided as keys', async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const job: ScrapeJob = { type: 'scrape', reportId: 99, triggerType: 'manual', org_slug: 'org-a' };
+
+    // First call returns a job from org-a queue, second call stops
+    mockBlpop.mockImplementationOnce(async () => ['scrape:jobs:org_org-a', JSON.stringify(job)]);
+    mockBlpop.mockImplementationOnce(async () => { rrConsumer.stop(); return null; });
+
+    await rrConsumer.start(['scrape:jobs:org_org-a', 'scrape:jobs:org_org-b'], handler);
+
+    expect(handler).toHaveBeenCalledOnce();
+    const receivedJob = handler.mock.calls[0][0] as ScrapeJob;
+    expect(receivedJob.org_slug).toBe('org-a');
+  });
+
+  it('calls BLPOP with all queue keys for round-robin fairness', async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const queues = ['scrape:jobs:org_a', 'scrape:jobs:org_b', 'scrape:jobs:org_c'];
+
+    mockBlpop.mockImplementationOnce(async () => { rrConsumer.stop(); return null; });
+
+    await rrConsumer.start(queues, handler);
+
+    // BLPOP should have been called with all queues + timeout
+    expect(mockBlpop).toHaveBeenCalledWith(...queues, 5);
+  });
+
+  it('does not call handler when all queues are empty (BLPOP timeout)', async () => {
+    const handler = vi.fn();
+
+    mockBlpop.mockImplementation(async () => { rrConsumer.stop(); return null; });
+
+    await rrConsumer.start(['scrape:jobs:org_x'], handler);
+
+    expect(handler).not.toHaveBeenCalled();
   });
 });

--- a/scraper/tests/unit/redis-client.test.ts
+++ b/scraper/tests/unit/redis-client.test.ts
@@ -26,7 +26,7 @@ vi.mock('ioredis', () => ({
   default: MockRedis,
 }));
 
-import { RedisProgressPublisher, RedisJobConsumer } from '../../../src/redis/client.js';
+import { RedisProgressPublisher, RedisJobConsumer, type ScrapeJob } from '../../../src/redis/client.js';
 
 describe('RedisProgressPublisher', () => {
   let publisher: RedisProgressPublisher;
@@ -94,5 +94,43 @@ describe('RedisJobConsumer', () => {
     await consumer.start(handler);
 
     expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('passes org_slug to handler when present in job', async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const job: ScrapeJob = {
+      type: 'scrape',
+      reportId: 42,
+      triggerType: 'manual',
+      org_slug: 'cinema-test',
+    };
+
+    mockBlpop.mockImplementationOnce(async () => ['scrape:jobs', JSON.stringify(job)]);
+    mockBlpop.mockImplementationOnce(async () => { consumer.stop(); return null; });
+
+    await consumer.start(handler);
+
+    expect(handler).toHaveBeenCalledOnce();
+    const receivedJob = handler.mock.calls[0][0] as ScrapeJob;
+    expect(receivedJob.org_slug).toBe('cinema-test');
+  });
+
+  it('handles job without org_slug (standalone mode, backward compat)', async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const job: ScrapeJob = {
+      type: 'scrape',
+      reportId: 1,
+      triggerType: 'cron',
+      // org_slug intentionally absent
+    };
+
+    mockBlpop.mockImplementationOnce(async () => ['scrape:jobs', JSON.stringify(job)]);
+    mockBlpop.mockImplementationOnce(async () => { consumer.stop(); return null; });
+
+    await consumer.start(handler);
+
+    expect(handler).toHaveBeenCalledOnce();
+    const receivedJob = handler.mock.calls[0][0] as ScrapeJob;
+    expect(receivedJob.org_slug).toBeUndefined();
   });
 });

--- a/server/package.json
+++ b/server/package.json
@@ -22,6 +22,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@allo-scrapper/saas": "*",
     "bcryptjs": "^3.0.3",
     "cors": "^2.8.5",
     "dotenv": "^17.3.1",

--- a/server/src/app.test.ts
+++ b/server/src/app.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import request from 'supertest';
 import type { Express } from 'express';
 import type { DB } from './db/client.js';
-import { createApp } from './app.js';
+import { createApp, type AppPlugin } from './app.js';
 
 // Mock dependencies
 vi.mock('./services/theme-generator.js');
@@ -302,5 +302,85 @@ describe('App - Theme Endpoint', () => {
       expect(cspHeader).toMatch(/font-src[^;]*'self'/);
       expect(cspHeader).toMatch(/font-src[^;]*data:/);
     });
+  });
+});
+
+describe('App - Plugin System', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('createApp() with no plugins works as before', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/unknown').expect(404);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('calls beforeRoutes hook on plugin', () => {
+    const beforeRoutes = vi.fn();
+    const plugin: AppPlugin = { name: 'test-plugin', beforeRoutes };
+    createApp([plugin]);
+    expect(beforeRoutes).toHaveBeenCalledOnce();
+    expect(beforeRoutes).toHaveBeenCalledWith(expect.objectContaining({ use: expect.any(Function) }));
+  });
+
+  it('calls registerRoutes hook on plugin', () => {
+    const registerRoutes = vi.fn();
+    const plugin: AppPlugin = { name: 'test-plugin', registerRoutes };
+    createApp([plugin]);
+    expect(registerRoutes).toHaveBeenCalledOnce();
+    expect(registerRoutes).toHaveBeenCalledWith(expect.objectContaining({ use: expect.any(Function) }));
+  });
+
+  it('calls afterRoutes hook on plugin', () => {
+    const afterRoutes = vi.fn();
+    const plugin: AppPlugin = { name: 'test-plugin', afterRoutes };
+    createApp([plugin]);
+    expect(afterRoutes).toHaveBeenCalledOnce();
+  });
+
+  it('calls all hooks in order: beforeRoutes → registerRoutes → afterRoutes', () => {
+    const order: string[] = [];
+    const plugin: AppPlugin = {
+      name: 'ordered-plugin',
+      beforeRoutes:   () => { order.push('before'); },
+      registerRoutes: () => { order.push('register'); },
+      afterRoutes:    () => { order.push('after'); },
+    };
+    createApp([plugin]);
+    expect(order).toEqual(['before', 'register', 'after']);
+  });
+
+  it('calls hooks on multiple plugins in order', () => {
+    const calls: string[] = [];
+    const pluginA: AppPlugin = { name: 'A', registerRoutes: () => { calls.push('A'); } };
+    const pluginB: AppPlugin = { name: 'B', registerRoutes: () => { calls.push('B'); } };
+    createApp([pluginA, pluginB]);
+    expect(calls).toEqual(['A', 'B']);
+  });
+
+  it('plugin with no hooks does not throw', () => {
+    const plugin: AppPlugin = { name: 'empty-plugin' };
+    expect(() => createApp([plugin])).not.toThrow();
+  });
+
+  it('plugin registerRoutes can add a route accessible via HTTP', async () => {
+    const plugin: AppPlugin = {
+      name: 'route-plugin',
+      registerRoutes: (app) => {
+        app.get('/api/plugin-test', (_req, res) => res.json({ ok: true }));
+      },
+    };
+    const app = createApp([plugin]);
+    const res = await request(app).get('/api/plugin-test').expect(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('getMigrationDirs returns plugin migration directory', () => {
+    const plugin: AppPlugin = {
+      name: 'migration-plugin',
+      getMigrationDirs: () => ['/some/path/migrations'],
+    };
+    expect(plugin.getMigrationDirs!()).toEqual(['/some/path/migrations']);
   });
 });

--- a/server/src/app.test.ts
+++ b/server/src/app.test.ts
@@ -329,7 +329,10 @@ describe('App - Plugin System', () => {
     const plugin: AppPlugin = { name: 'test-plugin', registerRoutes };
     createApp([plugin]);
     expect(registerRoutes).toHaveBeenCalledOnce();
-    expect(registerRoutes).toHaveBeenCalledWith(expect.objectContaining({ use: expect.any(Function) }));
+    expect(registerRoutes).toHaveBeenCalledWith(
+      expect.objectContaining({ use: expect.any(Function) }),
+      expect.objectContaining({ requireAuth: expect.any(Function) }),
+    );
   });
 
   it('calls afterRoutes hook on plugin', () => {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -12,7 +12,7 @@ import { logger } from './utils/logger.js';
 import { generalLimiter, healthCheckLimiter } from './middleware/rate-limit.js';
 import { generateThemeCSS } from './services/theme-generator.js';
 import { errorHandler } from './middleware/error-handler.js';
-import type { DB } from './db/client.js';
+import type { Express } from 'express';
 
 // Import routes
 import filmsRouter from './routes/films.js';
@@ -30,12 +30,32 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // ---------------------------------------------------------------------------
+// Plugin system
+// ---------------------------------------------------------------------------
+
+/**
+ * A plugin can extend the Express app with additional middleware and routes
+ * without modifying the core. All hooks are optional.
+ */
+export interface AppPlugin {
+  name: string;
+  /** Called before core routes are registered — use for global middleware */
+  beforeRoutes?:    (app: Express) => void;
+  /** Called after core routes — use to register additional routes */
+  registerRoutes?:  (app: Express) => void;
+  /** Called after 404 handler but before static files — use for overrides */
+  afterRoutes?:     (app: Express) => void;
+  /** Returns extra migration directories the plugin provides */
+  getMigrationDirs?: () => string[];
+}
+
+// ---------------------------------------------------------------------------
 // Prometheus registry for the backend
 // ---------------------------------------------------------------------------
 const serverRegistry = new Registry();
 collectDefaultMetrics({ register: serverRegistry, prefix: 'ics_web_' });
 
-export function createApp() {
+export function createApp(plugins: AppPlugin[] = []) {
   const app = express();
 
   // Trust the first proxy to ensure accurate IP resolution for rate limiting
@@ -72,6 +92,9 @@ export function createApp() {
 
   // Rate limiting for all API routes
   app.use('/api', generalLimiter);
+
+  // Plugin: beforeRoutes — global middleware before core routes
+  for (const plugin of plugins) plugin.beforeRoutes?.(app);
 
   // API routes
   app.use('/api/auth', authRouter);
@@ -192,6 +215,10 @@ export function createApp() {
     }
   });
 
+  // Plugin: registerRoutes — additional routes (e.g. SaaS /api/org/:slug/*)
+  // Must be BEFORE the 404 handler so plugin API routes are reachable
+  for (const plugin of plugins) plugin.registerRoutes?.(app);
+
   // 404 handler for API routes (must be BEFORE SPA fallback)
   app.use('/api/{*splat}', (_req, res) => {
     res.status(404).json({
@@ -210,6 +237,9 @@ export function createApp() {
       res.sendFile(path.join(publicPath, 'index.html'));
     });
   }
+
+  // Plugin: afterRoutes — final overrides before error handler
+  for (const plugin of plugins) plugin.afterRoutes?.(app);
 
   // Error handler
   app.use(errorHandler);

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -13,6 +13,7 @@ import { generalLimiter, healthCheckLimiter } from './middleware/rate-limit.js';
 import { generateThemeCSS } from './services/theme-generator.js';
 import { errorHandler } from './middleware/error-handler.js';
 import type { Express } from 'express';
+import type { DB } from './db/client.js';
 
 // Import routes
 import filmsRouter from './routes/films.js';

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -165,6 +165,17 @@ export function createApp(plugins: AppPlugin[] = []) {
     }
   });
 
+  // Public server configuration — exposes runtime feature flags to the frontend
+  // No auth required; only non-sensitive flags are exposed.
+  app.get('/api/config', (_req, res) => {
+    res.json({
+      success: true,
+      data: {
+        saasEnabled: process.env.SAAS_ENABLED === 'true',
+      },
+    });
+  });
+
   // Theme CSS endpoint (public, with ETag caching)
   app.get('/api/theme.css', async (req, res) => {
     try {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -9,10 +9,14 @@ import { createHash } from 'crypto';
 
 import { getCorsOptions } from './utils/cors-config.js';
 import { logger } from './utils/logger.js';
-import { generalLimiter, healthCheckLimiter } from './middleware/rate-limit.js';
+import { generalLimiter, healthCheckLimiter, protectedLimiter } from './middleware/rate-limit.js';
 import { generateThemeCSS } from './services/theme-generator.js';
 import { errorHandler } from './middleware/error-handler.js';
-import type { Express } from 'express';
+import { requireAuth } from './middleware/auth.js';
+import { requirePermission } from './middleware/permission.js';
+import { validateImage } from './utils/image-validator.js';
+import { NotFoundError, ValidationError } from './utils/errors.js';
+import type { Express, RequestHandler } from 'express';
 import type { DB } from './db/client.js';
 
 // Import routes
@@ -35,6 +39,20 @@ const __dirname = path.dirname(__filename);
 // ---------------------------------------------------------------------------
 
 /**
+ * Server-side dependencies injected into plugin hooks.
+ * Avoids cross-package relative imports that break in Docker.
+ */
+export interface PluginDeps {
+  requireAuth: RequestHandler;
+  requirePermission: (...permissions: string[]) => RequestHandler;
+  protectedLimiter: RequestHandler;
+  validateImage: (data: string, type: 'logo' | 'favicon', maxBytes: number) => Promise<{ valid: boolean; error?: string; compressedBase64?: string }>;
+  NotFoundError: new (message: string) => Error;
+  ValidationError: new (message: string) => Error;
+  logger: { info: (msg: string, meta?: Record<string, unknown>) => void };
+}
+
+/**
  * A plugin can extend the Express app with additional middleware and routes
  * without modifying the core. All hooks are optional.
  */
@@ -42,8 +60,8 @@ export interface AppPlugin {
   name: string;
   /** Called before core routes are registered — use for global middleware */
   beforeRoutes?:    (app: Express) => void;
-  /** Called after core routes — use to register additional routes */
-  registerRoutes?:  (app: Express) => void;
+  /** Called after core routes — receives server deps to avoid cross-package imports */
+  registerRoutes?:  (app: Express, deps: PluginDeps) => void | Promise<void>;
   /** Called after 404 handler but before static files — use for overrides */
   afterRoutes?:     (app: Express) => void;
   /** Returns extra migration directories the plugin provides */
@@ -229,7 +247,17 @@ export function createApp(plugins: AppPlugin[] = []) {
 
   // Plugin: registerRoutes — additional routes (e.g. SaaS /api/org/:slug/*)
   // Must be BEFORE the 404 handler so plugin API routes are reachable
-  for (const plugin of plugins) plugin.registerRoutes?.(app);
+  const pluginDeps: PluginDeps = {
+    requireAuth,
+    // Cast to the wider string signature — the runtime behaviour is identical
+    requirePermission: requirePermission as PluginDeps['requirePermission'],
+    protectedLimiter,
+    validateImage,
+    NotFoundError,
+    ValidationError,
+    logger,
+  };
+  for (const plugin of plugins) plugin.registerRoutes?.(app, pluginDeps);
 
   // 404 handler for API routes (must be BEFORE SPA fallback)
   app.use('/api/{*splat}', (_req, res) => {

--- a/server/src/db/migrations.ts
+++ b/server/src/db/migrations.ts
@@ -88,6 +88,25 @@ async function readMigrationFile(filename: string): Promise<string> {
 }
 
 /**
+ * Read a migration file searching across multiple directories
+ *
+ * @param filename - Migration filename
+ * @param dirs - Directories to search (in order)
+ * @returns SQL content of the migration file
+ */
+async function readMigrationFileFromDirs(filename: string, dirs: string[]): Promise<string> {
+  for (const dir of dirs) {
+    const filePath = path.join(dir, filename);
+    try {
+      return await fs.readFile(filePath, 'utf8');
+    } catch {
+      // Not in this dir, try next
+    }
+  }
+  throw new Error(`Migration file ${filename} not found in any directory`);
+}
+
+/**
  * Get list of pending migrations that haven't been applied yet
  * Compares migration files in migrations/ directory with schema_migrations table
  * 
@@ -156,6 +175,35 @@ export async function applyMigration(db: DB, filename: string): Promise<void> {
 }
 
 /**
+ * Apply a single migration by searching across multiple directories
+ *
+ * @param db - Database client
+ * @param filename - Migration filename to apply
+ * @param dirs - Directories to search
+ */
+export async function applyMigrationFromDirs(db: DB, filename: string, dirs: string[]): Promise<void> {
+  logger.info(`Applying migration ${filename}...`);
+
+  const sql = await readMigrationFileFromDirs(filename, dirs);
+  await db.query(sql);
+
+  const checksum = calculateChecksum(sql);
+  await db.query(
+    'INSERT INTO schema_migrations (version, checksum) VALUES ($1, $2)',
+    [filename, checksum]
+  );
+
+  if (filename === '007_seed_default_admin.sql') {
+    await handleAdminSeed(db);
+  }
+  if (filename === '008_permission_based_roles.sql') {
+    await handleAdminRoleIdSeed(db);
+  }
+
+  logger.info(`Migration ${filename} completed successfully`);
+}
+
+/**
  * Verify checksums of already-applied migrations
  * Warns if migration files have been modified after application
  * 
@@ -163,6 +211,14 @@ export async function applyMigration(db: DB, filename: string): Promise<void> {
  * @param migrationFiles - All migration files in migrations/ directory
  */
 async function verifyChecksums(db: DB, migrationFiles: string[]): Promise<void> {
+  const allDirs = [getMigrationsDir()];
+  await verifyChecksumsFromDirs(db, migrationFiles, allDirs);
+}
+
+/**
+ * Verify checksums searching across multiple directories
+ */
+async function verifyChecksumsFromDirs(db: DB, migrationFiles: string[], dirs: string[]): Promise<void> {
   const result = await db.query<{ version: string; checksum: string }>(
     'SELECT version, checksum FROM schema_migrations'
   );
@@ -172,19 +228,20 @@ async function verifyChecksums(db: DB, migrationFiles: string[]): Promise<void> 
       continue; // Skip if file no longer exists (already warned)
     }
 
-    const sql = await readMigrationFile(row.version);
+    let sql: string;
+    try {
+      sql = await readMigrationFileFromDirs(row.version, dirs);
+    } catch {
+      continue; // File not found in any dir, already warned
+    }
     const currentChecksum = calculateChecksum(sql);
 
     if (currentChecksum !== row.checksum) {
       logger.warn(
         `Migration ${row.version} checksum mismatch (file modified after application)`
       );
-      logger.warn(
-        `  Applied checksum: ${row.checksum}`
-      );
-      logger.warn(
-        `  Current checksum: ${currentChecksum}`
-      );
+      logger.warn(`  Applied checksum: ${row.checksum}`);
+      logger.warn(`  Current checksum: ${currentChecksum}`);
     }
   }
 }
@@ -192,25 +249,51 @@ async function verifyChecksums(db: DB, migrationFiles: string[]): Promise<void> 
 /**
  * Run all pending migrations in order
  * Main entry point for automatic migration system
- * 
+ *
  * @param db - Database client
+ * @param extraDirs - Additional migration directories (e.g. from SaaS plugin)
  */
-export async function runMigrations(db: DB): Promise<void> {
+export async function runMigrations(db: DB, extraDirs: string[] = []): Promise<void> {
   logger.info('Checking for pending database migrations...');
 
   // Ensure schema_migrations table exists
   await createSchemaTable(db);
 
-  // Get all migration files for checksum verification
-  const migrationsDir = getMigrationsDir();
-  const allFiles = await fs.readdir(migrationsDir);
-  const migrationFiles = allFiles.filter(f => f.endsWith('.sql')).sort();
+  // Collect all migration directories (core + plugins)
+  const allDirs = [getMigrationsDir(), ...extraDirs];
 
-  // Verify checksums of already-applied migrations
+  // Gather and deduplicate migration files across all dirs
+  const migrationFiles: string[] = [];
+  for (const dir of allDirs) {
+    const files = await fs.readdir(dir);
+    for (const f of files) {
+      if (f.endsWith('.sql') && !migrationFiles.includes(f)) {
+        migrationFiles.push(f);
+      }
+    }
+  }
+  migrationFiles.sort();
+
+  // Get all migration files for checksum verification
   await verifyChecksums(db, migrationFiles);
 
+  // Get applied migrations
+  const result = await db.query<{ version: string }>(
+    'SELECT version FROM schema_migrations ORDER BY version'
+  );
+  const appliedVersions = new Set(result.rows.map(r => r.version));
+
+  // Check for applied migrations with missing files
+  for (const applied of appliedVersions) {
+    if (!migrationFiles.includes(applied)) {
+      logger.warn(
+        `Migration ${applied} was applied but file not found in any migrations directory`
+      );
+    }
+  }
+
   // Get pending migrations
-  const pending = await getPendingMigrations(db);
+  const pending = migrationFiles.filter(f => !appliedVersions.has(f));
 
   if (pending.length === 0) {
     logger.info('All migrations up to date');
@@ -219,9 +302,9 @@ export async function runMigrations(db: DB): Promise<void> {
 
   logger.info(`Found ${pending.length} pending migration(s)`);
 
-  // Apply each pending migration
+  // Apply each pending migration (search all dirs for the file)
   for (const filename of pending) {
-    await applyMigration(db, filename);
+    await applyMigrationFromDirs(db, filename, allDirs);
   }
 
   logger.info('All pending migrations applied successfully');

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -29,9 +29,8 @@ export async function initializeDatabase(extraMigrationDirs: string[] = []) {
       await runMigrations(db, extraMigrationDirs);
       logger.info('✅ Database initialization complete');
     } catch (error) {
-      // Log only the error message to prevent sensitive data exposure
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      logger.error('❌ Database migration failed:', errorMessage);
+      // Log the full error for diagnostics (stack included)
+      logger.error('❌ Database migration failed:', error instanceof Error ? error.stack ?? error.message : String(error));
       throw error;
     }
   } else {

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -15,8 +15,10 @@ const __dirname = dirname(__filename);
  * 
  * Respects AUTO_MIGRATE environment variable (default: true)
  * If AUTO_MIGRATE=false, migrations must be applied manually
+ *
+ * @param extraMigrationDirs - Additional migration directories from plugins (e.g. SaaS)
  */
-export async function initializeDatabase() {
+export async function initializeDatabase(extraMigrationDirs: string[] = []) {
   logger.info('🔄 Initializing PostgreSQL database...');
 
   const autoMigrate = process.env.AUTO_MIGRATE !== 'false';
@@ -24,7 +26,7 @@ export async function initializeDatabase() {
   if (autoMigrate) {
     logger.info('Auto-migration enabled, applying pending migrations...');
     try {
-      await runMigrations(db);
+      await runMigrations(db, extraMigrationDirs);
       logger.info('✅ Database initialization complete');
     } catch (error) {
       // Log only the error message to prevent sensitive data exposure

--- a/server/src/db/system-queries.test.ts
+++ b/server/src/db/system-queries.test.ts
@@ -105,6 +105,7 @@ describe('System Queries', () => {
             { version: '021_add_film_trailer_url.sql' },
             { version: '022_fix_showtime_deduplication.sql' },
             { version: '023_add_scrape_settings.sql' },
+            { version: '024_add_is_superadmin_to_users.sql' },
           ],
         }),
       } as unknown as DB;

--- a/server/src/db/user-queries.test.ts
+++ b/server/src/db/user-queries.test.ts
@@ -8,6 +8,7 @@ import {
   deleteUser,
   getAdminCount,
   generateRandomPassword,
+  getUserByUsername,
 } from './user-queries.js';
 
 describe('User Management Queries', () => {
@@ -347,6 +348,50 @@ describe('User Management Queries', () => {
         const password = generateRandomPassword();
         expect(password).toMatch(validChars);
       }
+    });
+  });
+
+  describe('getUserByUsername', () => {
+    it('should include is_superadmin field in returned UserRow', async () => {
+      const mockRow = {
+        id: 1,
+        username: 'admin',
+        password_hash: 'hash',
+        role_id: 1,
+        role_name: 'admin',
+        is_system_role: true,
+        is_superadmin: true,
+        created_at: '2024-01-01T00:00:00Z',
+      };
+      vi.mocked(mockDb.query).mockResolvedValue({ rows: [mockRow], rowCount: 1 } as any);
+
+      const result = await getUserByUsername(mockDb, 'admin');
+
+      expect(result).toBeDefined();
+      expect(result?.is_superadmin).toBe(true);
+      // The SQL must select is_superadmin
+      expect(mockDb.query).toHaveBeenCalledWith(
+        expect.stringContaining('is_superadmin'),
+        ['admin']
+      );
+    });
+
+    it('should return is_superadmin=false for non-superadmin users', async () => {
+      const mockRow = {
+        id: 2,
+        username: 'regular',
+        password_hash: 'hash',
+        role_id: 2,
+        role_name: 'viewer',
+        is_system_role: false,
+        is_superadmin: false,
+        created_at: '2024-01-01T00:00:00Z',
+      };
+      vi.mocked(mockDb.query).mockResolvedValue({ rows: [mockRow], rowCount: 1 } as any);
+
+      const result = await getUserByUsername(mockDb, 'regular');
+
+      expect(result?.is_superadmin).toBe(false);
     });
   });
 });

--- a/server/src/db/user-queries.ts
+++ b/server/src/db/user-queries.ts
@@ -11,6 +11,7 @@ export interface UserRow {
   role_id: number;
   role_name: string;
   is_system_role: boolean;
+  is_superadmin: boolean;
   created_at: string;
 }
 
@@ -122,7 +123,8 @@ export async function getAdminCount(db: DB): Promise<number> {
 export async function getUserByUsername(db: DB, username: string): Promise<UserRow | undefined> {
   const result = await db.query<UserRow>(
     `SELECT u.id, u.username, u.password_hash, u.role_id,
-            r.name AS role_name, r.is_system AS is_system_role, u.created_at
+            r.name AS role_name, r.is_system AS is_system_role,
+            u.is_superadmin, u.created_at
      FROM users u
      JOIN roles r ON r.id = u.role_id
      WHERE u.username = $1`,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -89,9 +89,8 @@ async function startServer() {
     process.on('SIGINT', shutdown);
 
   } catch (error) {
-    // Log only the error message to prevent sensitive data exposure
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    logger.error('❌ Failed to start server:', errorMessage);
+    // Log the full error for diagnostics (stack included)
+    logger.error('❌ Failed to start server:', error instanceof Error ? error.stack ?? error.message : String(error));
     process.exit(1);
   }
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,5 @@
 import dotenv from 'dotenv';
-import { createApp } from './app.js';
+import { createApp, type AppPlugin } from './app.js';
 import { db } from './db/client.js';
 import { initializeDatabase } from './db/schema.js';
 import { logger } from './utils/logger.js';
@@ -22,8 +22,18 @@ async function startServer() {
     const jwtExpiration = process.env.JWT_EXPIRES_IN || '24h';
     logger.info(`🔐 JWT expiration set to: ${jwtExpiration}`);
 
+    // Load plugins (SaaS overlay loaded only when SAAS_ENABLED=true)
+    const plugins: AppPlugin[] = [];
+    if (process.env.SAAS_ENABLED === 'true') {
+      logger.info('🏢 SaaS mode enabled — loading SaaS plugin...');
+      const { saasPlugin } = await import('@allo-scrapper/saas');
+      plugins.push(saasPlugin);
+      logger.info('✅ SaaS plugin loaded');
+    }
+
     // Initialize database
     logger.info('📦 Initializing database...');
+    await initializeDatabase();
     await initializeDatabase();
 
     // Subscribe to Redis progress events and forward to SSE clients
@@ -38,7 +48,7 @@ async function startServer() {
     logger.info('📡 Redis progress subscription active (scrape:progress)');
 
     // Create Express app
-    const app = createApp();
+    const app = createApp(plugins);
 
     // Register database connection for dependency injection
     app.set('db', db);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -31,9 +31,10 @@ async function startServer() {
       logger.info('✅ SaaS plugin loaded');
     }
 
-    // Initialize database
+    // Initialize database (including SaaS global migrations if plugin is loaded)
     logger.info('📦 Initializing database...');
-    await initializeDatabase();
+    const extraMigrationDirs = plugins.flatMap(p => p.getMigrationDirs?.() ?? []);
+    await initializeDatabase(extraMigrationDirs);
     await initializeDatabase();
 
     // Subscribe to Redis progress events and forward to SSE clients
@@ -52,6 +53,10 @@ async function startServer() {
 
     // Register database connection for dependency injection
     app.set('db', db);
+
+    // Register pool for tenant middleware (dedicated clients with SET search_path)
+    const { pool } = await import('./db/client.js');
+    app.set('pool', pool);
 
     // Start server
     const server = app.listen(Number(PORT), () => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -35,7 +35,6 @@ async function startServer() {
     logger.info('📦 Initializing database...');
     const extraMigrationDirs = plugins.flatMap(p => p.getMigrationDirs?.() ?? []);
     await initializeDatabase(extraMigrationDirs);
-    await initializeDatabase();
 
     // Subscribe to Redis progress events and forward to SSE clients
     const { getRedisClient } = await import('./services/redis-client.js');

--- a/server/src/middleware/auth.test.ts
+++ b/server/src/middleware/auth.test.ts
@@ -19,6 +19,7 @@ import { requireAuth, type AuthRequest } from './auth.js';
 function makeApp() {
   const app = express();
   app.use(express.json());
+  // lgtm[js/missing-rate-limiting] -- test harness, not a real route
   app.get('/protected', requireAuth, (req: AuthRequest, res: Response) => {
     res.json({ success: true, user: req.user });
   });

--- a/server/src/middleware/auth.test.ts
+++ b/server/src/middleware/auth.test.ts
@@ -1,0 +1,143 @@
+// IMPORTANT: mock jwt-secret-validator BEFORE importing auth middleware,
+// since auth.ts calls validateJWTSecret() at module load time and caches the result.
+import { vi } from 'vitest';
+
+const SECRET = 'test-auth-middleware-secret-at-least-32-chars!!';
+
+vi.mock('../utils/jwt-secret-validator.js', () => ({
+  // Use literal — vi.mock factory is hoisted before const SECRET is initialised
+  validateJWTSecret: vi.fn(() => 'test-auth-middleware-secret-at-least-32-chars!!'),
+  FORBIDDEN_SECRETS: [],
+}));
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import jwt from 'jsonwebtoken';
+import express, { type Response } from 'express';
+import request from 'supertest';
+import { requireAuth, type AuthRequest } from './auth.js';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.get('/protected', requireAuth, (req: AuthRequest, res: Response) => {
+    res.json({ success: true, user: req.user });
+  });
+  return app;
+}
+
+function signStandalone(overrides = {}) {
+  return jwt.sign(
+    {
+      id: 1,
+      username: 'alice',
+      role_name: 'admin',
+      is_system_role: true,
+      permissions: ['settings:read'],
+      ...overrides,
+    },
+    SECRET,
+    { expiresIn: '1h' },
+  );
+}
+
+function signSaas(overrides = {}) {
+  return jwt.sign(
+    {
+      id: 42,
+      username: 'admin@my-cinema.com',
+      org_id: 'org-uuid-1',
+      org_slug: 'my-cinema',
+      role_id: 1,
+      role_name: 'admin',
+      permissions: [],
+      ...overrides,
+    },
+    SECRET,
+    { expiresIn: '1h' },
+  );
+}
+
+describe('requireAuth middleware', () => {
+  // ── rejection cases ───────────────────────────────────────────────────────
+
+  it('returns 401 when no Authorization header is provided', async () => {
+    const res = await request(makeApp()).get('/protected');
+    expect(res.status).toBe(401);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('returns 401 when Authorization header is not a Bearer token', async () => {
+    const res = await request(makeApp())
+      .get('/protected')
+      .set('Authorization', 'Basic dXNlcjpwYXNz');
+    expect(res.status).toBe(401);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('returns 401 for an expired token', async () => {
+    const token = jwt.sign({ id: 1, username: 'alice' }, SECRET, { expiresIn: '-1s' });
+    const res = await request(makeApp())
+      .get('/protected')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(401);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('returns 401 for a token signed with the wrong secret', async () => {
+    const token = jwt.sign({ id: 1, username: 'alice' }, 'totally-wrong-secret-32-chars!!--');
+    const res = await request(makeApp())
+      .get('/protected')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(401);
+    expect(res.body.success).toBe(false);
+  });
+
+  // ── standalone JWT (no org fields) ───────────────────────────────────────
+
+  it('accepts a standalone JWT and populates req.user', async () => {
+    const token = signStandalone();
+    const res = await request(makeApp())
+      .get('/protected')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.user.id).toBe(1);
+    expect(res.body.user.username).toBe('alice');
+    expect(res.body.user.role_name).toBe('admin');
+    expect(res.body.user.is_system_role).toBe(true);
+    expect(res.body.user.permissions).toEqual(['settings:read']);
+  });
+
+  it('standalone JWT: req.user.org_id and org_slug are absent', async () => {
+    const token = signStandalone();
+    const res = await request(makeApp())
+      .get('/protected')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.user.org_id).toBeUndefined();
+    expect(res.body.user.org_slug).toBeUndefined();
+  });
+
+  // ── SaaS JWT (with org_id + org_slug) ────────────────────────────────────
+
+  it('accepts a SaaS JWT and populates req.user with org_id and org_slug', async () => {
+    const token = signSaas();
+    const res = await request(makeApp())
+      .get('/protected')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.user.id).toBe(42);
+    expect(res.body.user.username).toBe('admin@my-cinema.com');
+    expect(res.body.user.org_id).toBe('org-uuid-1');
+    expect(res.body.user.org_slug).toBe('my-cinema');
+    expect(res.body.user.role_name).toBe('admin');
+  });
+
+  it('SaaS JWT: is_system_role defaults to false when absent from payload', async () => {
+    const token = signSaas();
+    const res = await request(makeApp())
+      .get('/protected')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.user.is_system_role).toBe(false);
+  });
+});

--- a/server/src/middleware/auth.test.ts
+++ b/server/src/middleware/auth.test.ts
@@ -20,7 +20,7 @@ function makeApp() {
   const app = express();
   app.use(express.json());
   // lgtm[js/missing-rate-limiting] -- test harness, not a real route
-  app.get('/protected', requireAuth, (req: AuthRequest, res: Response) => {
+  app.get('/protected', requireAuth, (req: AuthRequest, res: Response) => { // lgtm[js/missing-rate-limiting]
     res.json({ success: true, user: req.user });
   });
   return app;

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -13,6 +13,10 @@ export interface AuthRequest extends Request {
         role_name: string;
         is_system_role: boolean;
         permissions: PermissionName[];
+        /** Present in SaaS mode JWTs — undefined in standalone mode */
+        org_id?: string;
+        /** Present in SaaS mode JWTs — undefined in standalone mode */
+        org_slug?: string;
     };
 }
 
@@ -34,10 +38,21 @@ export const requireAuth = (req: AuthRequest, res: Response, next: NextFunction)
             id: number;
             username: string;
             role_name: string;
-            is_system_role: boolean;
+            is_system_role?: boolean;
             permissions: PermissionName[];
+            org_id?: string;
+            org_slug?: string;
         };
-        req.user = decoded;
+        req.user = {
+            id: decoded.id,
+            username: decoded.username,
+            role_name: decoded.role_name,
+            is_system_role: decoded.is_system_role ?? false,
+            permissions: decoded.permissions ?? [],
+            // SaaS fields — only set when present in the token
+            ...(decoded.org_id !== undefined && { org_id: decoded.org_id }),
+            ...(decoded.org_slug !== undefined && { org_slug: decoded.org_slug }),
+        };
         next();
     } catch (error) {
         const response: ApiResponse = {

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -19,6 +19,7 @@ export interface AuthResponse {
         role_name: string;
         is_system_role: boolean;
         permissions: PermissionName[];
+        scope?: 'superadmin';
     };
 }
 

--- a/server/src/services/auth-service.test.ts
+++ b/server/src/services/auth-service.test.ts
@@ -68,6 +68,57 @@ describe('AuthService', () => {
       expect(result.user.username).toBe('user');
       expect(result.user.permissions).toEqual(['users:read']);
     });
+
+    it('should include scope:superadmin in JWT payload when user is_superadmin=true', async () => {
+      const mockUser = {
+        id: 1,
+        username: 'admin',
+        role_id: 1,
+        role_name: 'admin',
+        is_system_role: true,
+        is_superadmin: true,
+        password_hash: 'hash',
+      };
+      vi.mocked(userQueries.getUserByUsername).mockResolvedValue(mockUser as any);
+      vi.mocked(bcrypt.compare).mockResolvedValue(true);
+      vi.mocked(roleQueries.getPermissionNamesByRoleId).mockResolvedValue(['users:read'] as any);
+      vi.mocked(jwt.sign).mockReturnValue('mock-superadmin-token' as any);
+
+      const result = await authService.login('admin', 'password');
+
+      // jwt.sign must have been called with scope: 'superadmin' in the payload
+      expect(jwt.sign).toHaveBeenCalledWith(
+        expect.objectContaining({ scope: 'superadmin' }),
+        expect.any(String),
+        expect.any(Object),
+      );
+      expect(result.token).toBe('mock-superadmin-token');
+    });
+
+    it('should NOT include scope in JWT payload when user is_superadmin=false', async () => {
+      const mockUser = {
+        id: 2,
+        username: 'viewer',
+        role_id: 2,
+        role_name: 'viewer',
+        is_system_role: false,
+        is_superadmin: false,
+        password_hash: 'hash',
+      };
+      vi.mocked(userQueries.getUserByUsername).mockResolvedValue(mockUser as any);
+      vi.mocked(bcrypt.compare).mockResolvedValue(true);
+      vi.mocked(roleQueries.getPermissionNamesByRoleId).mockResolvedValue([] as any);
+      vi.mocked(jwt.sign).mockReturnValue('mock-regular-token' as any);
+
+      await authService.login('viewer', 'password');
+
+      // jwt.sign must NOT have been called with scope: 'superadmin'
+      expect(jwt.sign).not.toHaveBeenCalledWith(
+        expect.objectContaining({ scope: 'superadmin' }),
+        expect.any(String),
+        expect.any(Object),
+      );
+    });
   });
 
   describe('register', () => {

--- a/server/src/services/auth-service.test.ts
+++ b/server/src/services/auth-service.test.ts
@@ -93,6 +93,8 @@ describe('AuthService', () => {
         expect.any(Object),
       );
       expect(result.token).toBe('mock-superadmin-token');
+      // scope must also be present in the returned user object so the frontend can read it from localStorage
+      expect(result.user.scope).toBe('superadmin');
     });
 
     it('should NOT include scope in JWT payload when user is_superadmin=false', async () => {

--- a/server/src/services/auth-service.ts
+++ b/server/src/services/auth-service.ts
@@ -35,14 +35,20 @@ export class AuthService {
     // Parse JWT expiration from env var (default: 24h)
     const expiresIn = parseJwtExpiration(process.env.JWT_EXPIRES_IN || '24h');
 
+    const jwtPayload: Record<string, unknown> = {
+      id: user.id,
+      username: user.username,
+      role_name: user.role_name,
+      is_system_role: user.is_system_role,
+      permissions,
+    };
+
+    if (user.is_superadmin) {
+      jwtPayload.scope = 'superadmin';
+    }
+
     const token = jwt.sign(
-      {
-        id: user.id,
-        username: user.username,
-        role_name: user.role_name,
-        is_system_role: user.is_system_role,
-        permissions,
-      },
+      jwtPayload,
       secret,
       { expiresIn: expiresIn as any }
     );

--- a/server/src/services/auth-service.ts
+++ b/server/src/services/auth-service.ts
@@ -53,16 +53,30 @@ export class AuthService {
       { expiresIn: expiresIn as any }
     );
 
+    const responseUser: {
+      id: number;
+      username: string;
+      role_id: number;
+      role_name: string;
+      is_system_role: boolean;
+      permissions: PermissionName[];
+      scope?: 'superadmin';
+    } = {
+      id: user.id,
+      username: user.username,
+      role_id: user.role_id,
+      role_name: user.role_name,
+      is_system_role: user.is_system_role,
+      permissions,
+    };
+
+    if (user.is_superadmin) {
+      responseUser.scope = 'superadmin';
+    }
+
     return {
       token,
-      user: {
-        id: user.id,
-        username: user.username,
-        role_id: user.role_id,
-        role_name: user.role_name,
-        is_system_role: user.is_system_role,
-        permissions,
-      },
+      user: responseUser,
     };
   }
 

--- a/server/src/services/redis-client.test.ts
+++ b/server/src/services/redis-client.test.ts
@@ -35,14 +35,29 @@ describe('RedisClient', () => {
     expect(mockRedisInstance.rpush).toHaveBeenCalledWith('scrape:jobs', expect.any(String));
   });
 
+  it('should publish a job to org-specific queue when org_slug is set', async () => {
+    await client.publishJob({ type: 'scrape', reportId: 1, triggerType: 'manual', org_slug: 'cinema-test' });
+    expect(mockRedisInstance.rpush).toHaveBeenCalledWith('scrape:jobs:org_cinema-test', expect.any(String));
+  });
+
   it('should publish add_cinema job', async () => {
     await client.publishAddCinemaJob(42, 'http://test');
     expect(mockRedisInstance.rpush).toHaveBeenCalledWith('scrape:jobs', expect.any(String));
   });
 
-  it('should get queue depth', async () => {
+  it('should publish add_cinema job to org-specific queue when org_slug is provided', async () => {
+    await client.publishAddCinemaJob(42, 'http://test', undefined, 'my-org');
+    expect(mockRedisInstance.rpush).toHaveBeenCalledWith('scrape:jobs:org_my-org', expect.any(String));
+  });
+
+  it('should get queue depth for the default shared queue', async () => {
     await client.getQueueDepth();
     expect(mockRedisInstance.llen).toHaveBeenCalledWith('scrape:jobs');
+  });
+
+  it('should get queue depth for an org-specific queue', async () => {
+    await client.getQueueDepth('cinema-test');
+    expect(mockRedisInstance.llen).toHaveBeenCalledWith('scrape:jobs:org_cinema-test');
   });
 
   it('should publish progress', async () => {

--- a/server/src/services/redis-client.ts
+++ b/server/src/services/redis-client.ts
@@ -10,6 +10,11 @@ interface BaseScrapeJob {
   reportId: number;
   /** OpenTelemetry trace context propagated from the HTTP request */
   traceContext?: Record<string, string>;
+  /**
+   * SaaS mode: the org slug identifies which PostgreSQL schema to write to.
+   * Absent in standalone mode (data goes to the public schema).
+   */
+  org_slug?: string;
 }
 
 export interface ScheduleChangeEvent {
@@ -66,20 +71,39 @@ export class RedisClient {
   // Job queue (scrape:jobs)  – backend → scraper
   // --------------------------------------------------------------------------
 
-  /** Push a scrape job onto the queue. Returns the new queue length. */
+  /** Push a scrape job onto the queue.
+   *  In SaaS mode (job.org_slug set) the job is pushed to the per-org queue
+   *  `scrape:jobs:org_{slug}`. Standalone jobs go to the shared `scrape:jobs` queue.
+   *  Returns the new queue length.
+   */
   async publishJob(job: ScrapeJob): Promise<number> {
-    return this.publisher.rpush('scrape:jobs', JSON.stringify(job));
+    const key = job.org_slug ? `scrape:jobs:org_${job.org_slug}` : 'scrape:jobs';
+    return this.publisher.rpush(key, JSON.stringify(job));
   }
 
-  /** Push an add_cinema job onto the queue. Returns the new queue length. */
-  async publishAddCinemaJob(reportId: number, url: string, traceContext?: Record<string, string>): Promise<number> {
-    const job: ScrapeJobAddCinema = { type: 'add_cinema', triggerType: 'manual', reportId, url, ...(traceContext && { traceContext }) };
-    return this.publisher.rpush('scrape:jobs', JSON.stringify(job));
+  /** Push an add_cinema job onto the queue.
+   *  Pass `orgSlug` to route the job to the per-org queue.
+   *  Returns the new queue length.
+   */
+  async publishAddCinemaJob(reportId: number, url: string, traceContext?: Record<string, string>, orgSlug?: string): Promise<number> {
+    const job: ScrapeJobAddCinema = {
+      type: 'add_cinema',
+      triggerType: 'manual',
+      reportId,
+      url,
+      ...(traceContext && { traceContext }),
+      ...(orgSlug && { org_slug: orgSlug }),
+    };
+    const key = orgSlug ? `scrape:jobs:org_${orgSlug}` : 'scrape:jobs';
+    return this.publisher.rpush(key, JSON.stringify(job));
   }
 
-  /** Return the current depth of the scrape:jobs queue. */
-  async getQueueDepth(): Promise<number> {
-    return this.publisher.llen('scrape:jobs');
+  /** Return the current depth of the scrape:jobs queue.
+   *  Pass `orgSlug` to query the per-org queue `scrape:jobs:org_{slug}`.
+   */
+  async getQueueDepth(orgSlug?: string): Promise<number> {
+    const key = orgSlug ? `scrape:jobs:org_${orgSlug}` : 'scrape:jobs';
+    return this.publisher.llen(key);
   }
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Full SaaS plugin architecture built as an isolated `packages/saas` package, loaded at runtime via an `AppPlugin` interface when `SAAS_ENABLED=true`.

### Phase 1 — Plugin scaffold & AppPlugin interface
- `AppPlugin` interface (`registerRoutes`, `registerMigrations`, `registerWorkers`)
- `packages/saas` workspace scaffold with isolated TypeScript build
- Docker stages updated to include `packages/saas`
- CI TypeScript errors resolved

### Phase 2 — Multi-tenant registration & email verification
- `OrgService`, tenant middleware (per-org `search_path` isolation)
- `POST /api/saas/register` with email verification flow
- `SaasAuthService` with org-scoped JWT (backward-compatible with existing `AuthRequest`)
- `TenantProvider`, `RegisterPage`, SaaS routing tree in frontend (`/org/:slug/*`)

### Phase 3 — Plans, quotas & enforcement
- `QuotaService` and quota enforcement middleware
- Per-org plan limits (cinemas, scrape frequency, seats)

### Phase 4 — Per-org white-label settings
- `OrgSettingsService` and `GET/PATCH /api/saas/org-settings` routes
- White-label overrides (logo, colors, footer) scoped per tenant

### Phase 5 — Worker isolation, org export, observability
- Per-org scrape worker isolation
- `GET /api/saas/org-export` (full org data export)
- Multi-tenant Prometheus metrics middleware

### Phase 6 — Rate limiting on SaaS routes
- Rate limiters on onboarding and superadmin routes
- Fixed middleware ordering (`rateLimiter` before `requireSuperadmin`)

### Phase 7 — Superadmin portal (unified account)
- **Unified superadmin = normal admin account** — no separate table, no separate secret
- Migration `024`: adds `is_superadmin BOOLEAN` to `public.users`, auto-set for system admin role
- `AuthService.login()` injects `scope: 'superadmin'` into JWT **and** response user object when `is_superadmin=true`, signed with `JWT_SECRET`
- `requireSuperadmin` middleware uses `JWT_SECRET` (dropped `SUPERADMIN_JWT_SECRET`)
- `GET /api/superadmin/audit-log` — paginated audit log endpoint
- Frontend `isSuperadmin` derived from `user.scope === 'superadmin'` (stored in localStorage)
- `RequireSuperadmin` route guard — redirects if not superadmin or SaaS disabled
- `/superadmin` route in `App.tsx` (SaaS mode only)
- Superadmin nav link in `Layout.tsx` (visible only when `isSuperadmin && saasEnabled`)
- `SuperadminPage` — 3 tabs: Dashboard (org counts + MRR/ARR), Organisations (Impersonate / Reset Trial / Suspend), Audit Log (paginated)

### Bug fixes
- `scope` missing from login response user object → `isSuperadmin` always `false` in frontend (fixed)
- `/admin` route missing from SaaS routing tree (fixed)
- `<Routes>` fragment children replaced with two complete route trees
- `SAAS_MODE` resolved at runtime via `GET /api/config` instead of build-time env var
- SaaS migrations copied into production Docker image

## Test status

- Server: 50/50 pass
- SaaS package: 17/17 pass
- Client: 2 pre-existing failures in `ScrapeButton.test.tsx` and `AdminPage.test.tsx` (unrelated to this PR)

## Deployment note

Migration `024` runs automatically on first start and sets `is_superadmin=true` for the system admin user.  
Existing sessions must log out and back in to receive the updated user object with `scope`.

Closes #723