### PR TITLE
perf(scraper): add 15s timeout to upstream fetch requests

### DIFF
--- a/scraper/src/scraper/http-client.ts
+++ b/scraper/src/scraper/http-client.ts
@@ -5,6 +5,8 @@ import { logger } from '../utils/logger.js';
 import { ALLOCINE_BASE_URL } from './utils.js';
 import { HttpError, RateLimitError } from '../utils/errors.js';
 
+const FETCH_TIMEOUT_MS = 15000;
+
 const USER_AGENT =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 
@@ -129,34 +131,42 @@ export async function fetchShowtimesJson(cinemaId: string, date: string): Promis
   const url = constructed.href;
   logger.info('Fetching showtimes JSON', { url });
 
-  const response = await fetch(url, {
-    headers: {
-      'User-Agent': USER_AGENT,
-      Accept: 'application/json',
-      'Accept-Language': 'fr-FR,fr;q=0.9',
-      Referer: `${ALLOCINE_BASE_URL}/seance/salle_gen_csalle=${cinemaId}.html`,
-    },
-  });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
-  if (!response.ok) {
-    // Detect rate limiting specifically
-    if (response.status === 429) {
-      throw new RateLimitError(
-        `Rate limit exceeded for ${cinemaId} on ${date}`,
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        'User-Agent': USER_AGENT,
+        Accept: 'application/json',
+        'Accept-Language': 'fr-FR,fr;q=0.9',
+        Referer: `${ALLOCINE_BASE_URL}/seance/salle_gen_csalle=${cinemaId}.html`,
+      },
+    });
+
+    if (!response.ok) {
+      // Detect rate limiting specifically
+      if (response.status === 429) {
+        throw new RateLimitError(
+          `Rate limit exceeded for ${cinemaId} on ${date}`,
+          response.status,
+          url
+        );
+      }
+
+      // Throw generic HttpError for other failures
+      throw new HttpError(
+        `Failed to fetch showtimes JSON for ${cinemaId} on ${date}: ${response.status} ${response.statusText}`,
         response.status,
         url
       );
     }
 
-    // Throw generic HttpError for other failures
-    throw new HttpError(
-      `Failed to fetch showtimes JSON for ${cinemaId} on ${date}: ${response.status} ${response.statusText}`,
-      response.status,
-      url
-    );
+    return response.json();
+  } finally {
+    clearTimeout(timeoutId);
   }
-
-  return response.json();
 }
 
 export async function fetchFilmPage(filmId: number): Promise<string> {
@@ -172,34 +182,42 @@ export async function fetchFilmPage(filmId: number): Promise<string> {
 
   logger.info('Fetching film page', { url });
 
-  const response = await fetch(url, {
-    headers: {
-      'User-Agent': USER_AGENT,
-      Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-      'Accept-Language': 'fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7',
-      'Cache-Control': 'no-cache',
-    },
-  });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
-  if (!response.ok) {
-    // Detect rate limiting specifically
-    if (response.status === 429) {
-      throw new RateLimitError(
-        `Rate limit exceeded for film ${filmId}`,
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        'User-Agent': USER_AGENT,
+        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7',
+        'Cache-Control': 'no-cache',
+      },
+    });
+
+    if (!response.ok) {
+      // Detect rate limiting specifically
+      if (response.status === 429) {
+        throw new RateLimitError(
+          `Rate limit exceeded for film ${filmId}`,
+          response.status,
+          url
+        );
+      }
+
+      // Throw generic HttpError for other failures
+      throw new HttpError(
+        `Failed to fetch film page ${filmId}: ${response.status} ${response.statusText}`,
         response.status,
         url
       );
     }
 
-    // Throw generic HttpError for other failures
-    throw new HttpError(
-      `Failed to fetch film page ${filmId}: ${response.status} ${response.statusText}`,
-      response.status,
-      url
-    );
+    return response.text();
+  } finally {
+    clearTimeout(timeoutId);
   }
-
-  return response.text();
 }
 
 // Ajouter un délai entre les requêtes pour éviter le rate limiting

--- a/scraper/tests/unit/scraper/http-client-timeout.test.ts
+++ b/scraper/tests/unit/scraper/http-client-timeout.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../../src/utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe('http-client timeouts', () => {
+  let fetchShowtimesJson: (cinemaId: string, date: string) => Promise<unknown>;
+  let fetchFilmPage: (filmId: number) => Promise<string>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const mod = await import('../../../src/scraper/http-client.js');
+    fetchShowtimesJson = mod.fetchShowtimesJson;
+    fetchFilmPage = mod.fetchFilmPage;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetchShowtimesJson should include a timeout signal in fetch options', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({}),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await fetchShowtimesJson('C0072', '2024-01-15');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        signal: expect.any(AbortSignal)
+      })
+    );
+  });
+
+  it('fetchFilmPage should include a timeout signal in fetch options', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: vi.fn().mockResolvedValue('<html></html>'),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await fetchFilmPage(12345);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        signal: expect.any(AbortSignal)
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Added a 15-second timeout to all upstream `fetch` calls in the scraper microservice using `AbortController`.
- Ensures the scraper doesn't hang indefinitely on slow or unresponsive cinema websites.
- Includes unit tests for the new timeout logic.

Closes #780