### PR TITLE
⚡ Bolt: [performance improvement] Optimize ScrapeProgress array iterations

### DIFF
--- a/client/src/components/ScrapeProgress.tsx
+++ b/client/src/components/ScrapeProgress.tsx
@@ -23,14 +23,25 @@ export default function ScrapeProgress({ onComplete }: ScrapeProgressProps = {})
 
   // Derive state from events
   const startedEvent = events.find((e): e is Extract<ProgressEvent, { type: 'started' }> => e.type === 'started');
-  const cinemaCompletedEvents = events.filter((e): e is Extract<ProgressEvent, { type: 'cinema_completed' }> => e.type === 'cinema_completed');
-  const filmStartedEvents = events.filter((e): e is Extract<ProgressEvent, { type: 'film_started' }> => e.type === 'film_started');
-  const filmCompletedEvents = events.filter((e): e is Extract<ProgressEvent, { type: 'film_completed' }> => e.type === 'film_completed');
+
+  // ⚡ PERFORMANCE: Use a single pass iteration to compute counts instead of multiple
+  // .filter().length calls to avoid allocating intermediate arrays and O(M*N) operations
+  let processedCinemas = 0;
+  let totalFilms = 0;
+  let processedFilms = 0;
+
+  for (let i = 0; i < events.length; i++) {
+    const type = events[i].type;
+    if (type === 'cinema_completed') {
+      processedCinemas++;
+    } else if (type === 'film_started') {
+      totalFilms++;
+    } else if (type === 'film_completed') {
+      processedFilms++;
+    }
+  }
 
   const totalCinemas = startedEvent?.total_cinemas || 0;
-  const processedCinemas = cinemaCompletedEvents.length;
-  const totalFilms = filmStartedEvents.length;
-  const processedFilms = filmCompletedEvents.length;
 
   // Get current cinema/film from latest event
   const currentCinema = latestEvent?.type === 'cinema_started' || latestEvent?.type === 'date_started' 


### PR DESCRIPTION
💡 **What:** 
Replaced three separate `.filter().length` passes over the `events` array in `ScrapeProgress.tsx` with a single `for` loop that increments counter variables (`processedCinemas`, `totalFilms`, `processedFilms`).

🎯 **Why:** 
Calling `.filter()` creates a new intermediate array in memory. When updating progress, the component was iterating through all events three times and creating three throw-away arrays on every single render update just to count elements. This change reduces the time complexity from $O(3N)$ to $O(N)$ and completely eliminates the intermediate array memory allocations.

📊 **Impact:** 
Reduces memory allocation overhead and improves rendering speed for the progress bar, especially when the `events` array grows large during long-running scraping tasks.

🔬 **Measurement:** 
Run `npm run test:run -- ScrapeProgress` in the `client` directory to verify the component renders and updates progress accurately. No functional changes were made, only an optimization of the counting logic.

---
*PR created automatically by Jules for task [2810040937424588311](https://jules.google.com/task/2810040937424588311) started by @PhBassin*