### PR TITLE
⚡ Bolt: Eliminate N+1 bottleneck in getAllRoles

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,6 @@
 ## 2026-03-31 - [Optimize Array Presence Checks and Counts in Node]
 **Learning:** Found that grouping an array and simultaneously computing summary counts using multiple `.filter(a => a.status === '...').length` creates unnecessary intermediate arrays and scales poorly to $O(M \times N)$ operations, increasing garbage collection and execution time on large datasets like scrape attempts.
 **Action:** Replace multiple `.filter().length` passes with variables that are incremented during an existing grouping or iteration loop, computing both grouping and statistics in a single $O(N)$ pass.
+## 2024-04-01 - Eliminate N+1 Bottleneck in `getAllRoles`
+**Learning:** `Promise.all` combined with multiple parallel `.map` DB query fetches is a persistent N+1 anti-pattern in database abstraction layers. While asynchronous, this still saturates connection pools and creates unnecessary linear DB requests, adding significant overhead when fetching lists (e.g. roles and their associated permissions).
+**Action:** Replace `Promise.all` loops with a single secondary query using `ANY($1)` on an array of parent IDs, then group the related child records in memory using standard objects/Maps.

--- a/server/src/db/role-queries.test.ts
+++ b/server/src/db/role-queries.test.ts
@@ -34,21 +34,20 @@ describe('Role & Permission Queries', () => {
         { id: 1, name: 'admin', description: 'Administrateur', is_system: true, created_at: '2024-01-01T00:00:00Z' },
         { id: 2, name: 'operator', description: 'Opérateur', is_system: true, created_at: '2024-01-01T00:00:00Z' },
       ];
-      const mockPermissionsForAdmin: Permission[] = [];
-      const mockPermissionsForOperator: Permission[] = [
-        { id: 1, name: 'scraper:trigger', description: 'Lancer un scrape global', category: 'scraper', created_at: '2024-01-01T00:00:00Z' },
+
+      const mockPermissionsResult = [
+        { role_id: 2, id: 1, name: 'scraper:trigger', description: 'Lancer un scrape global', category: 'scraper', created_at: '2024-01-01T00:00:00Z' },
       ];
 
       vi.mocked(mockDb.query)
         .mockResolvedValueOnce({ rows: mockRoles, rowCount: 2 } as any)
-        .mockResolvedValueOnce({ rows: mockPermissionsForAdmin, rowCount: 0 } as any)
-        .mockResolvedValueOnce({ rows: mockPermissionsForOperator, rowCount: 1 } as any);
+        .mockResolvedValueOnce({ rows: mockPermissionsResult, rowCount: 1 } as any);
 
       const result = await getAllRoles(mockDb);
 
       expect(result).toHaveLength(2);
       expect(result[0]).toMatchObject({ id: 1, name: 'admin', permissions: [] });
-      expect(result[1]).toMatchObject({ id: 2, name: 'operator', permissions: mockPermissionsForOperator });
+      expect(result[1]).toMatchObject({ id: 2, name: 'operator', permissions: [{ id: 1, name: 'scraper:trigger', description: 'Lancer un scrape global', category: 'scraper', created_at: '2024-01-01T00:00:00Z' }] });
     });
 
     it('should return empty array when no roles exist', async () => {

--- a/server/src/db/role-queries.ts
+++ b/server/src/db/role-queries.ts
@@ -29,15 +29,32 @@ export async function getAllRoles(db: DB): Promise<RoleWithPermissions[]> {
     return [];
   }
 
-  // ⚡ PERFORMANCE: Run independent DB queries concurrently to prevent N+1 bottleneck
-  const rolesWithPermissions = await Promise.all(
-    rolesResult.rows.map(async (role) => {
-      const permissions = await fetchPermissionsForRole(db, role.id);
-      return { ...role, permissions };
-    })
+  // ⚡ PERFORMANCE: Eliminate N+1 query bottleneck by fetching related records
+  // in a single secondary query using ANY($1), then grouping them in-memory
+  const roleIds = rolesResult.rows.map(r => r.id);
+  const permissionsResult = await db.query(
+    `SELECT rp.role_id, p.id, p.name, p.description, p.category, p.created_at
+     FROM permissions p
+     JOIN role_permissions rp ON rp.permission_id = p.id
+     WHERE rp.role_id = ANY($1)
+     ORDER BY p.category, p.name`,
+    [roleIds]
   );
 
-  return rolesWithPermissions;
+  const permissionsByRole = Object.create(null);
+  for (let i = 0; i < permissionsResult.rows.length; i++) {
+    const row = permissionsResult.rows[i];
+    if (!permissionsByRole[row.role_id]) {
+      permissionsByRole[row.role_id] = [];
+    }
+    const { role_id, ...permission } = row;
+    permissionsByRole[role_id].push(permission);
+  }
+
+  return rolesResult.rows.map(role => ({
+    ...role,
+    permissions: permissionsByRole[role.id] || []
+  }));
 }
 
 /**


### PR DESCRIPTION
💡 **What:** Eliminated an N+1 database querying anti-pattern inside `getAllRoles` by refactoring from a `Promise.all` `.map` loop to a single secondary batch query (`ANY($1)`) combined with in-memory array mapping and grouping.
🎯 **Why:** To improve performance by drastically reducing the number of individual database connections/queries established when fetching roles alongside all their permissions.
📊 **Impact:** Reduces database query load for `getAllRoles` from $O(N)$ to exactly $O(1)$ (2 total queries regardless of role count), saving network overhead and improving execution speed. 
🔬 **Measurement:** Verify tests run cleanly via `npm run test -w server -- --run`. All unit and security tests assert the role structures correctly match.

---
*PR created automatically by Jules for task [17976309415727245298](https://jules.google.com/task/17976309415727245298) started by @PhBassin*