### PR TITLE
⚡ Bolt: [performance improvement] Optimize ScrapeProgress render loop array passes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -36,3 +36,6 @@
 ## 2024-04-01 - Eliminate N+1 Bottleneck in `getAllRoles`
 **Learning:** `Promise.all` combined with multiple parallel `.map` DB query fetches is a persistent N+1 anti-pattern in database abstraction layers. While asynchronous, this still saturates connection pools and creates unnecessary linear DB requests, adding significant overhead when fetching lists (e.g. roles and their associated permissions).
 **Action:** Replace `Promise.all` loops with a single secondary query using `ANY($1)` on an array of parent IDs, then group the related child records in memory using standard objects/Maps.
+## 2026-04-06 - [Optimize Multiple Array Passes in Render Loops]
+**Learning:** Found that deriving component state by using multiple passes over the same array with `.filter().length` and `.find()` is highly inefficient for potentially large arrays in components that re-render frequently (like `ScrapeProgress`). This forces multiple full iterations and array allocations on every render.
+**Action:** When deriving multiple state values from a single list of events or objects, combine the logic into a single `for` loop to avoid creating intermediate arrays and drastically reduce the number of iterations over the data.

--- a/client/src/components/ScrapeButton.test.tsx
+++ b/client/src/components/ScrapeButton.test.tsx
@@ -61,12 +61,13 @@ describe('ScrapeButton', () => {
   });
 
   it('should handle 409 Conflict by calling onScrapeStart (resuming)', async () => {
-    const error = {
+    const error = new Error('Already running');
+    Object.assign(error, {
       response: {
         status: 409,
         data: { error: 'Already running' }
       }
-    };
+    });
     mockOnTrigger.mockRejectedValue(error);
     const onScrapeStart = vi.fn();
 
@@ -83,12 +84,13 @@ describe('ScrapeButton', () => {
   });
 
   it('should show error message for other errors', async () => {
-    const error = {
+    const error = new Error('Server exploded');
+    Object.assign(error, {
       response: {
         status: 500,
         data: { error: 'Server exploded' }
       }
-    };
+    });
     mockOnTrigger.mockRejectedValue(error);
 
     renderWithAuth(<ScrapeButton onTrigger={mockOnTrigger} />);

--- a/client/src/components/ScrapeProgress.tsx
+++ b/client/src/components/ScrapeProgress.tsx
@@ -1,5 +1,4 @@
 import { useScrapeProgress } from '../hooks/useScrapeProgress';
-import type { ProgressEvent } from '../types';
 
 export interface ScrapeProgressProps {
   onComplete?: (success: boolean) => void;
@@ -21,16 +20,24 @@ export default function ScrapeProgress({ onComplete }: ScrapeProgressProps = {})
     );
   }
 
-  // Derive state from events
-  const startedEvent = events.find((e): e is Extract<ProgressEvent, { type: 'started' }> => e.type === 'started');
-  const cinemaCompletedEvents = events.filter((e): e is Extract<ProgressEvent, { type: 'cinema_completed' }> => e.type === 'cinema_completed');
-  const filmStartedEvents = events.filter((e): e is Extract<ProgressEvent, { type: 'film_started' }> => e.type === 'film_started');
-  const filmCompletedEvents = events.filter((e): e is Extract<ProgressEvent, { type: 'film_completed' }> => e.type === 'film_completed');
+  // ⚡ PERFORMANCE: Derive state in a single pass over events instead of multiple `.filter().length` and `.find()` passes
+  let totalCinemas = 0;
+  let processedCinemas = 0;
+  let totalFilms = 0;
+  let processedFilms = 0;
 
-  const totalCinemas = startedEvent?.total_cinemas || 0;
-  const processedCinemas = cinemaCompletedEvents.length;
-  const totalFilms = filmStartedEvents.length;
-  const processedFilms = filmCompletedEvents.length;
+  for (let i = 0; i < events.length; i++) {
+    const e = events[i];
+    if (e.type === 'started') {
+      totalCinemas = e.total_cinemas || 0;
+    } else if (e.type === 'cinema_completed') {
+      processedCinemas++;
+    } else if (e.type === 'film_started') {
+      totalFilms++;
+    } else if (e.type === 'film_completed') {
+      processedFilms++;
+    }
+  }
 
   // Get current cinema/film from latest event
   const currentCinema = latestEvent?.type === 'cinema_started' || latestEvent?.type === 'date_started' 

--- a/client/src/pages/admin/AdminPage.test.tsx
+++ b/client/src/pages/admin/AdminPage.test.tsx
@@ -235,17 +235,19 @@ describe('AdminPage', () => {
   });
 
   describe('Tab order (admin)', () => {
-    it('should display all 6 tabs in correct order for admin: Cinemas, Rapports, Users, Roles, Settings, System', () => {
+    it('should display all tabs in correct order for admin', () => {
       renderWithRouter('/admin');
 
       const tabs = screen.getAllByRole('tab');
 
       expect(tabs[0]).toHaveTextContent('Cinemas');
-      expect(tabs[1]).toHaveTextContent('Rapports');
-      expect(tabs[2]).toHaveTextContent('Users');
-      expect(tabs[3]).toHaveTextContent('Roles');
-      expect(tabs[4]).toHaveTextContent('Settings');
-      expect(tabs[5]).toHaveTextContent('System');
+      expect(tabs[1]).toHaveTextContent('Schedules');
+      expect(tabs[2]).toHaveTextContent('Rapports');
+      expect(tabs[3]).toHaveTextContent('Users');
+      expect(tabs[4]).toHaveTextContent('Roles');
+      expect(tabs[5]).toHaveTextContent('Settings');
+      expect(tabs[6]).toHaveTextContent('Rate Limits');
+      expect(tabs[7]).toHaveTextContent('System');
     });
   });
 


### PR DESCRIPTION
💡 **What**: Replaced four separate array iteration passes (`.find()`, `.filter()`, `.filter()`, `.filter()`) in `ScrapeProgress.tsx` with a single, unified `for` loop to compute progress events. Fixed related pre-existing broken tests in `ScrapeButton.test.tsx` and `AdminPage.test.tsx`.
🎯 **Why**: `ScrapeProgress` component re-renders frequently as new events arrive via SSE. Filtering and searching the `events` array four times on every render creates unnecessary CPU overhead and memory allocation (garbage collection pressure).
📊 **Impact**: Reduces array iterations from $O(4N)$ to $O(N)$ during every render of the progress component, eliminating intermediate array allocation.
🔬 **Measurement**: Verify by running `npm run test -w client` and ensuring `ScrapeProgress.test.tsx` passes, confirming no state calculation regressions.

---
*PR created automatically by Jules for task [10195517265343236398](https://jules.google.com/task/10195517265343236398) started by @PhBassin*