### PR TITLE
⚡ Bolt: [performance improvement] Optimize film grouping in database queries

### DIFF
--- a/server/src/db/film-queries.ts
+++ b/server/src/db/film-queries.ts
@@ -161,7 +161,13 @@ export async function getFilm(db: DB, filmId: number): Promise<Film | undefined>
   };
 }
 
-// Récupérer les films programmés pour une date spécifique
+/**
+ * Récupérer les films programmés pour une date spécifique
+ * ⚡ PERFORMANCE: Optimized grouping algorithm
+ * - Uses a plain JS object (Object.create(null)) instead of Map for O(1) lookups without prototype overhead
+ * - Single pass iteration with classic for loop avoiding iterator allocations
+ * - Tracks result array alongside map to avoid slow Object.values() at the end
+ */
 export async function getFilmsByDate(
   db: DB,
   date: string,
@@ -188,11 +194,15 @@ export async function getFilmsByDate(
   );
 
   // Regrouper par film
-  const filmsMap = new Map<number, Film & { cinemas: Cinema[] }>();
+  const resultList: Array<Film & { cinemas: Cinema[] }> = [];
+  const filmsMap: Record<number, Film & { cinemas: Cinema[] }> = Object.create(null);
 
-  for (const row of result.rows) {
-    if (!filmsMap.has(row.id)) {
-      filmsMap.set(row.id, {
+  for (let i = 0; i < result.rows.length; i++) {
+    const row = result.rows[i];
+    let film = filmsMap[row.id];
+
+    if (!film) {
+      film = {
         id: row.id,
         title: row.title,
         original_title: row.original_title ?? undefined,
@@ -212,10 +222,11 @@ export async function getFilmsByDate(
         source_url: row.source_url,
         trailer_url: row.trailer_url ?? undefined,
         cinemas: [],
-      });
+      };
+      filmsMap[row.id] = film;
+      resultList.push(film);
     }
 
-    const film = filmsMap.get(row.id)!;
     film.cinemas.push({
       id: row.cinema_id,
       name: row.cinema_name,
@@ -227,10 +238,16 @@ export async function getFilmsByDate(
     });
   }
 
-  return Array.from(filmsMap.values());
+  return resultList;
 }
 
-// Récupérer les films programmés dans la semaine en cours
+/**
+ * Récupérer les films programmés dans la semaine en cours
+ * ⚡ PERFORMANCE: Optimized grouping algorithm
+ * - Uses a plain JS object (Object.create(null)) instead of Map for O(1) lookups without prototype overhead
+ * - Single pass iteration with classic for loop avoiding iterator allocations
+ * - Tracks result array alongside map to avoid slow Object.values() at the end
+ */
 export async function getWeeklyFilms(
   db: DB,
   weekStart: string
@@ -256,11 +273,15 @@ export async function getWeeklyFilms(
   );
 
   // Regrouper par film
-  const filmsMap = new Map<number, Film & { cinemas: Cinema[] }>();
+  const resultList: Array<Film & { cinemas: Cinema[] }> = [];
+  const filmsMap: Record<number, Film & { cinemas: Cinema[] }> = Object.create(null);
 
-  for (const row of result.rows) {
-    if (!filmsMap.has(row.id)) {
-      filmsMap.set(row.id, {
+  for (let i = 0; i < result.rows.length; i++) {
+    const row = result.rows[i];
+    let film = filmsMap[row.id];
+
+    if (!film) {
+      film = {
         id: row.id,
         title: row.title,
         original_title: row.original_title ?? undefined,
@@ -280,10 +301,11 @@ export async function getWeeklyFilms(
         source_url: row.source_url,
         trailer_url: row.trailer_url ?? undefined,
         cinemas: [],
-      });
+      };
+      filmsMap[row.id] = film;
+      resultList.push(film);
     }
 
-    const film = filmsMap.get(row.id)!;
     film.cinemas.push({
       id: row.cinema_id,
       name: row.cinema_name,
@@ -295,7 +317,7 @@ export async function getWeeklyFilms(
     });
   }
 
-  return Array.from(filmsMap.values());
+  return resultList;
 }
 
 // --- Film Search ---


### PR DESCRIPTION
### 💡 What
Replaced the `Map`-based algorithm for grouping database rows in `getFilmsByDate` and `getWeeklyFilms` with a plain JS object dictionary (`Object.create(null)`) and a traditional `for` loop. The results are tracked in a pre-allocated array instead of needing `Array.from(map.values())` at the end.

### 🎯 Why
In environments with a high volume of rows (which is common for these two queries since they perform a SQL `JOIN` that multiplies rows per showtime/cinema), allocating iterator objects for a `for...of` loop and the prototype lookup overhead on `Map.has()` and `Map.get()` creates unnecessary garbage collection pressure and slows down CPU-bound execution.

### 📊 Impact
* Eliminates `Map` allocations and `.has()`/`.get()` prototype checks.
* Eliminates iterator allocation overhead by replacing `for...of` with a standard `for (let i = 0...)` loop.
* Eliminates the $O(N)$ trailing iteration needed to convert the Map values to an array.

### 🔬 Measurement
Run `npm test -- --run src/db/film-queries.test.ts` within the `server` workspace. Tests pass instantly, and the grouping order remains deterministic and completely identical to the previous implementation.

---
*PR created automatically by Jules for task [8824762960052520409](https://jules.google.com/task/8824762960052520409) started by @PhBassin*