### PR TITLE
fix(client): fix duplicate and vague links in FilmCard

### DIFF
--- a/client/src/components/FilmCard.test.tsx
+++ b/client/src/components/FilmCard.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect } from 'vitest';
+import FilmCard from './FilmCard';
+import type { FilmWithShowtimes } from '../types';
+
+const mockFilm: FilmWithShowtimes = {
+  id: 1,
+  title: 'Test Movie',
+  original_title: 'Original Movie',
+  genres: ['Action', 'Drama'],
+  poster_url: 'http://example.com/poster.jpg',
+  synopsis: 'A test movie synopsis.',
+  duration_minutes: 120,
+  director: 'Test Director',
+  nationality: 'French',
+  certificate: 'U',
+  press_rating: 4.5,
+  audience_rating: 4.2,
+  cinemas: [],
+  source_url: 'http://example.com/movie'
+};
+
+describe('FilmCard', () => {
+  const renderFilmCard = () =>
+    render(
+      <MemoryRouter>
+        <FilmCard film={mockFilm} />
+      </MemoryRouter>
+    );
+
+  it('should not have duplicate redundant tab stops for the same film destination', () => {
+    renderFilmCard();
+    
+    const moviePath = `/film/${mockFilm.id}`;
+    const allLinks = screen.getAllByRole('link');
+    
+    // Only one link should be reachable/discoverable by default role if we hide the second one
+    const interactiveLinks = allLinks.filter(link => 
+      link.getAttribute('href') === moviePath && 
+      link.getAttribute('aria-hidden') !== 'true' &&
+      link.getAttribute('tabindex') !== '-1'
+    );
+    
+    expect(interactiveLinks).toHaveLength(1);
+    expect(interactiveLinks[0]).toHaveTextContent(mockFilm.title);
+  });
+
+  it('should have a descriptive aria-label for the "Fiche complète" link if it is not hidden', () => {
+    renderFilmCard();
+    
+    // If we keep the link, it must be descriptive
+    const detailLink = screen.queryByRole('link', { name: /fiche complète/i });
+    
+    if (detailLink && detailLink.getAttribute('aria-hidden') !== 'true') {
+        expect(detailLink).toHaveAttribute('aria-label', `Voir la fiche complète de ${mockFilm.title}`);
+    }
+  });
+});

--- a/client/src/components/FilmCard.test.tsx
+++ b/client/src/components/FilmCard.test.tsx
@@ -9,6 +9,7 @@ const mockFilm: FilmWithShowtimes = {
   title: 'Test Movie',
   original_title: 'Original Movie',
   genres: ['Action', 'Drama'],
+  actors: ['Actor 1', 'Actor 2'],
   poster_url: 'http://example.com/poster.jpg',
   synopsis: 'A test movie synopsis.',
   duration_minutes: 120,

--- a/client/src/components/FilmCard.tsx
+++ b/client/src/components/FilmCard.tsx
@@ -120,6 +120,9 @@ function FilmCard({ film, isNew = false, initialAfterTime }: FilmCardProps) {
             <Link 
               to={`/film/${film.id}`} 
               className="text-sm font-bold text-gray-500 hover:text-primary transition"
+              aria-label={`Voir la fiche complète de ${film.title}`}
+              aria-hidden="true"
+              tabIndex={-1}
             >
               Fiche complète →
             </Link>


### PR DESCRIPTION
## Summary\n- Added  to 'Fiche complète' link for better context.\n- Added  and  to 'Fiche complète' link to prevent redundant tab stops for keyboard users.\n\nCloses #806