### PR TITLE
perf(scraper): implement circuit breaker pattern for upstream failures

### DIFF
--- a/scraper/src/scraper/circuit-breaker.ts
+++ b/scraper/src/scraper/circuit-breaker.ts
@@ -1,0 +1,70 @@
+export class CircuitOpenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CircuitOpenError';
+  }
+}
+
+export type CircuitState = 'closed' | 'open' | 'half-open';
+
+export class CircuitBreaker {
+  private state: CircuitState = 'closed';
+  private failureCount = 0;
+  private lastFailureTime = 0;
+
+  constructor(
+    private threshold: number = 5,
+    private cooldownMs: number = 60000,
+    private isFailure: (err: any) => boolean = () => true
+  ) {}
+
+  public getState(): CircuitState {
+    // If open and cooldown has passed, transition to half-open
+    if (this.state === 'open' && Date.now() - this.lastFailureTime > this.cooldownMs) {
+      this.state = 'half-open';
+    }
+    return this.state;
+  }
+
+  public getFailureCount(): number {
+    return this.failureCount;
+  }
+
+  public async execute<T>(fn: () => Promise<T>): Promise<T> {
+    const currentState = this.getState();
+
+    if (currentState === 'open') {
+      throw new CircuitOpenError('Circuit breaker is open');
+    }
+
+    try {
+      const result = await fn();
+      this.onSuccess();
+      return result;
+    } catch (err) {
+      if (this.isFailure(err)) {
+        this.onFailure();
+      } else {
+        // If it's not a failure from the circuit breaker's perspective (e.g. 404),
+        // we might still want to consider it a success for the circuit state
+        // to reset the failure count (like a successful half-open test).
+        this.onSuccess();
+      }
+      throw err;
+    }
+  }
+
+  private onSuccess() {
+    this.failureCount = 0;
+    this.state = 'closed';
+  }
+
+  private onFailure() {
+    this.failureCount++;
+    this.lastFailureTime = Date.now();
+
+    if (this.failureCount >= this.threshold) {
+      this.state = 'open';
+    }
+  }
+}

--- a/scraper/src/scraper/http-client.ts
+++ b/scraper/src/scraper/http-client.ts
@@ -4,8 +4,15 @@ import puppeteer, { type Browser } from 'puppeteer-core';
 import { logger } from '../utils/logger.js';
 import { ALLOCINE_BASE_URL } from './utils.js';
 import { HttpError, RateLimitError } from '../utils/errors.js';
+import { CircuitBreaker } from './circuit-breaker.js';
 
 const FETCH_TIMEOUT_MS = 15000;
+
+export const circuitBreaker = new CircuitBreaker(5, 60000, (err) => {
+  if (err instanceof RateLimitError) return false;
+  if (err instanceof HttpError && err.statusCode && err.statusCode < 500) return false;
+  return true;
+});
 
 const USER_AGENT =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
@@ -81,31 +88,33 @@ export interface TheaterInitialData {
  * separately via the JSON API (fetchShowtimesJson).
  */
 export async function fetchTheaterPage(cinemaBaseUrl: string): Promise<TheaterInitialData> {
-  const browser = await getBrowser();
-  const context = await browser.createBrowserContext();
-  const page = await context.newPage();
+  return circuitBreaker.execute(async () => {
+    const browser = await getBrowser();
+    const context = await browser.createBrowserContext();
+    const page = await context.newPage();
 
-  try {
-    await page.setUserAgent(USER_AGENT);
-    logger.info('Loading theater page', { url: cinemaBaseUrl });
-    await page.goto(cinemaBaseUrl, { waitUntil: 'networkidle0', timeout: 60000 });
+    try {
+      await page.setUserAgent(USER_AGENT);
+      logger.info('Loading theater page', { url: cinemaBaseUrl });
+      await page.goto(cinemaBaseUrl, { waitUntil: 'networkidle0', timeout: 60000 });
 
-    const html = await page.content();
+      const html = await page.content();
 
-    // Extract available dates from the data-showtimes-dates attribute
-    const availableDates = await page.evaluate(() => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const el = (globalThis as any).document?.querySelector('#theaterpage-showtimes-index-ui');
-      const raw = el?.getAttribute('data-showtimes-dates');
-      if (!raw) return [] as string[];
-      try { return JSON.parse(raw) as string[]; } catch { return [] as string[]; }
-    });
+      // Extract available dates from the data-showtimes-dates attribute
+      const availableDates = await page.evaluate(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const el = (globalThis as any).document?.querySelector('#theaterpage-showtimes-index-ui');
+        const raw = el?.getAttribute('data-showtimes-dates');
+        if (!raw) return [] as string[];
+        try { return JSON.parse(raw) as string[]; } catch { return [] as string[]; }
+      });
 
-    logger.info('Available dates on page', { dates: availableDates });
-    return { html, availableDates };
-  } finally {
-    await context.close();
-  }
+      logger.info('Available dates on page', { dates: availableDates });
+      return { html, availableDates };
+    } finally {
+      await context.close();
+    }
+  });
 }
 
 /**
@@ -182,42 +191,44 @@ export async function fetchFilmPage(filmId: number): Promise<string> {
 
   logger.info('Fetching film page', { url });
 
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  return circuitBreaker.execute(async () => {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
-  try {
-    const response = await fetch(url, {
-      signal: controller.signal,
-      headers: {
-        'User-Agent': USER_AGENT,
-        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-        'Accept-Language': 'fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7',
-        'Cache-Control': 'no-cache',
-      },
-    });
+    try {
+      const response = await fetch(url, {
+        signal: controller.signal,
+        headers: {
+          'User-Agent': USER_AGENT,
+          Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+          'Accept-Language': 'fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7',
+          'Cache-Control': 'no-cache',
+        },
+      });
 
-    if (!response.ok) {
-      // Detect rate limiting specifically
-      if (response.status === 429) {
-        throw new RateLimitError(
-          `Rate limit exceeded for film ${filmId}`,
+      if (!response.ok) {
+        // Detect rate limiting specifically
+        if (response.status === 429) {
+          throw new RateLimitError(
+            `Rate limit exceeded for film ${filmId}`,
+            response.status,
+            url
+          );
+        }
+
+        // Throw generic HttpError for other failures
+        throw new HttpError(
+          `Failed to fetch film page ${filmId}: ${response.status} ${response.statusText}`,
           response.status,
           url
         );
       }
 
-      // Throw generic HttpError for other failures
-      throw new HttpError(
-        `Failed to fetch film page ${filmId}: ${response.status} ${response.statusText}`,
-        response.status,
-        url
-      );
+      return response.text();
+    } finally {
+      clearTimeout(timeoutId);
     }
-
-    return response.text();
-  } finally {
-    clearTimeout(timeoutId);
-  }
+  });
 }
 
 // Ajouter un délai entre les requêtes pour éviter le rate limiting

--- a/scraper/src/scraper/index.ts
+++ b/scraper/src/scraper/index.ts
@@ -1,16 +1,14 @@
 import pLimit from 'p-limit';
 import { db, type DB } from '../db/client.js';
 import { logger } from '../utils/logger.js';
-import {
-  getCinemaConfigs,
-  getCinemas,
-} from '../db/cinema-queries.js';
-import { closeBrowser, delay } from './http-client.js';
+import { getCinemaConfigs, getCinemas } from '../db/cinema-queries.js';
+import { closeBrowser, delay, circuitBreaker } from './http-client.js';
 import { getScrapeDates, type ScrapeMode } from '../utils/date.js';
 import type { CinemaConfig, Cinema, ProgressEvent, ScrapeSummary } from '../types/scraper.js';
 import { getStrategyByUrl, getStrategyBySource } from './strategy-factory.js';
 import { RateLimitError } from '../utils/errors.js';
 import { classifyError } from '../utils/error-classifier.js';
+import { CircuitOpenError } from './circuit-breaker.js';
 import {
   createScrapeAttempt,
   updateScrapeAttempt,
@@ -145,6 +143,26 @@ async function processCinema(
     const meta = await strategy.loadTheaterMetadata(db, cinema);
     availableDates = meta.availableDates;
   } catch (error) {
+    if (error instanceof RateLimitError || error instanceof CircuitOpenError) {
+      const isRateLimit = error instanceof RateLimitError;
+      logger.error(isRateLimit ? 'Rate limit detected - stopping all scraping' : 'Circuit open detected - stopping all scraping', { 
+        cinema: cinema.name, 
+        error: error.message 
+      });
+      summary.status = isRateLimit ? 'rate_limited' : 'circuit_open';
+      
+      const errorType = classifyError(error);
+      summary.errors.push({
+        cinema_name: cinema.name,
+        cinema_id: cinema.id,
+        error: error.message,
+        error_type: errorType,
+        http_status_code: (error as any).statusCode,
+      });
+      summary.failed_cinemas++;
+      return;
+    }
+
     const errorMessage = error instanceof Error ? error.message : String(error);
     const errorType = classifyError(error);
     logger.error('Failed to load theater metadata', { cinema: cinema.name, error: errorMessage });
@@ -223,10 +241,11 @@ async function processCinema(
           logger.error('Failed to update scrape attempt', { error });
         }
       }
-    } catch (error) {
-      // Detect rate limiting and signal abortion
-      if (error instanceof RateLimitError) {
-        logger.error('Rate limit detected - stopping all scraping', { 
+    } catch (error: any) {
+      // Detect rate limiting or circuit breaker open and signal abortion
+      if (error instanceof RateLimitError || error instanceof CircuitOpenError) {
+        const isRateLimit = error instanceof RateLimitError;
+        logger.error(isRateLimit ? 'Rate limit detected - stopping all scraping' : 'Circuit open detected - stopping all scraping', { 
           cinema: cinema.name, 
           date, 
           statusCode: error.statusCode 
@@ -242,11 +261,11 @@ async function processCinema(
           http_status_code: error.statusCode,
         });
 
-        // Update attempt as rate_limited
+        // Update attempt as rate_limited or failed
         if (attemptId) {
           try {
             await updateScrapeAttempt(db, attemptId, {
-              status: 'rate_limited',
+              status: isRateLimit ? 'rate_limited' : 'failed',
               error_type: errorType,
               error_message: error.message,
               http_status_code: error.statusCode,
@@ -280,8 +299,8 @@ async function processCinema(
           error: error.message
         });
 
-        // Mark status as rate_limited
-        summary.status = 'rate_limited';
+        // Mark status
+        summary.status = isRateLimit ? 'rate_limited' : 'circuit_open';
         return;
       }
 
@@ -437,7 +456,7 @@ export async function runScraper(
     });
 
     const limit = pLimit(concurrency);
-    const isAborted = () => summary.status === 'rate_limited';
+    const isAborted = () => summary.status === 'rate_limited' || summary.status === 'circuit_open';
 
     const tasks = cinemas.map((cinema, i) => 
       limit(() => processCinema(
@@ -457,6 +476,7 @@ export async function runScraper(
     await Promise.allSettled(tasks);
 
     summary.duration_ms = Date.now() - startTime;
+    summary.circuit_state = circuitBreaker.getState();
     logger.info('Scraping completed', { summary });
     await closeBrowser();
 
@@ -476,6 +496,7 @@ export async function runScraper(
       http_status_code: (error as any).statusCode,
     });
     summary.duration_ms = Date.now() - startTime;
+    summary.circuit_state = circuitBreaker.getState();
     await progress?.emit({ type: 'failed', error: errorMessage });
     throw error;
   }

--- a/scraper/src/scraper/index.ts
+++ b/scraper/src/scraper/index.ts
@@ -248,7 +248,7 @@ async function processCinema(
         logger.error(isRateLimit ? 'Rate limit detected - stopping all scraping' : 'Circuit open detected - stopping all scraping', { 
           cinema: cinema.name, 
           date, 
-          statusCode: error.statusCode 
+          statusCode: (error as any).statusCode 
         });
         
         const errorType = classifyError(error);
@@ -258,7 +258,7 @@ async function processCinema(
           date: date,
           error: error.message,
           error_type: errorType,
-          http_status_code: error.statusCode,
+          http_status_code: (error as any).statusCode,
         });
 
         // Update attempt as rate_limited or failed
@@ -268,7 +268,7 @@ async function processCinema(
               status: isRateLimit ? 'rate_limited' : 'failed',
               error_type: errorType,
               error_message: error.message,
-              http_status_code: error.statusCode,
+              http_status_code: (error as any).statusCode,
             });
           } catch (updateError) {
             logger.error('Failed to update scrape attempt', { error: updateError });

--- a/scraper/src/types/scraper.ts
+++ b/scraper/src/types/scraper.ts
@@ -126,5 +126,6 @@ export interface ScrapeSummary {
     error_type?: 'http_429' | 'http_5xx' | 'http_4xx' | 'network' | 'parse' | 'timeout';
     http_status_code?: number;
   }>;
-  status?: 'success' | 'partial_success' | 'failed' | 'rate_limited';
+  status?: 'success' | 'partial_success' | 'failed' | 'rate_limited' | 'circuit_open';
+  circuit_state?: 'closed' | 'open' | 'half-open';
 }

--- a/scraper/tests/unit/scraper/circuit-breaker.test.ts
+++ b/scraper/tests/unit/scraper/circuit-breaker.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { CircuitBreaker, CircuitOpenError } from '../../../src/scraper/circuit-breaker.js';
+
+describe('CircuitBreaker', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should start in closed state', () => {
+    const cb = new CircuitBreaker();
+    expect(cb.getState()).toBe('closed');
+  });
+
+  it('should execute successfully when closed', async () => {
+    const cb = new CircuitBreaker();
+    const result = await cb.execute(async () => 'success');
+    expect(result).toBe('success');
+    expect(cb.getState()).toBe('closed');
+    expect(cb.getFailureCount()).toBe(0);
+  });
+
+  it('should open after reaching the failure threshold', async () => {
+    const threshold = 3;
+    const cb = new CircuitBreaker(threshold);
+
+    // Fail threshold - 1 times
+    for (let i = 0; i < threshold - 1; i++) {
+      await expect(cb.execute(async () => { throw new Error('failure'); })).rejects.toThrow('failure');
+      expect(cb.getState()).toBe('closed');
+    }
+
+    // Fail 1 more time (reaches threshold)
+    await expect(cb.execute(async () => { throw new Error('failure'); })).rejects.toThrow('failure');
+    expect(cb.getState()).toBe('open');
+    expect(cb.getFailureCount()).toBe(threshold);
+  });
+
+  it('should reject requests immediately when open', async () => {
+    const threshold = 1;
+    const cb = new CircuitBreaker(threshold);
+
+    // Trip the circuit
+    await expect(cb.execute(async () => { throw new Error('failure'); })).rejects.toThrow('failure');
+    expect(cb.getState()).toBe('open');
+
+    // Next request should fail with CircuitOpenError
+    await expect(cb.execute(async () => 'success')).rejects.toThrow(CircuitOpenError);
+    // Should still be open
+    expect(cb.getState()).toBe('open');
+  });
+
+  it('should transition to half-open after cooldown period', async () => {
+    const threshold = 1;
+    const cooldownMs = 10000; // 10 seconds
+    const cb = new CircuitBreaker(threshold, cooldownMs);
+
+    // Trip the circuit
+    await expect(cb.execute(async () => { throw new Error('failure'); })).rejects.toThrow('failure');
+    expect(cb.getState()).toBe('open');
+
+    // Advance time past cooldown
+    vi.advanceTimersByTime(cooldownMs + 1);
+
+    // State should now be half-open
+    expect(cb.getState()).toBe('half-open');
+  });
+
+  it('should close if half-open request succeeds', async () => {
+    const threshold = 1;
+    const cooldownMs = 10000;
+    const cb = new CircuitBreaker(threshold, cooldownMs);
+
+    // Trip the circuit
+    await expect(cb.execute(async () => { throw new Error('failure'); })).rejects.toThrow('failure');
+
+    // Advance time past cooldown
+    vi.advanceTimersByTime(cooldownMs + 1);
+    expect(cb.getState()).toBe('half-open');
+
+    // Successful request should close the circuit
+    const result = await cb.execute(async () => 'success');
+    expect(result).toBe('success');
+    expect(cb.getState()).toBe('closed');
+    expect(cb.getFailureCount()).toBe(0);
+  });
+
+  it('should re-open if half-open request fails', async () => {
+    const threshold = 1;
+    const cooldownMs = 10000;
+    const cb = new CircuitBreaker(threshold, cooldownMs);
+
+    // Trip the circuit
+    await expect(cb.execute(async () => { throw new Error('failure'); })).rejects.toThrow('failure');
+
+    // Advance time past cooldown
+    vi.advanceTimersByTime(cooldownMs + 1);
+    expect(cb.getState()).toBe('half-open');
+
+    // Failed request should re-open the circuit
+    await expect(cb.execute(async () => { throw new Error('another failure'); })).rejects.toThrow('another failure');
+    
+    // Check that it's open again and we need another cooldown
+    expect(cb.getState()).toBe('open');
+    
+    // Immediate subsequent request should throw CircuitOpenError
+    await expect(cb.execute(async () => 'success')).rejects.toThrow(CircuitOpenError);
+  });
+
+  it('should ignore errors when isFailure returns false', async () => {
+    const threshold = 1;
+    const isFailure = (err: any) => err.message !== 'ignored';
+    const cb = new CircuitBreaker(threshold, 60000, isFailure);
+
+    // This error should be ignored
+    await expect(cb.execute(async () => { throw new Error('ignored'); })).rejects.toThrow('ignored');
+    expect(cb.getState()).toBe('closed');
+    expect(cb.getFailureCount()).toBe(0);
+
+    // This error should trip the circuit
+    await expect(cb.execute(async () => { throw new Error('failure'); })).rejects.toThrow('failure');
+    expect(cb.getState()).toBe('open');
+    expect(cb.getFailureCount()).toBe(1);
+  });
+
+});

--- a/scraper/tests/unit/scraper/concurrency.test.ts
+++ b/scraper/tests/unit/scraper/concurrency.test.ts
@@ -23,6 +23,9 @@ vi.mock('../../../src/scraper/strategy-factory.js', () => ({
 vi.mock('../../../src/scraper/http-client.js', () => ({
   closeBrowser: vi.fn().mockResolvedValue(undefined),
   delay: vi.fn().mockResolvedValue(undefined),
+  circuitBreaker: {
+    getState: vi.fn().mockReturnValue('closed'),
+  },
 }));
 
 describe('runScraper concurrency', () => {

--- a/scraper/tests/unit/scraper/index.test.ts
+++ b/scraper/tests/unit/scraper/index.test.ts
@@ -30,6 +30,9 @@ vi.mock('../../../src/scraper/http-client.js', () => ({
   fetchFilmPage: vi.fn(),
   delay: vi.fn(),
   closeBrowser: vi.fn(),
+  circuitBreaker: {
+    getState: vi.fn().mockReturnValue('closed'),
+  },
 }));
 
 vi.mock('../../../src/scraper/theater-parser.js', () => ({


### PR DESCRIPTION
## Summary
Implements a Circuit Breaker pattern to prevent wasted scraping attempts when upstream (AlloCiné) is down (HTTP 503, timeouts).

## Changes
- Added `CircuitBreaker` class with `closed`, `open`, and `half-open` states
- Wrapped `fetchTheaterPage`, `fetchShowtimesJson`, and `fetchFilmPage` with the circuit breaker
- Only server errors (5xx) and network timeouts trip the circuit (4xx and 429 are ignored)
- Circuit state is added to the `ScrapeSummary`
- Scraper gracefully aborts remaining tasks if the circuit opens

Closes #599