### PR TITLE
fix(api): restrict CORS to require Origin header in production

### DIFF
--- a/docs/guides/deployment/networking.md
+++ b/docs/guides/deployment/networking.md
@@ -521,6 +521,15 @@ ALLOWED_ORIGINS=https://cinema.example.com,https://www.cinema.example.com
 - Use reverse proxy with authentication
 - Enable rate limiting
 
+### 5. Origin Header Requirement (Production)
+
+To prevent CORS bypasses via server-to-server requests or CLI tools that don't send an `Origin` header, the application requires an `Origin` header in production mode (`NODE_ENV=production`).
+
+- **Production**: Requests without an `Origin` header will be rejected with an error.
+- **Development**: Requests without an `Origin` header are allowed for local testing with `curl` or Postman.
+
+If you are calling the API from a backend service or a script in production, ensure you include an `Origin` header that matches one of the entries in `ALLOWED_ORIGINS`.
+
 ---
 
 ## Related Documentation

--- a/server/src/utils/cors-config.test.ts
+++ b/server/src/utils/cors-config.test.ts
@@ -48,8 +48,39 @@ describe('getCorsOptions', () => {
     }
   });
 
-  it('should allow requests with no origin (like mobile apps or curl)', () => {
+  it('should allow requests with no origin in development', () => {
+    process.env.NODE_ENV = 'development';
     process.env.ALLOWED_ORIGINS = 'http://example.com';
+    const options = getCorsOptions();
+
+    const originCheck = options.origin;
+    const callback = vi.fn();
+
+    if (typeof originCheck === 'function') {
+      // @ts-ignore
+      originCheck(undefined, callback);
+      expect(callback).toHaveBeenCalledWith(null, true);
+    }
+  });
+
+  it('should block requests with no origin in production', () => {
+    process.env.NODE_ENV = 'production';
+    const options = getCorsOptions();
+
+    const originCheck = options.origin;
+    const callback = vi.fn();
+
+    if (typeof originCheck === 'function') {
+      // @ts-ignore
+      originCheck(undefined, callback);
+      expect(callback).toHaveBeenCalledWith(expect.any(Error));
+      const error = callback.mock.calls[0][0];
+      expect(error.message).toContain('Origin header required in production');
+    }
+  });
+
+  it('should allow requests with no origin if not in production (legacy behavior)', () => {
+    delete process.env.NODE_ENV;
     const options = getCorsOptions();
 
     const originCheck = options.origin;

--- a/server/src/utils/cors-config.test.ts
+++ b/server/src/utils/cors-config.test.ts
@@ -76,6 +76,7 @@ describe('getCorsOptions', () => {
       expect(callback).toHaveBeenCalledWith(expect.any(Error));
       const error = callback.mock.calls[0][0];
       expect(error.message).toContain('Origin header required in production');
+      expect(error.message).toContain('networking.md');
     }
   });
 

--- a/server/src/utils/cors-config.ts
+++ b/server/src/utils/cors-config.ts
@@ -8,7 +8,20 @@ export const getCorsOptions = (): CorsOptions => {
 
   return {
     origin: (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) => {
-      // Allow requests with no origin (like mobile apps or curl requests)
+      const isProduction = process.env.NODE_ENV === 'production';
+
+      // Production: Require Origin header from browsers
+      if (isProduction && !origin) {
+        return callback(
+          new Error(
+            'Origin header required in production. ' +
+            'Browser requests without an Origin header are blocked for security. ' +
+            'See docs/guides/deployment/networking.md for details.'
+          )
+        );
+      }
+
+      // Allow requests with no origin (like mobile apps or curl requests) in non-production
       if (!origin) {
         return callback(null, true);
       }


### PR DESCRIPTION
## Summary
- Production mode now rejects requests without an Origin header to prevent CORS bypasses.
- Development mode remains permissive for local testing tools like curl or Postman.
- Updated `docs/guides/deployment/networking.md` to reflect this change.

Closes #629