### PR TITLE
fix(api): handle SyntaxError from express.json() with clean 400 response

### DIFF
--- a/server/src/middleware/error-handler.test.ts
+++ b/server/src/middleware/error-handler.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { errorHandler } from './error-handler.js';
+
+describe('errorHandler middleware', () => {
+  it('should handle SyntaxError from express.json() with 400 status', async () => {
+    const app = express();
+    app.use(express.json());
+    app.post('/test', (req, res) => {
+      res.status(200).json({ success: true });
+    });
+    app.use(errorHandler);
+
+    // Send malformed JSON string directly
+    const res = await request(app)
+      .post('/test')
+      .set('Content-Type', 'application/json')
+      .send('{"invalid": json}'); 
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      success: false,
+      error: 'Invalid JSON payload'
+    });
+  });
+});

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -8,6 +8,14 @@ export const errorHandler = (
   res: Response,
   _next: NextFunction
 ) => {
+  // Handle JSON syntax errors from express.json()
+  if (err instanceof SyntaxError && 'status' in err && (err as any).status === 400 && 'body' in err) {
+    return res.status(400).json({
+      success: false,
+      error: 'Invalid JSON payload'
+    });
+  }
+
   if (err && (err instanceof AppError || ('statusCode' in err && typeof (err as any).statusCode === 'number'))) {
     const error = err as AppError;
     if (error.statusCode >= 500) {


### PR DESCRIPTION
## Summary
- Added explicit handling for `SyntaxError` thrown by `express.json()` when receiving malformed JSON.
- Returns a clean JSON response `{ success: false, error: 'Invalid JSON payload' }` with 400 status.
- Prevents raw technical error messages from being exposed.
- Avoids logging these client-side errors as unhandled system errors.

Closes #817