### PR TITLE
feat(saas): filter sensitive fields in org-export

### DIFF
--- a/packages/saas/src/routes/org-export.test.ts
+++ b/packages/saas/src/routes/org-export.test.ts
@@ -105,6 +105,49 @@ describe('Org Export Routes', () => {
       expect(response.body.data.cinemas).toHaveLength(2);
     });
 
+    it('should NOT leak sensitive organization fields', async () => {
+      const token = jwt.sign(
+        { id: 'user-1', org_id: 1, org_slug: 'test-org', permissions: ['export_data'] },
+        jwtSecret
+      );
+
+      // Mock org data with sensitive fields
+      vi.mocked(mockDb.query).mockResolvedValueOnce({
+        rows: [{
+          id: 1,
+          name: 'Test Org',
+          slug: 'test-org',
+          plan_id: 1,
+          status: 'active',
+          created_at: new Date('2026-01-01'),
+          stripe_subscription_id: 'sub_12345',
+          internal_notes: 'Highly secret notes',
+          private_metadata: { key: 'secret' }
+        }],
+        rowCount: 1,
+      });
+
+      // Mock other data
+      vi.mocked(mockClient.query).mockResolvedValue({ rows: [] } as any);
+
+      const response = await request(app)
+        .get('/export')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(200);
+      const org = response.body.data.org;
+      
+      // Allowed fields
+      expect(org).toHaveProperty('id');
+      expect(org).toHaveProperty('name');
+      expect(org).toHaveProperty('slug');
+      
+      // Sensitive fields should NOT be present
+      expect(org).not.toHaveProperty('stripe_subscription_id');
+      expect(org).not.toHaveProperty('internal_notes');
+      expect(org).not.toHaveProperty('private_metadata');
+    });
+
     it('should require export_data permission', async () => {
       const token = jwt.sign(
         { id: 'user-1', org_id: 1, org_slug: 'test-org', permissions: [] },

--- a/packages/saas/src/routes/org-export.ts
+++ b/packages/saas/src/routes/org-export.ts
@@ -35,9 +35,9 @@ export function createOrgExportRouter(): Router {
         return;
       }
 
-      // Get org metadata from public schema
+      // Get org metadata from public schema (filtered for privacy)
       const orgResult = await db.query(
-        'SELECT * FROM organizations WHERE id = $1',
+        'SELECT id, name, slug, status, plan_id, trial_ends_at, created_at FROM organizations WHERE id = $1',
         [org.id]
       );
 
@@ -61,8 +61,17 @@ export function createOrgExportRouter(): Router {
         client.query('SELECT * FROM org_settings LIMIT 1'),
       ]);
 
+      // Filter org data to avoid leaking internal fields
+      const { 
+        id, name, slug, status, plan_id, trial_ends_at, created_at 
+      } = orgResult.rows[0];
+      
+      const filteredOrg = { 
+        id, name, slug, status, plan_id, trial_ends_at, created_at 
+      };
+
       const exportData = {
-        org: orgResult.rows[0],
+        org: filteredOrg,
         cinemas: cinemasResult.rows,
         showtimes: showtimesResult.rows,
         reports: reportsResult.rows,

--- a/packages/saas/vitest.config.ts
+++ b/packages/saas/vitest.config.ts
@@ -1,15 +1,20 @@
 import { defineConfig } from 'vitest/config';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // Resolve cross-package imports from server/src so Vitest can transform them.
-// At runtime these are loaded by the server process which has the files on disk;
-// in tests (Vitest/esbuild) we need explicit aliases because Vitest cannot
-// traverse outside its own rootDir via bare relative paths ending in `.js`.
 const serverSrc = path.resolve(__dirname, '../../server/src');
 
 export default defineConfig({
   resolve: {
     alias: [
+      {
+        find: '@server',
+        replacement: serverSrc,
+      },
       // Map any import of the form `../../../server/src/<X>.js` → actual TS file
       {
         find: /^(\.\.\/)*server\/src\/(.*)\.js$/,


### PR DESCRIPTION
## Summary
- Explicitly select only necessary fields for organization export.
- Filter organization object before returning it to ensure privacy.
- Prevents leakage of internal fields like `stripe_subscription_id`, `internal_notes`, etc.

Closes #781