### PR TITLE
feat(saas): email verification, invitation flows, and critical bug fixes (#740 + #748)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "workspaces": [
         "client",
         "server",
-        "scraper"
+        "scraper",
+        "packages/saas"
       ],
       "devDependencies": {
         "@playwright/test": "^1.58.2",
@@ -81,6 +82,10 @@
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@allo-scrapper/saas": {
+      "resolved": "packages/saas",
+      "link": true
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -5609,9 +5614,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "10.1.0"
@@ -9669,6 +9674,45 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "packages/saas": {
+      "name": "@allo-scrapper/saas",
+      "version": "1.0.0",
+      "dependencies": {
+        "bcryptjs": "^3.0.3",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.3.2",
+        "jsonwebtoken": "^9.0.3"
+      },
+      "devDependencies": {
+        "@types/bcryptjs": "^3.0.0",
+        "@types/express": "^5.0.6",
+        "@types/jsonwebtoken": "^9.0.10",
+        "@types/node": "^25.4.0",
+        "@types/supertest": "^7.2.0",
+        "@vitest/coverage-v8": "^4.0.18",
+        "supertest": "^7.2.2",
+        "tsx": "^4.19.2",
+        "typescript": "^6.0.2",
+        "vitest": "^4.1.1"
+      },
+      "peerDependencies": {
+        "pg": "^8.20.0"
+      }
+    },
+    "packages/saas/node_modules/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "scraper": {

--- a/packages/saas/migrations/org_schema/000_bootstrap.sql
+++ b/packages/saas/migrations/org_schema/000_bootstrap.sql
@@ -21,13 +21,29 @@ ON CONFLICT (name) DO NOTHING;
 
 -- Users table (tenant members — one record per human per org)
 CREATE TABLE IF NOT EXISTS users (
-  id            SERIAL PRIMARY KEY,
-  username      VARCHAR(255) NOT NULL UNIQUE,
-  password_hash TEXT,
-  role_id       INTEGER NOT NULL DEFAULT 1 REFERENCES roles(id),
-  email_verified BOOLEAN NOT NULL DEFAULT FALSE,
-  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  id                   SERIAL PRIMARY KEY,
+  username             VARCHAR(255) NOT NULL UNIQUE,
+  password_hash        TEXT,
+  role_id              INTEGER NOT NULL DEFAULT 1 REFERENCES roles(id),
+  email_verified       BOOLEAN NOT NULL DEFAULT FALSE,
+  verification_token   TEXT,
+  verification_expires TIMESTAMPTZ,
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE INDEX IF NOT EXISTS idx_users_username ON users (username);
+
+-- Invitations table (pending member invitations)
+CREATE TABLE IF NOT EXISTS invitations (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email       VARCHAR(255) NOT NULL,
+  role_id     INTEGER NOT NULL DEFAULT 1 REFERENCES roles(id),
+  token       TEXT NOT NULL UNIQUE,
+  expires_at  TIMESTAMPTZ NOT NULL,
+  accepted_at TIMESTAMPTZ,
+  created_by  INTEGER REFERENCES users(id),
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_invitations_token ON invitations (token);

--- a/packages/saas/package.json
+++ b/packages/saas/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "bcryptjs": "^3.0.3",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.3.2",
     "jsonwebtoken": "^9.0.3"
   },
   "devDependencies": {

--- a/packages/saas/src/db/types.ts
+++ b/packages/saas/src/db/types.ts
@@ -61,3 +61,29 @@ export interface MintJwtInput {
   roleName: string;
   permissions: string[];
 }
+
+/** A user row within an org schema */
+export interface OrgUser {
+  id: number;
+  username: string;
+  password_hash: string | null;
+  role_id: number;
+  role_name?: string;
+  email_verified: boolean;
+  verification_token: string | null;
+  verification_expires: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** A row from the org-schema invitations table */
+export interface Invitation {
+  id: string;
+  email: string;
+  role_id: number;
+  token: string;
+  expires_at: string;
+  accepted_at: string | null;
+  created_by: number | null;
+  created_at: string;
+}

--- a/packages/saas/src/middleware/tenant.test.ts
+++ b/packages/saas/src/middleware/tenant.test.ts
@@ -119,6 +119,39 @@ describe('resolveTenant', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
+  it('releases client exactly ONCE when org is not found (not twice)', async () => {
+    const client = {
+      query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+      release: vi.fn(),
+    };
+    const pool = { connect: vi.fn().mockResolvedValue(client) };
+    const req = makeReq('missing', pool);
+    const res = makeRes();
+    const next = vi.fn();
+
+    const { resolveTenant } = await import('./tenant.js');
+    await resolveTenant(req as unknown as Request, res as unknown as Response, next as unknown as NextFunction);
+
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases client exactly ONCE when org is suspended (not twice)', async () => {
+    const org = { id: 3, slug: 'bad', schema_name: 'org_bad', status: 'suspended' };
+    const client = {
+      query: vi.fn().mockResolvedValue({ rows: [org], rowCount: 1 }),
+      release: vi.fn(),
+    };
+    const pool = { connect: vi.fn().mockResolvedValue(client) };
+    const req = makeReq('bad', pool);
+    const res = makeRes();
+    const next = vi.fn();
+
+    const { resolveTenant } = await import('./tenant.js');
+    await resolveTenant(req as unknown as Request, res as unknown as Response, next as unknown as NextFunction);
+
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
   it('always releases the client even when next() throws', async () => {
     const org = { id: 1, slug: 'acme', schema_name: 'org_acme', status: 'active' };
     const client = {

--- a/packages/saas/src/middleware/tenant.ts
+++ b/packages/saas/src/middleware/tenant.ts
@@ -34,18 +34,26 @@ export async function resolveTenant(
   const slug = req.params['slug'] as string;
   const pool = req.app.get('pool') as Pool;
   const client = await pool.connect();
+  let released = false;
+
+  const releaseOnce = () => {
+    if (!released) {
+      released = true;
+      client.release();
+    }
+  };
 
   try {
     const org = await getOrgBySlug(client, slug);
 
     if (!org) {
-      client.release();
+      releaseOnce();
       res.status(404).json({ success: false, error: 'Organization not found' });
       return;
     }
 
     if (!ACTIVE_STATUSES.has(org.status)) {
-      client.release();
+      releaseOnce();
       res.status(403).json({ success: false, error: `Organization is ${org.status}` });
       return;
     }
@@ -61,9 +69,7 @@ export async function resolveTenant(
 
     await next();
   } finally {
-    // Always release the client back to the pool
-    if (req.dbClient) {
-      req.dbClient.release();
-    }
+    // Always release the client back to the pool (no-op if already released above)
+    releaseOnce();
   }
 }

--- a/packages/saas/src/plugin.ts
+++ b/packages/saas/src/plugin.ts
@@ -10,6 +10,7 @@ import path from 'path';
 import type { Express } from 'express';
 import { createRegisterRouter } from './routes/register.js';
 import { createOrgRouter } from './routes/org.js';
+import { createOnboardingRouter } from './routes/onboarding.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -37,6 +38,9 @@ export const saasPlugin: AppPlugin = {
     // Registration & slug availability
     app.use('/api', createRegisterRouter());
 
+    // Email verification & member invitation flows
+    app.use('/api', createOnboardingRouter());
+
     // All org-scoped routes: /api/org/:slug/*
     app.use('/api/org/:slug', createOrgRouter());
   },
@@ -47,8 +51,8 @@ export const saasPlugin: AppPlugin = {
  * Used by server/src/db/migrations.ts when SAAS_ENABLED=true.
  */
 export function getSaasMigrationDir(): string {
-  const isDocker = __dirname.startsWith('/app/');
-  return isDocker
+  const isProduction = process.env['NODE_ENV'] === 'production';
+  return isProduction
     ? path.join('/app', 'packages', 'saas', 'migrations')
     : path.join(__dirname, '../migrations');
 }

--- a/packages/saas/src/routes/onboarding.test.ts
+++ b/packages/saas/src/routes/onboarding.test.ts
@@ -12,28 +12,28 @@ import type { Organization } from '../db/types.js';
 
 // Mock EmailService and InvitationService to avoid real DB calls
 vi.mock('../services/email-service.js', () => ({
-  EmailService: vi.fn().mockImplementation(() => ({
-    verifyEmailToken: vi.fn(),
-    markEmailVerified: vi.fn().mockResolvedValue(undefined),
-    generateVerificationToken: vi.fn().mockReturnValue('a'.repeat(64)),
-    storeVerificationToken: vi.fn().mockResolvedValue(undefined),
-    sendVerificationEmail: vi.fn().mockResolvedValue(undefined),
-  })),
+  EmailService: vi.fn().mockImplementation(function (this: any) {
+    this.verifyEmailToken = vi.fn();
+    this.markEmailVerified = vi.fn().mockResolvedValue(undefined);
+    this.generateVerificationToken = vi.fn().mockReturnValue('a'.repeat(64));
+    this.storeVerificationToken = vi.fn().mockResolvedValue(undefined);
+    this.sendVerificationEmail = vi.fn().mockResolvedValue(undefined);
+  }),
 }));
 
 vi.mock('../services/invitation-service.js', () => ({
-  InvitationService: vi.fn().mockImplementation(() => ({
-    createInvitation: vi.fn(),
-    getInvitationByToken: vi.fn(),
-    acceptInvitation: vi.fn(),
-  })),
+  InvitationService: vi.fn().mockImplementation(function (this: any) {
+    this.createInvitation = vi.fn();
+    this.getInvitationByToken = vi.fn();
+    this.acceptInvitation = vi.fn();
+  }),
 }));
 
 vi.mock('../services/saas-auth-service.js', () => ({
-  SaasAuthService: vi.fn().mockImplementation(() => ({
-    createAdminUser: vi.fn(),
-    mintJwt: vi.fn().mockReturnValue('mock.jwt.token'),
-  })),
+  SaasAuthService: vi.fn().mockImplementation(function (this: any) {
+    this.createAdminUser = vi.fn();
+    this.mintJwt = vi.fn().mockReturnValue('mock.jwt.token');
+  }),
 }));
 
 function makeOrg(slug = 'acme'): Organization {
@@ -52,7 +52,8 @@ function buildApp(orgSlug = 'acme') {
   const app = express();
   app.use(express.json());
 
-  const db = { query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }) };
+  // db.query returns the org row for getOrgBySlug lookups by default
+  const db = { query: vi.fn().mockResolvedValue({ rows: [makeOrg(orgSlug)], rowCount: 1 }) };
   const pool = {
     connect: vi.fn().mockResolvedValue({
       query: vi.fn().mockResolvedValue({ rows: [makeOrg(orgSlug)], rowCount: 1 }),
@@ -75,13 +76,13 @@ function buildApp(orgSlug = 'acme') {
 describe('GET /api/auth/verify-email/:token', () => {
   it('returns 200 when token is valid', async () => {
     const { EmailService } = await import('../services/email-service.js');
-    vi.mocked(EmailService).mockImplementation(() => ({
-      verifyEmailToken: vi.fn().mockResolvedValue(7),
-      markEmailVerified: vi.fn().mockResolvedValue(undefined),
-      generateVerificationToken: vi.fn().mockReturnValue('a'.repeat(64)),
-      storeVerificationToken: vi.fn().mockResolvedValue(undefined),
-      sendVerificationEmail: vi.fn().mockResolvedValue(undefined),
-    }));
+    vi.mocked(EmailService).mockImplementation(function (this: any) {
+      this.verifyEmailToken = vi.fn().mockResolvedValue(7);
+      this.markEmailVerified = vi.fn().mockResolvedValue(undefined);
+      this.generateVerificationToken = vi.fn().mockReturnValue('a'.repeat(64));
+      this.storeVerificationToken = vi.fn().mockResolvedValue(undefined);
+      this.sendVerificationEmail = vi.fn().mockResolvedValue(undefined);
+    } as any);
 
     const app = buildApp();
     const { createOnboardingRouter } = await import('./onboarding.js');
@@ -94,13 +95,13 @@ describe('GET /api/auth/verify-email/:token', () => {
 
   it('returns 400 when token is invalid or expired', async () => {
     const { EmailService } = await import('../services/email-service.js');
-    vi.mocked(EmailService).mockImplementation(() => ({
-      verifyEmailToken: vi.fn().mockResolvedValue(null),
-      markEmailVerified: vi.fn().mockResolvedValue(undefined),
-      generateVerificationToken: vi.fn().mockReturnValue('a'.repeat(64)),
-      storeVerificationToken: vi.fn().mockResolvedValue(undefined),
-      sendVerificationEmail: vi.fn().mockResolvedValue(undefined),
-    }));
+    vi.mocked(EmailService).mockImplementation(function (this: any) {
+      this.verifyEmailToken = vi.fn().mockResolvedValue(null);
+      this.markEmailVerified = vi.fn().mockResolvedValue(undefined);
+      this.generateVerificationToken = vi.fn().mockReturnValue('a'.repeat(64));
+      this.storeVerificationToken = vi.fn().mockResolvedValue(undefined);
+      this.sendVerificationEmail = vi.fn().mockResolvedValue(undefined);
+    } as any);
 
     const app = buildApp();
     const { createOnboardingRouter } = await import('./onboarding.js');
@@ -135,17 +136,17 @@ describe('POST /api/auth/join/:token', () => {
     const newUser = { id: 10, username: 'bob@example.com', role_id: 2, role_name: 'editor' };
 
     const { InvitationService } = await import('../services/invitation-service.js');
-    vi.mocked(InvitationService).mockImplementation(() => ({
-      createInvitation: vi.fn(),
-      getInvitationByToken: vi.fn().mockResolvedValue(invitation),
-      acceptInvitation: vi.fn().mockResolvedValue(newUser),
-    }));
+    vi.mocked(InvitationService).mockImplementation(function (this: any) {
+      this.createInvitation = vi.fn();
+      this.getInvitationByToken = vi.fn().mockResolvedValue(invitation);
+      this.acceptInvitation = vi.fn().mockResolvedValue(newUser);
+    } as any);
 
     const { SaasAuthService } = await import('../services/saas-auth-service.js');
-    vi.mocked(SaasAuthService).mockImplementation(() => ({
-      createAdminUser: vi.fn(),
-      mintJwt: vi.fn().mockReturnValue('join.jwt.token'),
-    }));
+    vi.mocked(SaasAuthService).mockImplementation(function (this: any) {
+      this.createAdminUser = vi.fn();
+      this.mintJwt = vi.fn().mockReturnValue('join.jwt.token');
+    } as any);
 
     const app = buildApp();
     // Inject org lookup mock for the join route
@@ -166,11 +167,11 @@ describe('POST /api/auth/join/:token', () => {
 
   it('returns 400 when invitation token is invalid or expired', async () => {
     const { InvitationService } = await import('../services/invitation-service.js');
-    vi.mocked(InvitationService).mockImplementation(() => ({
-      createInvitation: vi.fn(),
-      getInvitationByToken: vi.fn().mockResolvedValue(null),
-      acceptInvitation: vi.fn(),
-    }));
+    vi.mocked(InvitationService).mockImplementation(function (this: any) {
+      this.createInvitation = vi.fn();
+      this.getInvitationByToken = vi.fn().mockResolvedValue(null);
+      this.acceptInvitation = vi.fn();
+    } as any);
 
     const app = buildApp();
     const db = app.get('db') as { query: ReturnType<typeof vi.fn> };
@@ -202,11 +203,11 @@ describe('POST /api/org/:slug/invitations', () => {
     };
 
     const { InvitationService } = await import('../services/invitation-service.js');
-    vi.mocked(InvitationService).mockImplementation(() => ({
-      createInvitation: vi.fn().mockResolvedValue(invitation),
-      getInvitationByToken: vi.fn(),
-      acceptInvitation: vi.fn(),
-    }));
+    vi.mocked(InvitationService).mockImplementation(function (this: any) {
+      this.createInvitation = vi.fn().mockResolvedValue(invitation);
+      this.getInvitationByToken = vi.fn();
+      this.acceptInvitation = vi.fn();
+    } as any);
 
     const app = buildApp();
     // Mock requireAuth by injecting user

--- a/packages/saas/src/routes/onboarding.test.ts
+++ b/packages/saas/src/routes/onboarding.test.ts
@@ -1,0 +1,246 @@
+/**
+ * RED tests for onboarding routes.
+ *
+ * GET  /api/auth/verify-email/:token
+ * POST /api/auth/join/:token
+ * POST /api/org/:slug/invitations
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import type { Organization } from '../db/types.js';
+
+// Mock EmailService and InvitationService to avoid real DB calls
+vi.mock('../services/email-service.js', () => ({
+  EmailService: vi.fn().mockImplementation(() => ({
+    verifyEmailToken: vi.fn(),
+    markEmailVerified: vi.fn().mockResolvedValue(undefined),
+    generateVerificationToken: vi.fn().mockReturnValue('a'.repeat(64)),
+    storeVerificationToken: vi.fn().mockResolvedValue(undefined),
+    sendVerificationEmail: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+vi.mock('../services/invitation-service.js', () => ({
+  InvitationService: vi.fn().mockImplementation(() => ({
+    createInvitation: vi.fn(),
+    getInvitationByToken: vi.fn(),
+    acceptInvitation: vi.fn(),
+  })),
+}));
+
+vi.mock('../services/saas-auth-service.js', () => ({
+  SaasAuthService: vi.fn().mockImplementation(() => ({
+    createAdminUser: vi.fn(),
+    mintJwt: vi.fn().mockReturnValue('mock.jwt.token'),
+  })),
+}));
+
+function makeOrg(slug = 'acme'): Organization {
+  return {
+    id: 1,
+    name: 'Acme',
+    slug,
+    plan_id: 1,
+    schema_name: `org_${slug}`,
+    status: 'active',
+    trial_ends_at: null,
+  };
+}
+
+function buildApp(orgSlug = 'acme') {
+  const app = express();
+  app.use(express.json());
+
+  const db = { query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }) };
+  const pool = {
+    connect: vi.fn().mockResolvedValue({
+      query: vi.fn().mockResolvedValue({ rows: [makeOrg(orgSlug)], rowCount: 1 }),
+      release: vi.fn(),
+    }),
+  };
+  app.set('db', db);
+  app.set('pool', pool);
+
+  // Simulate resolveTenant for /api/org/:slug routes
+  app.use('/api/org/:slug', (req, _res, next) => {
+    (req as any).org = makeOrg((req.params as any).slug);
+    (req as any).dbClient = db;
+    next();
+  });
+
+  return app;
+}
+
+describe('GET /api/auth/verify-email/:token', () => {
+  it('returns 200 when token is valid', async () => {
+    const { EmailService } = await import('../services/email-service.js');
+    vi.mocked(EmailService).mockImplementation(() => ({
+      verifyEmailToken: vi.fn().mockResolvedValue(7),
+      markEmailVerified: vi.fn().mockResolvedValue(undefined),
+      generateVerificationToken: vi.fn().mockReturnValue('a'.repeat(64)),
+      storeVerificationToken: vi.fn().mockResolvedValue(undefined),
+      sendVerificationEmail: vi.fn().mockResolvedValue(undefined),
+    }));
+
+    const app = buildApp();
+    const { createOnboardingRouter } = await import('./onboarding.js');
+    app.use('/api', createOnboardingRouter());
+
+    const res = await request(app).get('/api/auth/verify-email/acme:validtoken');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('returns 400 when token is invalid or expired', async () => {
+    const { EmailService } = await import('../services/email-service.js');
+    vi.mocked(EmailService).mockImplementation(() => ({
+      verifyEmailToken: vi.fn().mockResolvedValue(null),
+      markEmailVerified: vi.fn().mockResolvedValue(undefined),
+      generateVerificationToken: vi.fn().mockReturnValue('a'.repeat(64)),
+      storeVerificationToken: vi.fn().mockResolvedValue(undefined),
+      sendVerificationEmail: vi.fn().mockResolvedValue(undefined),
+    }));
+
+    const app = buildApp();
+    const { createOnboardingRouter } = await import('./onboarding.js');
+    app.use('/api', createOnboardingRouter());
+
+    const res = await request(app).get('/api/auth/verify-email/acme:expiredtoken');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('INVALID_OR_EXPIRED_TOKEN');
+  });
+
+  it('returns 400 when token has no org prefix', async () => {
+    const app = buildApp();
+    const { createOnboardingRouter } = await import('./onboarding.js');
+    app.use('/api', createOnboardingRouter());
+
+    const res = await request(app).get('/api/auth/verify-email/notprefixed');
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /api/auth/join/:token', () => {
+  it('returns 201 with JWT when invitation is valid', async () => {
+    const future = new Date(Date.now() + 3600_000).toISOString();
+    const invitation = {
+      id: 'uuid-1',
+      email: 'bob@example.com',
+      role_id: 2,
+      token: 'acme:tok',
+      expires_at: future,
+      accepted_at: null,
+    };
+    const newUser = { id: 10, username: 'bob@example.com', role_id: 2, role_name: 'editor' };
+
+    const { InvitationService } = await import('../services/invitation-service.js');
+    vi.mocked(InvitationService).mockImplementation(() => ({
+      createInvitation: vi.fn(),
+      getInvitationByToken: vi.fn().mockResolvedValue(invitation),
+      acceptInvitation: vi.fn().mockResolvedValue(newUser),
+    }));
+
+    const { SaasAuthService } = await import('../services/saas-auth-service.js');
+    vi.mocked(SaasAuthService).mockImplementation(() => ({
+      createAdminUser: vi.fn(),
+      mintJwt: vi.fn().mockReturnValue('join.jwt.token'),
+    }));
+
+    const app = buildApp();
+    // Inject org lookup mock for the join route
+    const db = app.get('db') as { query: ReturnType<typeof vi.fn> };
+    db.query = vi.fn()
+      .mockResolvedValueOnce({ rows: [makeOrg('acme')], rowCount: 1 }); // getOrgBySlug
+
+    const { createOnboardingRouter } = await import('./onboarding.js');
+    app.use('/api', createOnboardingRouter());
+
+    const res = await request(app)
+      .post('/api/auth/join/acme:tok')
+      .send({ password: 'secret123' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.token).toBeDefined();
+  });
+
+  it('returns 400 when invitation token is invalid or expired', async () => {
+    const { InvitationService } = await import('../services/invitation-service.js');
+    vi.mocked(InvitationService).mockImplementation(() => ({
+      createInvitation: vi.fn(),
+      getInvitationByToken: vi.fn().mockResolvedValue(null),
+      acceptInvitation: vi.fn(),
+    }));
+
+    const app = buildApp();
+    const db = app.get('db') as { query: ReturnType<typeof vi.fn> };
+    db.query = vi.fn()
+      .mockResolvedValueOnce({ rows: [makeOrg('acme')], rowCount: 1 });
+
+    const { createOnboardingRouter } = await import('./onboarding.js');
+    app.use('/api', createOnboardingRouter());
+
+    const res = await request(app)
+      .post('/api/auth/join/acme:expired')
+      .send({ password: 'secret123' });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /api/org/:slug/invitations', () => {
+  it('returns 201 with token when authenticated and valid', async () => {
+    const future = new Date(Date.now() + 48 * 3600_000).toISOString();
+    const invitation = {
+      id: 'uuid-new',
+      email: 'new@example.com',
+      role_id: 2,
+      token: 'acme:newtok',
+      expires_at: future,
+      accepted_at: null,
+      created_at: new Date().toISOString(),
+    };
+
+    const { InvitationService } = await import('../services/invitation-service.js');
+    vi.mocked(InvitationService).mockImplementation(() => ({
+      createInvitation: vi.fn().mockResolvedValue(invitation),
+      getInvitationByToken: vi.fn(),
+      acceptInvitation: vi.fn(),
+    }));
+
+    const app = buildApp();
+    // Mock requireAuth by injecting user
+    app.use('/api/org/:slug/invitations', (req, _res, next) => {
+      (req as any).user = { id: 1, username: 'admin', org_slug: (req.params as any).slug };
+      next();
+    });
+
+    const { createOnboardingRouter } = await import('./onboarding.js');
+    app.use('/api', createOnboardingRouter());
+
+    const res = await request(app)
+      .post('/api/org/acme/invitations')
+      .send({ email: 'new@example.com', role_id: 2 });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.token).toBe('acme:newtok');
+  });
+
+  it('returns 400 when email is missing', async () => {
+    const app = buildApp();
+    app.use('/api/org/:slug/invitations', (req, _res, next) => {
+      (req as any).user = { id: 1, username: 'admin', org_slug: 'acme' };
+      next();
+    });
+
+    const { createOnboardingRouter } = await import('./onboarding.js');
+    app.use('/api', createOnboardingRouter());
+
+    const res = await request(app)
+      .post('/api/org/acme/invitations')
+      .send({ role_id: 2 });
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/saas/src/routes/onboarding.ts
+++ b/packages/saas/src/routes/onboarding.ts
@@ -7,11 +7,39 @@
  */
 import { Router } from 'express';
 import type { Request, Response } from 'express';
+import rateLimit from 'express-rate-limit';
 import { getOrgBySlug } from '../db/org-queries.js';
 import type { DB, Pool } from '../db/types.js';
 import { EmailService } from '../services/email-service.js';
 import { InvitationService } from '../services/invitation-service.js';
 import { SaasAuthService } from '../services/saas-auth-service.js';
+
+/** Rate limit: 10 email verification attempts per 15 minutes per IP */
+const verifyEmailLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: parseInt(process.env['RATE_LIMIT_VERIFY_EMAIL_MAX'] ?? '10', 10),
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { success: false, error: 'Too many verification attempts, please try again later.' },
+});
+
+/** Rate limit: 10 join/invitation-acceptance attempts per 15 minutes per IP */
+const joinLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: parseInt(process.env['RATE_LIMIT_JOIN_MAX'] ?? '10', 10),
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { success: false, error: 'Too many join attempts, please try again later.' },
+});
+
+/** Rate limit: 20 invitation-creation requests per 15 minutes per IP */
+const invitationLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: parseInt(process.env['RATE_LIMIT_INVITATION_MAX'] ?? '20', 10),
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { success: false, error: 'Too many invitation requests, please try again later.' },
+});
 
 export function createOnboardingRouter(): Router {
   const router = Router();
@@ -22,7 +50,7 @@ export function createOnboardingRouter(): Router {
    * Token format: `orgSlug:hex64`
    * Resolves the org from the slug prefix, then verifies the token.
    */
-  router.get('/auth/verify-email/:token', async (req: Request, res: Response) => {
+  router.get('/auth/verify-email/:token', verifyEmailLimiter, async (req: Request, res: Response) => {
     try {
       const { token } = req.params as { token: string };
 
@@ -66,7 +94,7 @@ export function createOnboardingRouter(): Router {
    *
    * Token format: `orgSlug:hex64`
    */
-  router.post('/auth/join/:token', async (req: Request, res: Response) => {
+  router.post('/auth/join/:token', joinLimiter, async (req: Request, res: Response) => {
     try {
       const { token } = req.params as { token: string };
       const { password } = req.body as { password?: string };
@@ -130,7 +158,7 @@ export function createOnboardingRouter(): Router {
    * Create a member invitation. Requires authentication.
    * Body: { email: string, role_id?: number }
    */
-  router.post('/org/:slug/invitations', async (req: Request, res: Response) => {
+  router.post('/org/:slug/invitations', invitationLimiter, async (req: Request, res: Response) => {
     try {
       const { slug } = req.params as { slug: string };
       const { email, role_id } = req.body as { email?: string; role_id?: number };

--- a/packages/saas/src/routes/onboarding.ts
+++ b/packages/saas/src/routes/onboarding.ts
@@ -1,0 +1,175 @@
+/**
+ * Onboarding routes.
+ *
+ * GET  /api/auth/verify-email/:token   — verify a user's email address
+ * POST /api/auth/join/:token           — accept a member invitation (set password → JWT)
+ * POST /api/org/:slug/invitations      — create a member invitation (authenticated)
+ */
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { getOrgBySlug } from '../db/org-queries.js';
+import type { DB, Pool } from '../db/types.js';
+import { EmailService } from '../services/email-service.js';
+import { InvitationService } from '../services/invitation-service.js';
+import { SaasAuthService } from '../services/saas-auth-service.js';
+
+export function createOnboardingRouter(): Router {
+  const router = Router();
+
+  /**
+   * GET /api/auth/verify-email/:token
+   *
+   * Token format: `orgSlug:hex64`
+   * Resolves the org from the slug prefix, then verifies the token.
+   */
+  router.get('/auth/verify-email/:token', async (req: Request, res: Response) => {
+    try {
+      const { token } = req.params as { token: string };
+
+      // Validate token prefix
+      const colonIdx = token.indexOf(':');
+      if (colonIdx < 1) {
+        res.status(400).json({ success: false, error: 'INVALID_TOKEN_FORMAT' });
+        return;
+      }
+
+      const orgSlug = token.slice(0, colonIdx);
+      const db = req.app.get('db') as DB;
+
+      const org = await getOrgBySlug(db, orgSlug);
+      if (!org) {
+        res.status(400).json({ success: false, error: 'INVALID_OR_EXPIRED_TOKEN' });
+        return;
+      }
+
+      const emailSvc = new EmailService(db);
+      const userId = await emailSvc.verifyEmailToken(org, token);
+
+      if (!userId) {
+        res.status(400).json({ success: false, error: 'INVALID_OR_EXPIRED_TOKEN' });
+        return;
+      }
+
+      await emailSvc.markEmailVerified(org, userId);
+      res.status(200).json({ success: true });
+    } catch (err) {
+      console.error('[onboarding] verify-email error:', err);
+      res.status(500).json({ success: false, error: 'INTERNAL_ERROR' });
+    }
+  });
+
+  /**
+   * POST /api/auth/join/:token
+   *
+   * Accept a member invitation. Requires { password } in the body.
+   * Returns a JWT on success.
+   *
+   * Token format: `orgSlug:hex64`
+   */
+  router.post('/auth/join/:token', async (req: Request, res: Response) => {
+    try {
+      const { token } = req.params as { token: string };
+      const { password } = req.body as { password?: string };
+
+      if (!password) {
+        res.status(400).json({ success: false, error: 'PASSWORD_REQUIRED' });
+        return;
+      }
+
+      const colonIdx = token.indexOf(':');
+      if (colonIdx < 1) {
+        res.status(400).json({ success: false, error: 'INVALID_TOKEN_FORMAT' });
+        return;
+      }
+
+      const orgSlug = token.slice(0, colonIdx);
+      const db = req.app.get('db') as DB;
+      const pool = req.app.get('pool') as Pool;
+
+      const org = await getOrgBySlug(db, orgSlug);
+      if (!org) {
+        res.status(400).json({ success: false, error: 'INVALID_OR_EXPIRED_TOKEN' });
+        return;
+      }
+
+      const invitationSvc = new InvitationService(db);
+      const invitation = await invitationSvc.getInvitationByToken(org, token);
+      if (!invitation) {
+        res.status(400).json({ success: false, error: 'INVALID_OR_EXPIRED_TOKEN' });
+        return;
+      }
+
+      // Hash password using bcrypt
+      const bcrypt = await import('bcryptjs');
+      const salt = await bcrypt.genSalt(10);
+      const passwordHash = await bcrypt.hash(password, salt);
+
+      const user = await invitationSvc.acceptInvitation(org, invitation, passwordHash);
+
+      const authSvc = new SaasAuthService(pool);
+      const jwtToken = authSvc.mintJwt({
+        userId: user.id,
+        username: user.username,
+        orgId: org.id,
+        orgSlug: org.slug,
+        roleId: user.role_id,
+        roleName: user.role_name ?? 'member',
+        permissions: [],
+      });
+
+      res.status(201).json({ success: true, token: jwtToken });
+    } catch (err) {
+      console.error('[onboarding] join error:', err);
+      res.status(500).json({ success: false, error: 'INTERNAL_ERROR' });
+    }
+  });
+
+  /**
+   * POST /api/org/:slug/invitations
+   *
+   * Create a member invitation. Requires authentication.
+   * Body: { email: string, role_id?: number }
+   */
+  router.post('/org/:slug/invitations', async (req: Request, res: Response) => {
+    try {
+      const { slug } = req.params as { slug: string };
+      const { email, role_id } = req.body as { email?: string; role_id?: number };
+
+      if (!email) {
+        res.status(400).json({ success: false, error: 'EMAIL_REQUIRED' });
+        return;
+      }
+
+      // req.org is set by resolveTenant if the route is nested under org middleware,
+      // otherwise fall back to loading org by slug
+      const org = (req as any).org ?? await (async () => {
+        const db = req.app.get('db') as DB;
+        return getOrgBySlug(db, slug);
+      })();
+
+      if (!org) {
+        res.status(404).json({ success: false, error: 'ORGANIZATION_NOT_FOUND' });
+        return;
+      }
+
+      // Use req.dbClient if available (from tenant middleware), otherwise use app db
+      const db: DB = (req as any).dbClient ?? (req.app.get('db') as DB);
+
+      const invitationSvc = new InvitationService(db);
+      const createdBy = (req as any).user?.id as number | undefined;
+
+      const invitation = await invitationSvc.createInvitation(org, {
+        email,
+        role_id: role_id ?? 1,
+        created_by: createdBy,
+      });
+
+      res.status(201).json({ success: true, token: invitation.token, invitation });
+    } catch (err) {
+      console.error('[onboarding] create-invitation error:', err);
+      res.status(500).json({ success: false, error: 'INTERNAL_ERROR' });
+    }
+  });
+
+  return router;
+}

--- a/packages/saas/src/routes/register.test.ts
+++ b/packages/saas/src/routes/register.test.ts
@@ -98,10 +98,11 @@ describe('POST /api/saas/orgs (register)', () => {
     };
     const db = {
       query: vi.fn()
-        .mockResolvedValueOnce({ rows: [{ count: '0' }], rowCount: 1 })  // isSlugAvailable
-        .mockResolvedValueOnce({ rows: [{ count: '0' }], rowCount: 1 })  // second isSlugAvailable in createOrg
+        .mockResolvedValueOnce({ rows: [{ count: '0' }], rowCount: 1 })  // isSlugAvailable (route)
+        .mockResolvedValueOnce({ rows: [{ count: '0' }], rowCount: 1 })  // isSlugAvailable (createOrg)
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 })                 // BEGIN
         .mockResolvedValueOnce({ rows: [org], rowCount: 1 })              // insertOrg
-        .mockResolvedValue({ rows: [], rowCount: 0 }),                    // rest (CREATE SCHEMA, bootstrap)
+        .mockResolvedValue({ rows: [], rowCount: 0 }),                    // rest (CREATE SCHEMA, bootstrap, COMMIT)
     };
     const pool = {
       connect: vi.fn().mockResolvedValue({

--- a/packages/saas/src/routes/register.ts
+++ b/packages/saas/src/routes/register.ts
@@ -5,12 +5,23 @@
  * GET  /api/saas/orgs/:slug/available — check slug availability
  */
 import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
 import { isSlugAvailable } from '../db/org-queries.js';
 import { createOrg } from '../services/org-service.js';
 import { SaasAuthService } from '../services/saas-auth-service.js';
+import { EmailService } from '../services/email-service.js';
 import type { DB, Pool } from '../db/types.js';
 
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{1,28}[a-z0-9]$/;
+
+/** Rate limit: 5 org-creation attempts per 15 minutes per IP */
+const orgCreationLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: parseInt(process.env['RATE_LIMIT_SAAS_ORG_MAX'] ?? '5', 10),
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { success: false, error: 'Too many registration attempts, please try again later.' },
+});
 
 export function createRegisterRouter(): Router {
   const router = Router();
@@ -22,7 +33,7 @@ export function createRegisterRouter(): Router {
    *
    * Body: { orgName, slug, adminEmail, adminPassword }
    */
-  router.post('/saas/orgs', async (req, res) => {
+  router.post('/saas/orgs', orgCreationLimiter, async (req, res) => {
     const { orgName, slug, adminEmail, adminPassword } = req.body as Record<string, string>;
 
     const errors: string[] = [];
@@ -66,6 +77,16 @@ export function createRegisterRouter(): Router {
       roleId: adminUser.role_id,
       roleName: adminUser.role_name,
       permissions: [], // Phase 3: load from org schema permissions table
+    });
+
+    // Dispatch verification email non-blocking (fire-and-forget)
+    const emailService = new EmailService(db);
+    const verificationToken = emailService.generateVerificationToken();
+    const prefixedToken = `${org.slug}:${verificationToken}`;
+    emailService.storeVerificationToken(org, adminUser.id, prefixedToken).then(() =>
+      emailService.sendVerificationEmail(adminEmail, prefixedToken, org.slug)
+    ).catch((err: unknown) => {
+      console.error('[register] Failed to send verification email:', err);
     });
 
     return res.status(201).json({

--- a/packages/saas/src/services/email-service.test.ts
+++ b/packages/saas/src/services/email-service.test.ts
@@ -1,0 +1,157 @@
+/**
+ * RED tests for EmailService.
+ * All DB calls are mocked — no real DB required.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { DB, Organization } from '../db/types.js';
+
+function makeDb(): DB {
+  return {
+    query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+  };
+}
+
+function makeOrg(slug = 'acme'): Organization {
+  return {
+    id: 1,
+    name: 'Acme Cinema',
+    slug,
+    plan_id: 1,
+    schema_name: `org_${slug}`,
+    status: 'active',
+    trial_ends_at: null,
+  };
+}
+
+describe('EmailService', () => {
+  let db: DB;
+
+  beforeEach(() => {
+    db = makeDb();
+    vi.clearAllMocks();
+  });
+
+  describe('generateVerificationToken', () => {
+    it('returns a 64-character hex string', async () => {
+      const { EmailService } = await import('./email-service.js');
+      const svc = new EmailService(db);
+      const token = svc.generateVerificationToken();
+      expect(token).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('generates unique tokens on each call', async () => {
+      const { EmailService } = await import('./email-service.js');
+      const svc = new EmailService(db);
+      const t1 = svc.generateVerificationToken();
+      const t2 = svc.generateVerificationToken();
+      expect(t1).not.toBe(t2);
+    });
+  });
+
+  describe('storeVerificationToken', () => {
+    it('writes token and expiry to the org users table', async () => {
+      const { EmailService } = await import('./email-service.js');
+      const svc = new EmailService(db);
+      const org = makeOrg();
+      const userId = 42;
+      const token = 'abc123'.padEnd(64, '0');
+
+      await svc.storeVerificationToken(org, userId, token);
+
+      const queryMock = vi.mocked(db.query);
+      expect(queryMock).toHaveBeenCalled();
+      // Should set search_path to the org schema
+      const calls = queryMock.mock.calls.map(([sql]) => sql as string);
+      expect(calls.some((s) => s.includes(org.schema_name))).toBe(true);
+      // Should UPDATE users with token and expires
+      expect(
+        calls.some(
+          (s) =>
+            s.toLowerCase().includes('update') &&
+            s.toLowerCase().includes('verification_token')
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe('verifyEmailToken', () => {
+    it('returns userId when token is valid and not expired', async () => {
+      const future = new Date(Date.now() + 3600_000).toISOString();
+      const queryMock = vi.fn()
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // SET search_path
+        .mockResolvedValueOnce({
+          rows: [{ id: 7, verification_expires: future }],
+          rowCount: 1,
+        }); // SELECT user by token
+      const db2: DB = { query: queryMock };
+
+      const { EmailService } = await import('./email-service.js');
+      const svc = new EmailService(db2);
+      const org = makeOrg();
+      const result = await svc.verifyEmailToken(org, 'sometoken');
+
+      expect(result).toBe(7);
+    });
+
+    it('returns null when token is expired', async () => {
+      const past = new Date(Date.now() - 1000).toISOString();
+      const queryMock = vi.fn()
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // SET search_path
+        .mockResolvedValueOnce({
+          rows: [{ id: 7, verification_expires: past }],
+          rowCount: 1,
+        });
+      const db2: DB = { query: queryMock };
+
+      const { EmailService } = await import('./email-service.js');
+      const svc = new EmailService(db2);
+      const result = await svc.verifyEmailToken(makeOrg(), 'sometoken');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when token not found', async () => {
+      const queryMock = vi.fn()
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // SET search_path
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }); // no row
+      const db2: DB = { query: queryMock };
+
+      const { EmailService } = await import('./email-service.js');
+      const svc = new EmailService(db2);
+      const result = await svc.verifyEmailToken(makeOrg(), 'missing');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('markEmailVerified', () => {
+    it('sets email_verified=true and clears token fields', async () => {
+      const { EmailService } = await import('./email-service.js');
+      const svc = new EmailService(db);
+      const org = makeOrg();
+
+      await svc.markEmailVerified(org, 7);
+
+      const queryMock = vi.mocked(db.query);
+      const calls = queryMock.mock.calls.map(([sql]) => sql as string);
+      expect(
+        calls.some(
+          (s) =>
+            s.toLowerCase().includes('update') &&
+            s.toLowerCase().includes('email_verified')
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe('sendVerificationEmail', () => {
+    it('does not throw when SMTP_HOST is not set (console-log stub)', async () => {
+      delete process.env['SMTP_HOST'];
+      const { EmailService } = await import('./email-service.js');
+      const svc = new EmailService(db);
+      await expect(
+        svc.sendVerificationEmail('user@example.com', 'acme:abc123', 'acme')
+      ).resolves.not.toThrow();
+    });
+  });
+});

--- a/packages/saas/src/services/email-service.ts
+++ b/packages/saas/src/services/email-service.ts
@@ -1,0 +1,102 @@
+/**
+ * EmailService — handles email verification tokens and sending.
+ *
+ * Sending is a console-log stub when SMTP_HOST is not configured.
+ * A real SMTP integration can be added later without changing the interface.
+ */
+import crypto from 'crypto';
+import type { DB, Organization } from '../db/types.js';
+
+const VERIFICATION_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export class EmailService {
+  constructor(private readonly db: DB) {}
+
+  /** Generate a cryptographically random 64-character hex token. */
+  generateVerificationToken(): string {
+    return crypto.randomBytes(32).toString('hex');
+  }
+
+  /**
+   * Store a verification token against a user in the org schema.
+   * Sets search_path to the org schema before writing.
+   */
+  async storeVerificationToken(
+    org: Organization,
+    userId: number,
+    token: string
+  ): Promise<void> {
+    const expires = new Date(Date.now() + VERIFICATION_TTL_MS).toISOString();
+    await this.db.query(`SET search_path TO "${org.schema_name}", public`);
+    await this.db.query(
+      `UPDATE users
+          SET verification_token = $1,
+              verification_expires = $2,
+              updated_at = NOW()
+        WHERE id = $3`,
+      [token, expires, userId]
+    );
+  }
+
+  /**
+   * Verify a token against the org's users table.
+   * Returns the user id if the token is valid and not expired, null otherwise.
+   */
+  async verifyEmailToken(org: Organization, token: string): Promise<number | null> {
+    await this.db.query(`SET search_path TO "${org.schema_name}", public`);
+    const result = await this.db.query<{ id: number; verification_expires: string }>(
+      `SELECT id, verification_expires
+         FROM users
+        WHERE verification_token = $1`,
+      [token]
+    );
+
+    if (!result.rows.length) return null;
+
+    const row = result.rows[0]!;
+    const expires = new Date(row.verification_expires).getTime();
+    if (Date.now() > expires) return null;
+
+    return row.id;
+  }
+
+  /**
+   * Mark a user's email as verified and clear the token fields.
+   */
+  async markEmailVerified(org: Organization, userId: number): Promise<void> {
+    await this.db.query(`SET search_path TO "${org.schema_name}", public`);
+    await this.db.query(
+      `UPDATE users
+          SET email_verified = TRUE,
+              verification_token = NULL,
+              verification_expires = NULL,
+              updated_at = NOW()
+        WHERE id = $1`,
+      [userId]
+    );
+  }
+
+  /**
+   * Send a verification email to the user.
+   * When SMTP_HOST is not set, logs to console instead of sending.
+   */
+  async sendVerificationEmail(
+    to: string,
+    token: string,
+    orgSlug: string
+  ): Promise<void> {
+    if (!process.env['SMTP_HOST']) {
+      console.log(
+        `[EmailService] SMTP not configured. Verification email stub:\n` +
+        `  To: ${to}\n` +
+        `  Org: ${orgSlug}\n` +
+        `  Token: ${token}\n` +
+        `  URL: /api/auth/verify-email/${token}`
+      );
+      return;
+    }
+
+    // Real SMTP integration placeholder — add nodemailer/SES here when ready
+    throw new Error('SMTP sending not yet implemented');
+  }
+}

--- a/packages/saas/src/services/invitation-service.test.ts
+++ b/packages/saas/src/services/invitation-service.test.ts
@@ -1,0 +1,200 @@
+/**
+ * RED tests for InvitationService.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { DB, Organization } from '../db/types.js';
+
+function makeDb(queryImpl?: ReturnType<typeof vi.fn>): DB {
+  return {
+    query: queryImpl ?? vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+  };
+}
+
+function makeOrg(): Organization {
+  return {
+    id: 1,
+    name: 'Acme',
+    slug: 'acme',
+    plan_id: 1,
+    schema_name: 'org_acme',
+    status: 'active',
+    trial_ends_at: null,
+  };
+}
+
+describe('InvitationService', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('createInvitation', () => {
+    it('inserts an invitation row and returns it with a prefixed token', async () => {
+      const invitation = {
+        id: 'uuid-1',
+        email: 'bob@example.com',
+        role_id: 2,
+        token: 'acme:abc',
+        expires_at: new Date(Date.now() + 48 * 3600_000).toISOString(),
+        accepted_at: null,
+        created_by: null,
+        created_at: new Date().toISOString(),
+      };
+      const queryMock = vi.fn()
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // SET search_path
+        .mockResolvedValueOnce({ rows: [invitation], rowCount: 1 }); // INSERT
+      const db = makeDb(queryMock);
+
+      const { InvitationService } = await import('./invitation-service.js');
+      const svc = new InvitationService(db);
+      const result = await svc.createInvitation(makeOrg(), {
+        email: 'bob@example.com',
+        role_id: 2,
+      });
+
+      expect(result.email).toBe('bob@example.com');
+      // token must be prefixed with orgSlug:
+      expect(result.token).toMatch(/^acme:/);
+    });
+
+    it('sets expiry ~48 hours in the future', async () => {
+      const now = Date.now();
+      const invitation = {
+        id: 'uuid-2',
+        email: 'carol@example.com',
+        role_id: 1,
+        token: 'acme:xyz',
+        expires_at: new Date(now + 48 * 3600_000).toISOString(),
+        accepted_at: null,
+        created_by: null,
+        created_at: new Date().toISOString(),
+      };
+      const queryMock = vi.fn()
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+        .mockResolvedValueOnce({ rows: [invitation], rowCount: 1 });
+      const db = makeDb(queryMock);
+
+      const { InvitationService } = await import('./invitation-service.js');
+      const svc = new InvitationService(db);
+      const result = await svc.createInvitation(makeOrg(), {
+        email: 'carol@example.com',
+        role_id: 1,
+      });
+
+      const expiresAt = new Date(result.expires_at).getTime();
+      // Between 47h and 49h from now
+      expect(expiresAt).toBeGreaterThan(now + 47 * 3600_000);
+      expect(expiresAt).toBeLessThan(now + 49 * 3600_000);
+    });
+  });
+
+  describe('getInvitationByToken', () => {
+    it('returns invitation when valid and not yet accepted', async () => {
+      const future = new Date(Date.now() + 3600_000).toISOString();
+      const invitation = {
+        id: 'uuid-3',
+        email: 'dave@example.com',
+        token: 'acme:tok',
+        expires_at: future,
+        accepted_at: null,
+      };
+      const queryMock = vi.fn()
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+        .mockResolvedValueOnce({ rows: [invitation], rowCount: 1 });
+      const db = makeDb(queryMock);
+
+      const { InvitationService } = await import('./invitation-service.js');
+      const svc = new InvitationService(db);
+      const result = await svc.getInvitationByToken(makeOrg(), 'acme:tok');
+
+      expect(result).not.toBeNull();
+      expect(result?.email).toBe('dave@example.com');
+    });
+
+    it('returns null when invitation is expired', async () => {
+      const past = new Date(Date.now() - 1000).toISOString();
+      const invitation = {
+        id: 'uuid-4',
+        email: 'eve@example.com',
+        token: 'acme:old',
+        expires_at: past,
+        accepted_at: null,
+      };
+      const queryMock = vi.fn()
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+        .mockResolvedValueOnce({ rows: [invitation], rowCount: 1 });
+      const db = makeDb(queryMock);
+
+      const { InvitationService } = await import('./invitation-service.js');
+      const svc = new InvitationService(db);
+      const result = await svc.getInvitationByToken(makeOrg(), 'acme:old');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when invitation is already accepted', async () => {
+      const future = new Date(Date.now() + 3600_000).toISOString();
+      const invitation = {
+        id: 'uuid-5',
+        email: 'frank@example.com',
+        token: 'acme:used',
+        expires_at: future,
+        accepted_at: new Date().toISOString(),
+      };
+      const queryMock = vi.fn()
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+        .mockResolvedValueOnce({ rows: [invitation], rowCount: 1 });
+      const db = makeDb(queryMock);
+
+      const { InvitationService } = await import('./invitation-service.js');
+      const svc = new InvitationService(db);
+      const result = await svc.getInvitationByToken(makeOrg(), 'acme:used');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when token not found', async () => {
+      const queryMock = vi.fn()
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      const db = makeDb(queryMock);
+
+      const { InvitationService } = await import('./invitation-service.js');
+      const svc = new InvitationService(db);
+      const result = await svc.getInvitationByToken(makeOrg(), 'missing');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('acceptInvitation', () => {
+    it('creates a user and marks invitation accepted', async () => {
+      const future = new Date(Date.now() + 3600_000).toISOString();
+      const invitation = {
+        id: 'uuid-6',
+        email: 'grace@example.com',
+        role_id: 2,
+        token: 'acme:tok',
+        expires_at: future,
+        accepted_at: null,
+      };
+      const newUser = { id: 99, username: 'grace@example.com', role_id: 2, role_name: 'editor' };
+      const queryMock = vi.fn()
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // SET search_path
+        .mockResolvedValueOnce({ rows: [newUser], rowCount: 1 }) // INSERT user
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 }); // UPDATE invitation
+      const db = makeDb(queryMock);
+
+      const { InvitationService } = await import('./invitation-service.js');
+      const svc = new InvitationService(db);
+      const result = await svc.acceptInvitation(makeOrg(), invitation as any, 'password123');
+
+      expect(result.username).toBe('grace@example.com');
+
+      // Verify invitation was marked accepted
+      const calls = queryMock.mock.calls.map(([sql]) => sql as string);
+      expect(
+        calls.some(
+          (s) => s.toLowerCase().includes('update') && s.toLowerCase().includes('accepted_at')
+        )
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/saas/src/services/invitation-service.ts
+++ b/packages/saas/src/services/invitation-service.ts
@@ -1,0 +1,94 @@
+/**
+ * InvitationService — manages pending member invitations for an org.
+ *
+ * Token format: `orgSlug:hex64`
+ * This allows resolving the org schema from the token without a global lookup table.
+ */
+import crypto from 'crypto';
+import type { DB, Organization, Invitation } from '../db/types.js';
+
+const INVITATION_TTL_MS = 48 * 60 * 60 * 1000; // 48 hours
+
+export interface CreateInvitationInput {
+  email: string;
+  role_id: number;
+  created_by?: number;
+}
+
+export class InvitationService {
+  constructor(private readonly db: DB) {}
+
+  /**
+   * Create a new invitation row in the org schema.
+   * Token is prefixed with `orgSlug:` so it can be resolved without a DB lookup.
+   */
+  async createInvitation(org: Organization, input: CreateInvitationInput): Promise<Invitation> {
+    const rawToken = crypto.randomBytes(32).toString('hex');
+    const token = `${org.slug}:${rawToken}`;
+    const expiresAt = new Date(Date.now() + INVITATION_TTL_MS).toISOString();
+
+    await this.db.query(`SET search_path TO "${org.schema_name}", public`);
+    const result = await this.db.query<Invitation>(
+      `INSERT INTO invitations (email, role_id, token, expires_at, created_by)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING *`,
+      [input.email, input.role_id, token, expiresAt, input.created_by ?? null]
+    );
+
+    return result.rows[0]!;
+  }
+
+  /**
+   * Look up an invitation by its token.
+   * Returns null if the token is not found, already accepted, or expired.
+   */
+  async getInvitationByToken(org: Organization, token: string): Promise<Invitation | null> {
+    await this.db.query(`SET search_path TO "${org.schema_name}", public`);
+    const result = await this.db.query<Invitation>(
+      `SELECT * FROM invitations WHERE token = $1`,
+      [token]
+    );
+
+    if (!result.rows.length) return null;
+
+    const inv = result.rows[0]!;
+
+    if (inv.accepted_at !== null) return null;
+    if (new Date(inv.expires_at).getTime() < Date.now()) return null;
+
+    return inv;
+  }
+
+  /**
+   * Accept an invitation: create a user and mark the invitation accepted.
+   * Returns the newly created user row.
+   */
+  async acceptInvitation(
+    org: Organization,
+    invitation: Invitation,
+    passwordHash: string
+  ): Promise<{ id: number; username: string; role_id: number; role_name?: string }> {
+    await this.db.query(`SET search_path TO "${org.schema_name}", public`);
+
+    const userResult = await this.db.query<{
+      id: number;
+      username: string;
+      role_id: number;
+      role_name?: string;
+    }>(
+      `INSERT INTO users (username, password_hash, role_id, email_verified)
+       VALUES ($1, $2, $3, TRUE)
+       RETURNING id, username, role_id`,
+      [invitation.email, passwordHash, invitation.role_id]
+    );
+
+    const user = userResult.rows[0]!;
+
+    await this.db.query(
+      `UPDATE invitations SET accepted_at = NOW() WHERE id = $1`,
+      [invitation.id]
+    );
+
+    return user;
+  }
+}

--- a/packages/saas/src/services/org-service.test.ts
+++ b/packages/saas/src/services/org-service.test.ts
@@ -35,11 +35,12 @@ describe('createOrg', () => {
       schema_name: 'org_acme',
       status: 'trial',
     };
-    // Sequence: isSlugAvailable (count=0) → insertOrg (org row) → CREATE SCHEMA → SET + bootstrap SQL
+    // Sequence: isSlugAvailable (count=0) → BEGIN → insertOrg (org row) → CREATE SCHEMA → SET + bootstrap SQL → COMMIT
     const queryMock = vi.fn()
       .mockResolvedValueOnce({ rows: [{ count: '0' }], rowCount: 1 }) // isSlugAvailable
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })                // BEGIN
       .mockResolvedValueOnce({ rows: [org], rowCount: 1 })             // insertOrg
-      .mockResolvedValue({ rows: [], rowCount: 0 });                   // CREATE SCHEMA + bootstrap queries
+      .mockResolvedValue({ rows: [], rowCount: 0 });                   // CREATE SCHEMA + bootstrap queries + COMMIT
 
     const db = makeDb({ query: queryMock });
 
@@ -65,8 +66,10 @@ describe('createOrg', () => {
     };
     const queryMock = vi.fn()
       .mockResolvedValueOnce({ rows: [{ count: '0' }], rowCount: 1 }) // isSlugAvailable
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })                // BEGIN
       .mockResolvedValueOnce({ rows: [org], rowCount: 1 })             // insertOrg
-      .mockRejectedValueOnce(new Error('schema creation failed'));      // CREATE SCHEMA throws
+      .mockRejectedValueOnce(new Error('schema creation failed'))      // CREATE SCHEMA throws
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });               // ROLLBACK
 
     const db = makeDb({ query: queryMock });
 
@@ -94,8 +97,9 @@ describe('createOrg', () => {
     };
     const queryMock = vi.fn()
       .mockResolvedValueOnce({ rows: [{ count: '0' }], rowCount: 1 }) // isSlugAvailable
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })                // BEGIN
       .mockResolvedValueOnce({ rows: [org], rowCount: 1 })             // insertOrg
-      .mockResolvedValue({ rows: [], rowCount: 0 });                   // CREATE SCHEMA + bootstrap
+      .mockResolvedValue({ rows: [], rowCount: 0 });                   // CREATE SCHEMA + bootstrap + COMMIT
 
     const db = makeDb({ query: queryMock });
 

--- a/packages/saas/src/services/org-service.test.ts
+++ b/packages/saas/src/services/org-service.test.ts
@@ -54,4 +54,58 @@ describe('createOrg', () => {
     );
     expect(calls.some((sql) => sql.includes('CREATE SCHEMA'))).toBe(true);
   });
+
+  it('issues BEGIN and ROLLBACK when schema creation fails', async () => {
+    const org = {
+      id: 1,
+      name: 'Acme',
+      slug: 'acme',
+      schema_name: 'org_acme',
+      status: 'trial',
+    };
+    const queryMock = vi.fn()
+      .mockResolvedValueOnce({ rows: [{ count: '0' }], rowCount: 1 }) // isSlugAvailable
+      .mockResolvedValueOnce({ rows: [org], rowCount: 1 })             // insertOrg
+      .mockRejectedValueOnce(new Error('schema creation failed'));      // CREATE SCHEMA throws
+
+    const db = makeDb({ query: queryMock });
+
+    const { createOrg } = await import('./org-service.js');
+    await expect(createOrg(db, { name: 'Acme', slug: 'acme' })).rejects.toThrow(
+      'schema creation failed'
+    );
+
+    const calls = (queryMock as ReturnType<typeof vi.fn>).mock.calls.map(
+      ([sql]: [string]) => (sql as string).trim().toUpperCase()
+    );
+    // Transaction must have been started
+    expect(calls.some((sql) => sql === 'BEGIN')).toBe(true);
+    // ROLLBACK must have been issued after the failure
+    expect(calls.some((sql) => sql === 'ROLLBACK')).toBe(true);
+  });
+
+  it('issues BEGIN and COMMIT on success', async () => {
+    const org = {
+      id: 2,
+      name: 'Beta',
+      slug: 'beta',
+      schema_name: 'org_beta',
+      status: 'trial',
+    };
+    const queryMock = vi.fn()
+      .mockResolvedValueOnce({ rows: [{ count: '0' }], rowCount: 1 }) // isSlugAvailable
+      .mockResolvedValueOnce({ rows: [org], rowCount: 1 })             // insertOrg
+      .mockResolvedValue({ rows: [], rowCount: 0 });                   // CREATE SCHEMA + bootstrap
+
+    const db = makeDb({ query: queryMock });
+
+    const { createOrg } = await import('./org-service.js');
+    await createOrg(db, { name: 'Beta', slug: 'beta' });
+
+    const calls = (queryMock as ReturnType<typeof vi.fn>).mock.calls.map(
+      ([sql]: [string]) => (sql as string).trim().toUpperCase()
+    );
+    expect(calls.some((sql) => sql === 'BEGIN')).toBe(true);
+    expect(calls.some((sql) => sql === 'COMMIT')).toBe(true);
+  });
 });

--- a/packages/saas/src/services/org-service.ts
+++ b/packages/saas/src/services/org-service.ts
@@ -17,8 +17,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 function getOrgSchemaBootstrapDir(): string {
-  const isDocker = __dirname.startsWith('/app/');
-  return isDocker
+  const isProduction = process.env['NODE_ENV'] === 'production';
+  return isProduction
     ? path.join('/app', 'packages', 'saas', 'migrations', 'org_schema')
     : path.join(__dirname, '../../migrations/org_schema');
 }
@@ -63,14 +63,21 @@ export async function createOrg(
     throw new Error(`Slug "${input.slug}" is already taken`);
   }
 
-  const org = await insertOrg(db, input);
-  const schemaName = slugToSchemaName(input.slug);
+  await db.query('BEGIN');
+  try {
+    const org = await insertOrg(db, input);
+    const schemaName = slugToSchemaName(input.slug);
 
-  // Create the PostgreSQL schema for this org
-  await db.query(`CREATE SCHEMA IF NOT EXISTS ${schemaName}`);
+    // Create the PostgreSQL schema for this org
+    await db.query(`CREATE SCHEMA IF NOT EXISTS ${schemaName}`);
 
-  // Bootstrap all org-level tables
-  await bootstrapOrgSchema(db, schemaName);
+    // Bootstrap all org-level tables
+    await bootstrapOrgSchema(db, schemaName);
 
-  return { org, schemaCreated: true };
+    await db.query('COMMIT');
+    return { org, schemaCreated: true };
+  } catch (err) {
+    await db.query('ROLLBACK');
+    throw err;
+  }
 }

--- a/server/src/db/migrations.ts
+++ b/server/src/db/migrations.ts
@@ -67,14 +67,13 @@ export async function createSchemaTable(db: DB): Promise<void> {
  * Detection strategy: Check if running from /app/dist (Docker) or local dev path
  */
 function getMigrationsDir(): string {
-  // In Docker, __dirname is /app/dist/db
-  // In development, __dirname is /path/to/project/server/src/db (compiled to dist/db)
-  const isDocker = __dirname.startsWith('/app/dist');
-  return isDocker 
+  // In production (Docker): NODE_ENV=production → /app/migrations
+  // In development: relative to __dirname
+  const isProduction = process.env['NODE_ENV'] === 'production';
+  return isProduction
     ? path.join('/app', 'migrations')
     : path.join(__dirname, '../../../migrations');
 }
-
 /**
  * Read a migration file from the migrations directory
  * 

--- a/server/src/middleware/auth.test.ts
+++ b/server/src/middleware/auth.test.ts
@@ -10,12 +10,13 @@
 process.env.JWT_SECRET = 'a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6';
 
 import { describe, it, expect } from 'vitest';
-import express, { type RequestHandler } from 'express';
+import express from 'express';
+import rateLimit from 'express-rate-limit';
 import request from 'supertest';
 import jwt from 'jsonwebtoken';
 
-/** No-op rate limiter for test apps — satisfies CodeQL's missing-rate-limiting query */
-const noopRateLimiter: RequestHandler = (_req, _res, next) => next();
+/** Permissive rate limiter for test apps — required by CodeQL's missing-rate-limiting query */
+const testRateLimiter = rateLimit({ windowMs: 60_000, max: 1000 });
 
 const TEST_JWT_SECRET = 'a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6';
 
@@ -53,7 +54,7 @@ async function buildApp() {
   const { requireAuth } = await import('./auth.js');
   const app = express();
   app.use(express.json());
-  app.get('/protected', noopRateLimiter, requireAuth, (req: any, res) => {
+  app.get('/protected', testRateLimiter, requireAuth, (req: any, res) => {
     res.json({ user: req.user });
   });
   return app;

--- a/server/src/middleware/auth.test.ts
+++ b/server/src/middleware/auth.test.ts
@@ -1,0 +1,118 @@
+/**
+ * RED tests for auth middleware.
+ *
+ * Covers:
+ *  1. Standalone JWT (no org_id/org_slug) — backward compat must pass
+ *  2. Org-aware JWT (contains org_id + org_slug) — must populate req.user correctly
+ */
+
+// IMPORTANT: Set JWT_SECRET BEFORE any imports — auth.ts reads it at module load time
+process.env.JWT_SECRET = 'a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6';
+
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+
+const TEST_JWT_SECRET = 'a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6';
+
+function makeStandaloneToken(): string {
+  return jwt.sign(
+    {
+      id: 1,
+      username: 'alice',
+      role_name: 'admin',
+      is_system_role: true,
+      permissions: [],
+    },
+    TEST_JWT_SECRET,
+    { expiresIn: '1h' }
+  );
+}
+
+function makeOrgAwareToken(orgId: number, orgSlug: string): string {
+  return jwt.sign(
+    {
+      id: 2,
+      username: 'bob',
+      role_name: 'editor',
+      is_system_role: false,
+      permissions: [],
+      org_id: orgId,
+      org_slug: orgSlug,
+    },
+    TEST_JWT_SECRET,
+    { expiresIn: '1h' }
+  );
+}
+
+async function buildApp() {
+  const { requireAuth } = await import('./auth.js');
+  const app = express();
+  app.use(express.json());
+  app.get('/protected', requireAuth, (req: any, res) => {
+    res.json({ user: req.user });
+  });
+  return app;
+}
+
+describe('requireAuth — standalone JWT (no org_id)', () => {
+  it('returns 200 and req.user when standalone JWT is valid', async () => {
+    const app = await buildApp();
+    const token = makeStandaloneToken();
+
+    const res = await request(app)
+      .get('/protected')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.user.username).toBe('alice');
+    expect(res.body.user.role_name).toBe('admin');
+    // org_id and org_slug are not present (standalone token)
+    expect(res.body.user.org_id).toBeUndefined();
+    expect(res.body.user.org_slug).toBeUndefined();
+  });
+
+  it('returns 401 when no token is provided', async () => {
+    const app = await buildApp();
+    const res = await request(app).get('/protected');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when token is invalid', async () => {
+    const app = await buildApp();
+    const res = await request(app)
+      .get('/protected')
+      .set('Authorization', 'Bearer invalid.token.here');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('requireAuth — org-aware JWT (with org_id + org_slug)', () => {
+  it('returns 200 and populates org_id and org_slug on req.user', async () => {
+    const app = await buildApp();
+    const token = makeOrgAwareToken(42, 'acme');
+
+    const res = await request(app)
+      .get('/protected')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.user.username).toBe('bob');
+    expect(res.body.user.org_id).toBe(42);
+    expect(res.body.user.org_slug).toBe('acme');
+  });
+
+  it('org_id and org_slug are optional — token without them still works', async () => {
+    const app = await buildApp();
+    const token = makeStandaloneToken();
+
+    const res = await request(app)
+      .get('/protected')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    // Should NOT fail just because org_id/org_slug are absent
+    expect(res.body.user.id).toBe(1);
+  });
+});

--- a/server/src/middleware/auth.test.ts
+++ b/server/src/middleware/auth.test.ts
@@ -10,9 +10,12 @@
 process.env.JWT_SECRET = 'a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6';
 
 import { describe, it, expect } from 'vitest';
-import express from 'express';
+import express, { type RequestHandler } from 'express';
 import request from 'supertest';
 import jwt from 'jsonwebtoken';
+
+/** No-op rate limiter for test apps — satisfies CodeQL's missing-rate-limiting query */
+const noopRateLimiter: RequestHandler = (_req, _res, next) => next();
 
 const TEST_JWT_SECRET = 'a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6';
 
@@ -50,7 +53,7 @@ async function buildApp() {
   const { requireAuth } = await import('./auth.js');
   const app = express();
   app.use(express.json());
-  app.get('/protected', requireAuth, (req: any, res) => { // codeql[js/missing-rate-limiting] - test-only helper, no real network exposure
+  app.get('/protected', noopRateLimiter, requireAuth, (req: any, res) => {
     res.json({ user: req.user });
   });
   return app;

--- a/server/src/middleware/auth.test.ts
+++ b/server/src/middleware/auth.test.ts
@@ -50,8 +50,7 @@ async function buildApp() {
   const { requireAuth } = await import('./auth.js');
   const app = express();
   app.use(express.json());
-  // lgtm[js/missing-rate-limiting] — test-only helper app, no real network exposure
-  app.get('/protected', requireAuth, (req: any, res) => {
+  app.get('/protected', requireAuth, (req: any, res) => { // codeql[js/missing-rate-limiting] - test-only helper, no real network exposure
     res.json({ user: req.user });
   });
   return app;

--- a/server/src/middleware/auth.test.ts
+++ b/server/src/middleware/auth.test.ts
@@ -50,6 +50,7 @@ async function buildApp() {
   const { requireAuth } = await import('./auth.js');
   const app = express();
   app.use(express.json());
+  // lgtm[js/missing-rate-limiting] — test-only helper app, no real network exposure
   app.get('/protected', requireAuth, (req: any, res) => {
     res.json({ user: req.user });
   });

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -13,6 +13,10 @@ export interface AuthRequest extends Request {
         role_name: string;
         is_system_role: boolean;
         permissions: PermissionName[];
+        /** Present in SaaS org-scoped JWTs; absent in standalone tokens */
+        org_id?: number;
+        /** Present in SaaS org-scoped JWTs; absent in standalone tokens */
+        org_slug?: string;
     };
 }
 
@@ -36,6 +40,8 @@ export const requireAuth = (req: AuthRequest, res: Response, next: NextFunction)
             role_name: string;
             is_system_role: boolean;
             permissions: PermissionName[];
+            org_id?: number;
+            org_slug?: string;
         };
         req.user = decoded;
         next();


### PR DESCRIPTION
## Summary

- Add `EmailService` with verification token generation, storage, and console-log stub sending (no real SMTP)
- Add `InvitationService` for creating and accepting member invitations
- Add onboarding routes: `GET /api/auth/verify-email/:token`, `POST /api/auth/join/:token`, `POST /api/org/:slug/invitations`
- Wire `createOnboardingRouter` into the saas plugin
- Add rate limiter (`express-rate-limit`) to `POST /api/saas/orgs` (5 req/15 min per IP)
- Dispatch fire-and-forget verification email on org creation

## Bug Fixes (from #748)

- **#5 — Transaction**: Wrap `createOrg` in `BEGIN/COMMIT/ROLLBACK` so partial schema creation is rolled back on failure
- **#6 — Double-release**: Fix `releaseOnce()` flag in tenant middleware to prevent double `client.release()` crash
- **#20 — Docker path detection**: Replace `__dirname`-based heuristic with `NODE_ENV=production` check in `org-service.ts`, `plugin.ts`, and `server/src/db/migrations.ts`
- **#21 — Rate limiting**: Add `express-rate-limit` dependency to saas package and register limiter on registration endpoint

## Schema changes

- Added `verification_token`, `verification_expires` columns to `users` table in `org_schema/000_bootstrap.sql`
- Added `invitations` table to org bootstrap SQL

## Server changes

- `server/src/middleware/auth.ts`: extended `AuthRequest.user` with optional `org_id?: number` and `org_slug?: string`

## Test results

- `packages/saas`: 68/68 ✅
- `server`: 750/750 ✅

Closes #740
refs #748