### PR TITLE
⚡ Bolt: [performance improvement] Optimize array transformations in theater-json-parser.ts

### DIFF
--- a/scraper/src/scraper/theater-json-parser.ts
+++ b/scraper/src/scraper/theater-json-parser.ts
@@ -96,7 +96,11 @@ function extractMovieId(movie: AllocineMovie): number | null {
 }
 
 function uniqueNonEmptyStrings(values: string[]): string[] {
-  return Array.from(new Set(values.map(v => v.trim()).filter(Boolean)));
+  return Array.from(new Set(values.reduce<string[]>((acc, v) => {
+    const trimmed = v.trim();
+    if (trimmed) acc.push(trimmed);
+    return acc;
+  }, [])));
 }
 
 /**
@@ -273,8 +277,16 @@ export function parseShowtimesJson(
       }
     }
 
-    const genres = decodeHtmlEntitiesArray((movie.genres ?? []).map(g => g.translate ?? '').filter(Boolean));
-    const nationalityRaw = (movie.countries ?? []).map(c => c.localizedName ?? '').filter(Boolean).join(', ') || undefined;
+    const genres = decodeHtmlEntitiesArray((movie.genres ?? []).reduce<string[]>((acc, g) => {
+      const translated = g.translate ?? '';
+      if (translated) acc.push(translated);
+      return acc;
+    }, []));
+    const nationalityRaw = (movie.countries ?? []).reduce<string[]>((acc, c) => {
+      const localizedName = c.localizedName ?? '';
+      if (localizedName) acc.push(localizedName);
+      return acc;
+    }, []).join(', ') || undefined;
     const nationality = decodeHtmlEntities(nationalityRaw);
     
     // Ratings (out of 5) - sanitize to filter NaN/Infinity


### PR DESCRIPTION
🎯 **What**
Replaced chained `.map().filter()` operations with `.reduce()` in `uniqueNonEmptyStrings` and the extraction of `genres` and `nationalityRaw` within `scraper/src/scraper/theater-json-parser.ts`.

💡 **Why**
Chaining `.map().filter()` creates unnecessary intermediate arrays, increasing memory allocation and garbage collection overhead. This is a known performance anti-pattern within this codebase, especially when processing large datasets or in hot loops. By computing the result in one pass, we avoid allocating unused intermediate objects.

📊 **Impact**
Eliminates three intermediate array allocations per parsed movie in the scraper's internal API parsing logic. This reduces the scraper's memory footprint and garbage collection pressure, marginally improving throughput when processing large batches of cinema data.

🔬 **Measurement**
The impact can be verified by running the scraper's test suite and observing no regressions in functionality. Memory profiling during a large scraping job would show fewer array allocations.

---
*PR created automatically by Jules for task [10932505383945066406](https://jules.google.com/task/10932505383945066406) started by @PhBassin*