### PR TITLE
fix(db): seed default superadmin from admin account

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
     permissions:
       contents: read
 
+    env:
+      SAAS_ENABLED: 'true'
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,27 +251,30 @@ git commit -m "docs: update README with <feature>"        # DOCS — if applicab
 
 ---
 
-## Step 7: Pull Request
+## Step 7: CI — Push & Verify
 
+**CRITICAL: You MUST verify the build status in the remote repository.**
+
+1. **Push branch:** `git push -u origin <branch-name>`
+2. **Watch CI status:** `gh pr checks <pr-number> --watch`
+3. **Fix failures:** If CI fails, analyze logs (`gh run view <id> --log`), fix locally, and follow the atomic commit/push/verify cycle.
+
+### Local CI Simulation (Recommended Before Push)
+
+To avoid failing CI in the remote, run these commands locally:
+
+**Client (Frontend):**
 ```bash
-# Push branch
-git push -u origin <type>/<issue-number>-<short-description>
-
-# Create PR
-gh pr create --title "feat(scope): description" --body "## Summary
-- Change 1
-- Change 2
-
-Closes #<issue-number>"
+cd client
+npm run build    # Runs tsc -b && vite build
 ```
 
-**Before requesting review:**
-- [ ] All tests pass (`npm run test:run`)
-- [ ] Code coverage maintained
-- [ ] Conventional Commits used
-- [ ] Documentation updated (if applicable)
-- [ ] Version label added (`patch`, `minor`, or `major`)
-- [ ] Issue referenced in PR body
+**Server (Backend):**
+```bash
+cd server
+npm run test:run # Runs vitest once
+npm run build    # Runs tsc -b
+```
 
 **After merge:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,11 +25,13 @@ This document provides instructions for AI coding agents (Claude, GitHub Copilot
 4. GREEN   → Write minimal code to make tests pass
 5. DOCS    → Update README.md / AGENTS.md if API or behaviour changed
 6. COMMIT  → Atomic commits with Conventional Commits format
-7. PR      → Open Pull Request referencing the issue, wait for review
+7. CI      → Push and check GitHub Actions status (fix any failures)
+8. PR      → Open/Update Pull Request referencing the issue, wait for review
              → After merge: use cleanup skill or manually switch back to develop, pull latest
 ```
 
 **Conditional steps (not always required):**
+- **CI Fix** — If CI fails, you MUST analyze logs (`gh run view <id> --log`) and fix the root cause before requesting review.
 - **Docker build** — run `docker compose build` before pushing if Dockerfile or dependencies changed
 - **E2E tests** — Run Playwright integration tests (`npm run e2e`) when modifying frontend workflows, API interactions, or real-time features
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,8 @@ RUN chown nodejs:nodejs /app
 
 USER nodejs
 
+ENV SAAS_ENABLED=true
+
 # Copy package files for production install
 COPY --chown=nodejs:nodejs package.json package-lock.json ./
 COPY --chown=nodejs:nodejs client/package.json ./client/

--- a/README.md
+++ b/README.md
@@ -562,8 +562,8 @@ VITE_SAAS_ENABLED=true
 
 **Default Credentials:**
 ```
-Username: superadmin
-Password: changeme
+Username: admin
+Password: <same as default admin account, logged at startup>
 ```
 
 ⚠️ **CRITICAL:** Change the default superadmin password immediately after first login.
@@ -599,8 +599,8 @@ Password: changeme
 # Authentication
 POST /api/superadmin/login
 {
-  "username": "superadmin",
-  "password": "changeme"
+  "username": "admin",
+  "password": "your-generated-admin-password"
 }
 
 # Dashboard metrics

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { BrowserRouter, Routes, Route, useNavigate } from 'react-router-dom';
-import { useEffect, useContext, Suspense, lazy, useState } from 'react';
+import { useEffect, useContext, Suspense, lazy } from 'react';
 import Layout from './components/Layout';
 import HomePage from './pages/HomePage';
 import CinemaPage from './pages/CinemaPage';
@@ -17,6 +17,8 @@ import { AuthProvider } from './contexts/AuthProvider';
 import { SettingsProvider } from './contexts/SettingsProvider';
 import { SettingsContext } from './contexts/SettingsContext';
 import { TenantProvider } from './contexts/TenantProvider';
+import { ConfigProvider } from './contexts/ConfigProvider';
+import { ConfigContext } from './contexts/ConfigContext';
 import ProtectedRoute from './components/ProtectedRoute';
 import RequirePermission from './components/RequirePermission';
 import { RequireSuperadmin } from './components/RequireSuperadmin';
@@ -24,7 +26,6 @@ import ErrorBoundary from './components/ErrorBoundary';
 import { useTheme } from './hooks/useTheme';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ADMIN_PERMISSIONS } from './utils/adminPermissions';
-import { getConfig } from './api/saas';
 
 // Lazy load devtools only in development
 const ReactQueryDevtools = import.meta.env.DEV
@@ -179,29 +180,31 @@ function SaasRoutes() {
         path="/org/:slug/*"
         element={
           <TenantProvider>
-            <Layout>
-              <Routes>
-                <Route path="/" element={<HomePage />} />
-                <Route path="/cinema/:id" element={<CinemaPage />} />
-                <Route path="/film/:id" element={<FilmPage />} />
-                <Route
-                  path="/change-password"
-                  element={
-                    <ProtectedRoute>
-                      <ChangePasswordPage />
-                    </ProtectedRoute>
-                  }
-                />
-                <Route
-                  path="/admin"
-                  element={
-                    <RequirePermission anyOf={ADMIN_PERMISSIONS}>
-                      <AdminPage />
-                    </RequirePermission>
-                  }
-                />
-              </Routes>
-            </Layout>
+            <SettingsProvider>
+              <Layout>
+                <Routes>
+                  <Route path="/" element={<HomePage />} />
+                  <Route path="/cinema/:id" element={<CinemaPage />} />
+                  <Route path="/film/:id" element={<FilmPage />} />
+                  <Route
+                    path="/change-password"
+                    element={
+                      <ProtectedRoute>
+                        <ChangePasswordPage />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/admin"
+                    element={
+                      <RequirePermission anyOf={ADMIN_PERMISSIONS}>
+                        <AdminPage />
+                      </RequirePermission>
+                    }
+                  />
+                </Routes>
+              </Layout>
+            </SettingsProvider>
           </TenantProvider>
         }
       />
@@ -209,57 +212,35 @@ function SaasRoutes() {
   );
 }
 
-function App() {
-  const [saasEnabled, setSaasEnabled] = useState<boolean | null>(null);
-  const [error, setError] = useState<boolean>(false);
+function MainContent() {
+  const { saasEnabled, isLoading } = useContext(ConfigContext);
 
-  useEffect(() => {
-    getConfig()
-      .then((cfg) => setSaasEnabled(cfg.saasEnabled))
-      .catch((err) => {
-        console.error('Failed to load config:', err);
-        setError(true);
-      });
-  }, []);
-
-  if (error) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
-        <div className="max-w-md w-full text-center">
-          <h1 className="text-2xl font-bold text-red-600 mb-2">Configuration Error</h1>
-          <p className="text-gray-600 mb-4">
-            Failed to load application configuration. Please check your connection and try again.
-          </p>
-          <button 
-            onClick={() => window.location.reload()}
-            className="px-4 py-2 bg-primary text-white rounded hover:bg-primary/90 transition-colors"
-          >
-            Retry
-          </button>
-        </div>
-      </div>
-    );
-  }
-
-  // Wait until config is loaded before rendering routes
-  if (saasEnabled === null) {
+  if (isLoading) {
     return <LoadingScreen />;
   }
 
   return (
+    <BrowserRouter>
+      {saasEnabled ? (
+        <SaasRoutes />
+      ) : (
+        <SettingsProvider>
+          <AppRoutes />
+        </SettingsProvider>
+      )}
+    </BrowserRouter>
+  );
+}
+
+function App() {
+  return (
     <ErrorBoundary>
       <QueryClientProvider client={queryClient}>
-        <AuthProvider>
-          <BrowserRouter>
-            {saasEnabled ? (
-              <SaasRoutes />
-            ) : (
-              <SettingsProvider>
-                <AppRoutes />
-              </SettingsProvider>
-            )}
-          </BrowserRouter>
-        </AuthProvider>
+        <ConfigProvider>
+          <AuthProvider>
+            <MainContent />
+          </AuthProvider>
+        </ConfigProvider>
         <Suspense fallback={null}>
           <ReactQueryDevtools initialIsOpen={false} />
         </Suspense>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -160,7 +160,16 @@ function SaasRoutes() {
   return (
     <Routes>
       {/* Public SaaS pages */}
-      <Route path="/" element={<LandingPage />} />
+      <Route
+        path="/"
+        element={
+          <SettingsProvider>
+            <Layout>
+              <LandingPage />
+            </Layout>
+          </SettingsProvider>
+        }
+      />
       <Route path="/login" element={<LoginPage />} />
       <Route path="/register" element={<RegisterPage />} />
 

--- a/client/src/api/settings.ts
+++ b/client/src/api/settings.ts
@@ -80,8 +80,9 @@ export interface AppSettingsExport {
 /**
  * Get public settings (no authentication required)
  */
-export async function getPublicSettings(): Promise<AppSettingsPublic> {
-  const response = await apiClient.get<ApiResponse<AppSettingsPublic>>('/settings');
+export async function getPublicSettings(orgSlug?: string): Promise<AppSettingsPublic> {
+  const url = orgSlug ? `/org/${orgSlug}/settings` : '/settings';
+  const response = await apiClient.get<ApiResponse<AppSettingsPublic>>(url);
   if (!response.data.success || !response.data.data) {
     throw new Error(response.data.error || 'Failed to fetch public settings');
   }
@@ -91,8 +92,9 @@ export async function getPublicSettings(): Promise<AppSettingsPublic> {
 /**
  * Get full settings (admin only)
  */
-export async function getAdminSettings(): Promise<AppSettings> {
-  const response = await apiClient.get<ApiResponse<AppSettings>>('/settings/admin');
+export async function getAdminSettings(orgSlug?: string): Promise<AppSettings> {
+  const url = orgSlug ? `/org/${orgSlug}/settings/admin` : '/settings/admin';
+  const response = await apiClient.get<ApiResponse<AppSettings>>(url);
   if (!response.data.success || !response.data.data) {
     throw new Error(response.data.error || 'Failed to fetch admin settings');
   }
@@ -102,8 +104,10 @@ export async function getAdminSettings(): Promise<AppSettings> {
 /**
  * Update settings (admin only)
  */
-export async function updateSettings(updates: AppSettingsUpdate): Promise<AppSettings> {
-  const response = await apiClient.put<ApiResponse<AppSettings>>('/settings', updates);
+export async function updateSettings(updates: AppSettingsUpdate, orgSlug?: string): Promise<AppSettings> {
+  const url = orgSlug ? `/org/${orgSlug}/settings/admin` : '/settings';
+  const method = orgSlug ? 'put' : 'put'; // Both are PUT, but keep the structure
+  const response = await apiClient.put<ApiResponse<AppSettings>>(url, updates);
   if (!response.data.success || !response.data.data) {
     throw new Error(response.data.error || 'Failed to update settings');
   }

--- a/client/src/api/settings.ts
+++ b/client/src/api/settings.ts
@@ -106,7 +106,6 @@ export async function getAdminSettings(orgSlug?: string): Promise<AppSettings> {
  */
 export async function updateSettings(updates: AppSettingsUpdate, orgSlug?: string): Promise<AppSettings> {
   const url = orgSlug ? `/org/${orgSlug}/settings/admin` : '/settings';
-  const method = orgSlug ? 'put' : 'put'; // Both are PUT, but keep the structure
   const response = await apiClient.put<ApiResponse<AppSettings>>(url, updates);
   if (!response.data.success || !response.data.data) {
     throw new Error(response.data.error || 'Failed to update settings');

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -126,7 +126,7 @@ export default function Layout({ children, title }: LayoutProps) {
                   Admin
                 </Link>
               )}
-              {saasEnabled && isAdmin && (
+              {saasEnabled && isAdmin && !user?.org_slug && (
                 <Link to="/superadmin" className="hover:text-primary transition text-amber-400 font-semibold" data-testid="superadmin-portal-link">
                   SaaS Portal
                 </Link>

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useContext, useState, useEffect, useRef } from 'react';
 import { AuthContext } from '../contexts/AuthContext';
 import { SettingsContext } from '../contexts/SettingsContext';
+import { ConfigContext } from '../contexts/ConfigContext';
 import { ADMIN_PERMISSIONS } from '../utils/adminPermissions';
 
 interface LayoutProps {
@@ -11,8 +12,9 @@ interface LayoutProps {
 }
 
 export default function Layout({ children, title }: LayoutProps) {
-  const { isAuthenticated, user, logout, hasPermission } = useContext(AuthContext);
+  const { isAuthenticated, user, logout, hasPermission, isAdmin } = useContext(AuthContext);
   const { publicSettings } = useContext(SettingsContext);
+  const { saasEnabled } = useContext(ConfigContext);
   const navigate = useNavigate();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isHeaderVisible, setIsHeaderVisible] = useState(true);
@@ -122,6 +124,11 @@ export default function Layout({ children, title }: LayoutProps) {
               {hasAdminAccess && (
                 <Link to="/admin?tab=cinemas" className="hover:text-primary transition">
                   Admin
+                </Link>
+              )}
+              {saasEnabled && isAdmin && (
+                <Link to="/superadmin" className="hover:text-primary transition text-amber-400 font-semibold" data-testid="superadmin-portal-link">
+                  SaaS Portal
                 </Link>
               )}
               <div className="border-l border-gray-600 h-6"></div>

--- a/client/src/components/RequireSuperadmin.tsx
+++ b/client/src/components/RequireSuperadmin.tsx
@@ -10,6 +10,19 @@ interface RequireSuperadminProps {
 }
 
 /**
+ * Decode Base64URL to string.
+ */
+function decodeBase64Url(value: string): string | null {
+  try {
+    const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
+    return atob(padded);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Decode JWT payload from localStorage token.
  * Returns null if no token or invalid token.
  */
@@ -21,9 +34,10 @@ function decodeToken(): { scope?: string } | null {
     const parts = token.split('.');
     if (parts.length !== 3) return null;
 
-    const payload = parts[1];
-    const decoded = JSON.parse(atob(payload));
-    return decoded;
+    const payloadJson = decodeBase64Url(parts[1]);
+    if (!payloadJson) return null;
+
+    return JSON.parse(payloadJson);
   } catch {
     return null;
   }

--- a/client/src/components/RequireSuperadmin.tsx
+++ b/client/src/components/RequireSuperadmin.tsx
@@ -3,7 +3,8 @@
  * Checks for scope='superadmin' in the JWT payload.
  */
 import { Navigate } from 'react-router-dom';
-import type { ReactNode } from 'react';
+import { useContext, type ReactNode } from 'react';
+import { AuthContext } from '../contexts/AuthContext';
 
 interface RequireSuperadminProps {
   children: ReactNode;
@@ -44,9 +45,12 @@ function decodeToken(): { scope?: string } | null {
 }
 
 export function RequireSuperadmin({ children }: RequireSuperadminProps) {
+  const { user } = useContext(AuthContext);
   const decoded = decodeToken();
   
-  if (!decoded || decoded.scope !== 'superadmin') {
+  const isSuperadmin = (decoded && decoded.scope === 'superadmin') || (user?.scope === 'superadmin');
+  
+  if (!isSuperadmin) {
     return <Navigate to="/superadmin/login" replace />;
   }
 

--- a/client/src/contexts/AuthContext.ts
+++ b/client/src/contexts/AuthContext.ts
@@ -2,13 +2,14 @@ import { createContext } from 'react';
 import type { PermissionName } from '../types/role';
 
 export interface User {
-    id: number;
+    id: number | string;
     username: string;
-    role_id: number;
-    role_name: string;
-    is_system_role: boolean;
+    role_id?: number;
+    role_name?: string;
+    is_system_role?: boolean;
     permissions: PermissionName[];
     org_slug?: string;
+    scope?: string;
 }
 
 export interface AuthContextType {

--- a/client/src/contexts/AuthContext.ts
+++ b/client/src/contexts/AuthContext.ts
@@ -8,6 +8,7 @@ export interface User {
     role_name: string;
     is_system_role: boolean;
     permissions: PermissionName[];
+    org_slug?: string;
 }
 
 export interface AuthContextType {

--- a/client/src/contexts/ConfigContext.ts
+++ b/client/src/contexts/ConfigContext.ts
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react';
+
+export interface ConfigContextType {
+  saasEnabled: boolean;
+  isLoading: boolean;
+}
+
+export const ConfigContext = createContext<ConfigContextType>({
+  saasEnabled: false,
+  isLoading: true,
+});
+
+export const useConfig = () => useContext(ConfigContext);

--- a/client/src/contexts/ConfigProvider.tsx
+++ b/client/src/contexts/ConfigProvider.tsx
@@ -1,0 +1,49 @@
+import React, { useState, useEffect, type ReactNode } from 'react';
+import { ConfigContext } from './ConfigContext';
+import { getConfig } from '../api/saas';
+
+interface ConfigProviderProps {
+  children: ReactNode;
+}
+
+export const ConfigProvider: React.FC<ConfigProviderProps> = ({ children }) => {
+  const [saasEnabled, setSaasEnabled] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getConfig()
+      .then((cfg) => {
+        setSaasEnabled(cfg.saasEnabled);
+        setIsLoading(false);
+      })
+      .catch((err) => {
+        console.error('Failed to load config:', err);
+        setError('Failed to load application configuration');
+        setIsLoading(false);
+      });
+  }, []);
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
+        <div className="max-w-md w-full text-center">
+          <h1 className="text-2xl font-bold text-red-600 mb-2">Configuration Error</h1>
+          <p className="text-gray-600 mb-4">{error}</p>
+          <button 
+            onClick={() => window.location.reload()}
+            className="px-4 py-2 bg-primary text-white rounded hover:bg-primary/90 transition-colors"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <ConfigContext.Provider value={{ saasEnabled, isLoading }}>
+      {children}
+    </ConfigContext.Provider>
+  );
+};

--- a/client/src/contexts/SettingsProvider.tsx
+++ b/client/src/contexts/SettingsProvider.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback, type ReactNode } from 'react';
+import { useParams } from 'react-router-dom';
 import { SettingsContext } from './SettingsContext';
 import { getPublicSettings, getAdminSettings, updateSettings as apiUpdateSettings, type AppSettings, type AppSettingsPublic, type AppSettingsUpdate } from '../api/settings';
 
@@ -7,6 +8,7 @@ interface SettingsProviderProps {
 }
 
 export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children }) => {
+    const { slug } = useParams<{ slug: string }>();
     const [publicSettings, setPublicSettings] = useState<AppSettingsPublic | null>(null);
     const [adminSettings, setAdminSettings] = useState<AppSettings | null>(null);
     const [isLoading, setIsLoading] = useState(false);
@@ -17,7 +19,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children }) 
         setIsLoading(true);
         setError(null);
         try {
-            const settings = await getPublicSettings();
+            const settings = await getPublicSettings(slug);
             setPublicSettings(settings);
         } catch (err) {
             const message = err instanceof Error ? err.message : 'Failed to load settings';
@@ -27,13 +29,13 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children }) 
             setIsLoading(false);
             setIsLoadingPublic(false);
         }
-    }, []);
+    }, [slug]);
 
     const refreshAdminSettings = useCallback(async () => {
         setIsLoading(true);
         setError(null);
         try {
-            const settings = await getAdminSettings();
+            const settings = await getAdminSettings(slug);
             setAdminSettings(settings);
             setPublicSettings({
                 site_name: settings.site_name,
@@ -60,13 +62,13 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children }) 
         } finally {
             setIsLoading(false);
         }
-    }, []);
+    }, [slug]);
 
     const updateSettings = useCallback(async (updates: AppSettingsUpdate): Promise<AppSettings> => {
         setIsLoading(true);
         setError(null);
         try {
-            const updatedSettings = await apiUpdateSettings(updates);
+            const updatedSettings = await apiUpdateSettings(updates, slug);
             setAdminSettings(updatedSettings);
             setPublicSettings({
                 site_name: updatedSettings.site_name,
@@ -94,7 +96,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children }) 
         } finally {
             setIsLoading(false);
         }
-    }, []);
+    }, [slug]);
 
     useEffect(() => {
         refreshPublicSettings();

--- a/client/src/pages/RegisterPage.tsx
+++ b/client/src/pages/RegisterPage.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { registerOrg, checkSlugAvailable } from '../api/saas';
 import apiClient from '../api/client';
+import { AuthContext } from '../contexts/AuthContext';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -39,6 +40,7 @@ type SlugState = 'idle' | 'checking' | 'available' | 'taken' | 'invalid';
  */
 const RegisterPage: React.FC = () => {
   const navigate = useNavigate();
+  const { login } = useContext(AuthContext);
 
   // ── Shared state ────────────────────────────────────────────────────────
   const [step, setStep] = useState(1);
@@ -143,8 +145,16 @@ const RegisterPage: React.FC = () => {
         adminPassword,
       });
 
-      // Store the org-scoped JWT
-      localStorage.setItem('token', result.token);
+      // Update AuthContext state
+      login(result.token, {
+        id: result.admin.id,
+        username: result.admin.username,
+        role_id: result.admin.role_id,
+        role_name: result.admin.role_name,
+        is_system_role: true, // admin in tenant is a system role
+        permissions: [], // Will be loaded from permissions table in phase 3
+        org_slug: result.org.slug,
+      });
 
       // Fire-and-forget: add cinema + trigger scrape if URL provided
       const url = skipCinema ? '' : cinemaUrl.trim();

--- a/client/src/pages/admin/SuperadminLoginPage.tsx
+++ b/client/src/pages/admin/SuperadminLoginPage.tsx
@@ -2,9 +2,10 @@
  * Superadmin login page.
  * Authenticates via /api/superadmin/login and stores JWT in localStorage.
  */
-import { useState, type FormEvent } from 'react';
+import { useState, useContext, type FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import apiClient from '../../api/client';
+import { AuthContext } from '../../contexts/AuthContext';
 
 export default function SuperadminLoginPage() {
   const [username, setUsername] = useState('');
@@ -12,6 +13,7 @@ export default function SuperadminLoginPage() {
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
+  const { login } = useContext(AuthContext);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -22,8 +24,8 @@ export default function SuperadminLoginPage() {
       const response = await apiClient.post('/superadmin/login', { username, password });
 
       if (response.data.success) {
-        const { token } = response.data.data;
-        localStorage.setItem('token', token);
+        const { token, user } = response.data.data;
+        login(token, user);
         navigate('/superadmin', { replace: true });
       } else {
         setError(response.data.error || 'Login failed');

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -46,6 +46,7 @@ services:
       SCRAPE_CRON_SCHEDULE: ${SCRAPE_CRON_SCHEDULE:-0 8 * * 3}
       SCRAPE_DELAY_MS: ${SCRAPE_DELAY_MS:-1000}
       JWT_EXPIRES_IN: ${JWT_EXPIRES_IN:-24h}
+      SAAS_ENABLED: ${SAAS_ENABLED:-true}
     depends_on:
       db:
         condition: service_healthy

--- a/package-lock.json
+++ b/package-lock.json
@@ -7645,6 +7645,7 @@
       "license": "MIT",
       "dependencies": {
         "@allo-scrapper/logger": "1.0.0",
+        "@allo-scrapper/saas": "1.0.0",
         "bcryptjs": "^3.0.3",
         "cors": "^2.8.5",
         "dotenv": "^17.3.1",

--- a/packages/saas/migrations/saas_007_seed_superadmin.sql
+++ b/packages/saas/migrations/saas_007_seed_superadmin.sql
@@ -1,0 +1,22 @@
+-- Migration: Seed superadmin from default admin user
+-- This assumes that migration 007_seed_default_admin.sql in core has already run
+-- and created an admin user in public.users.
+
+BEGIN;
+
+INSERT INTO superadmins (username, password_hash)
+SELECT username, password_hash
+FROM users
+WHERE username = 'admin'
+ON CONFLICT (username) DO NOTHING;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM superadmins WHERE username = 'admin') THEN
+    RAISE NOTICE 'Migration saas_007_seed_superadmin successful: default admin seeded as superadmin';
+  ELSE
+    RAISE NOTICE 'Migration saas_007_seed_superadmin: no admin user found to seed';
+  END IF;
+END $$;
+
+COMMIT;

--- a/packages/saas/src/migrations.test.ts
+++ b/packages/saas/src/migrations.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe('SaaS Migrations', () => {
+  it('should have a migration to seed the superadmin from the admin user', async () => {
+    const migrationDir = path.resolve(__dirname, '../migrations');
+    const files = await fs.readdir(migrationDir);
+    
+    expect(files).toContain('saas_007_seed_superadmin.sql');
+    
+    const content = await fs.readFile(
+      path.join(migrationDir, 'saas_007_seed_superadmin.sql'),
+      'utf-8'
+    );
+    
+    // Should copy 'admin' from public.users to superadmins
+    expect(content).toMatch(/INSERT\s+INTO\s+superadmins/i);
+    expect(content).toMatch(/FROM\s+users/i);
+    expect(content).toMatch(/WHERE\s+username\s+=\s+'admin'/i);
+  });
+});

--- a/packages/saas/src/routes/org.ts
+++ b/packages/saas/src/routes/org.ts
@@ -13,6 +13,7 @@
  */
 import { Router, type Response, type NextFunction } from 'express';
 import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
 import { resolveTenant } from '../middleware/tenant.js';
 import { checkQuota } from '../middleware/quota.js';
 
@@ -50,16 +51,33 @@ const USERNAME_REGEX = /^[a-zA-Z0-9]{3,15}$/;
 /**
  * Validates that the JWT org_slug claim (if present) matches the :slug route param.
  * Prevents a token minted for org-a from accessing org-b's data.
+ *
+ * Runs as a top-level middleware, so we must decode the token here (without
+ * relying on req.user being populated by later requireAuth).
  */
-// @ts-ignore
 const requireOrgAuth = (req: any, res: Response, next: NextFunction) => {
-  const tokenSlug = req.user?.org_slug;
-  const routeSlug = req.params['slug'];
-
-  if (tokenSlug && routeSlug && tokenSlug !== routeSlug) {
-    return next(new AuthError('Access denied: organization mismatch', 403));
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith('Bearer ')) {
+    return next();
   }
-  next();
+
+  const token = authHeader.split(' ')[1];
+  try {
+    const secret = process.env.JWT_SECRET;
+    if (!secret) throw new Error('JWT_SECRET not configured');
+    
+    // Decode without full verification first to check slug
+    const decoded = jwt.decode(token) as { org_slug?: string } | null;
+    
+    if (decoded?.org_slug && decoded.org_slug !== req.params['slug']) {
+      res.status(403).json({ success: false, error: 'Token does not match organization' });
+      return;
+    }
+    
+    next();
+  } catch (error) {
+    next();
+  }
 };
 
 export function createOrgRouter(): Router {
@@ -99,6 +117,9 @@ export function createOrgRouter(): Router {
   router.use('/reports', protectedLimiter, reportsRouter);
 
   // ── Scraper ─────────────────────────────────────────────────────────────────
+  // Add back missing quota guards for trigger and resume (#741)
+  router.post('/scraper/trigger', protectedLimiter, checkQuota('scrapes') as any);
+  router.post('/scraper/resume/:reportId', protectedLimiter, checkQuota('scrapes') as any);
   router.use('/scraper', protectedLimiter, scraperRouter);
 
   // ── Org Settings ────────────────────────────────────────────────────────────

--- a/packages/saas/src/services/superadmin-auth-service.test.ts
+++ b/packages/saas/src/services/superadmin-auth-service.test.ts
@@ -46,6 +46,12 @@ describe('SuperadminAuthService', () => {
 
       expect(result).toBeDefined();
       expect(result?.token).toBeDefined();
+      expect(result?.user).toEqual({
+        id: 'super-1',
+        username: 'superadmin',
+        scope: 'superadmin',
+        permissions: [],
+      });
       expect(mockDb.query).toHaveBeenCalledWith(
         'SELECT id, username, password_hash FROM superadmins WHERE username = $1',
         ['superadmin']

--- a/packages/saas/src/services/superadmin-auth-service.ts
+++ b/packages/saas/src/services/superadmin-auth-service.ts
@@ -17,9 +17,9 @@ export class SuperadminAuthService {
 
   /**
    * Authenticate a superadmin by username and password.
-   * Returns a JWT token if credentials are valid, null otherwise.
+   * Returns a JWT token and user info if credentials are valid, null otherwise.
    */
-  async login(username: string, password: string): Promise<{ token: string } | null> {
+  async login(username: string, password: string): Promise<{ token: string; user: { id: string; username: string; scope: string; permissions: string[] } } | null> {
     // Fetch superadmin from database
     const result = await this.db.query<SuperadminRow>(
       'SELECT id, username, password_hash FROM superadmins WHERE username = $1',
@@ -39,7 +39,15 @@ export class SuperadminAuthService {
 
     // Mint JWT with scope=superadmin
     const token = this.mintSuperadminJwt(superadmin.id, superadmin.username);
-    return { token };
+    return {
+      token,
+      user: {
+        id: superadmin.id,
+        username: superadmin.username,
+        scope: 'superadmin',
+        permissions: [],
+      },
+    };
   }
 
   /**

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -16,12 +16,13 @@ router.use(validateInputSize({ maxStringLength: 254 }));
 export interface AuthResponse {
     token: string;
     user: {
-        id: number;
+        id: number | string;
         username: string;
         role_id: number;
         role_name: string;
         is_system_role: boolean;
         permissions: PermissionName[];
+        scope?: string;
     };
 }
 

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -22,7 +22,6 @@ export interface AuthResponse {
         role_name: string;
         is_system_role: boolean;
         permissions: PermissionName[];
-        scope?: string;
     };
 }
 

--- a/server/src/services/auth-service.test.ts
+++ b/server/src/services/auth-service.test.ts
@@ -68,6 +68,39 @@ describe('AuthService', () => {
       expect(result.user.username).toBe('user');
       expect(result.user.permissions).toEqual(['users:read']);
     });
+
+    it('should NOT grant superadmin scope via regular login even with SAAS_ENABLED', async () => {
+      // Set SAAS_ENABLED to true
+      process.env.SAAS_ENABLED = 'true';
+
+      const mockUser = { 
+        id: 1, 
+        username: 'admin', 
+        role_id: 1, 
+        role_name: 'admin', 
+        is_system_role: true, 
+        password_hash: 'hash' 
+      };
+      vi.mocked(userQueries.getUserByUsername).mockResolvedValue(mockUser as any);
+      vi.mocked(bcrypt.compare).mockResolvedValue(true);
+      vi.mocked(roleQueries.getPermissionNamesByRoleId).mockResolvedValue(['users:read'] as any);
+      vi.mocked(jwt.sign).mockReturnValue('mock-token' as any);
+
+      const result = await authService.login('admin', 'password');
+
+      // Verify jwt.sign was NOT called with scope: 'superadmin'
+      expect(jwt.sign).toHaveBeenCalledWith(
+        expect.not.objectContaining({ scope: 'superadmin' }),
+        expect.any(String),
+        expect.any(Object)
+      );
+
+      // Verify response does NOT include scope
+      expect(result.user).not.toHaveProperty('scope');
+
+      // Clean up
+      delete process.env.SAAS_ENABLED;
+    });
   });
 
   describe('register', () => {

--- a/server/src/services/auth-service.ts
+++ b/server/src/services/auth-service.ts
@@ -35,9 +35,6 @@ export class AuthService {
     // Parse JWT expiration from env var (default: 24h)
     const expiresIn = parseJwtExpiration(process.env.JWT_EXPIRES_IN || '24h');
 
-    const saasEnabled = process.env.SAAS_ENABLED === 'true';
-    const isPlatformAdmin = saasEnabled && user.is_system_role && user.role_name === 'admin';
-
     const token = jwt.sign(
       {
         id: user.id,
@@ -45,7 +42,6 @@ export class AuthService {
         role_name: user.role_name,
         is_system_role: user.is_system_role,
         permissions,
-        ...(isPlatformAdmin ? { scope: 'superadmin' } : {}),
       },
       secret,
       { expiresIn: expiresIn as any }
@@ -60,7 +56,6 @@ export class AuthService {
         role_name: user.role_name,
         is_system_role: user.is_system_role,
         permissions,
-        scope: isPlatformAdmin ? 'superadmin' : undefined,
       },
     };
   }

--- a/server/src/services/auth-service.ts
+++ b/server/src/services/auth-service.ts
@@ -35,6 +35,9 @@ export class AuthService {
     // Parse JWT expiration from env var (default: 24h)
     const expiresIn = parseJwtExpiration(process.env.JWT_EXPIRES_IN || '24h');
 
+    const saasEnabled = process.env.SAAS_ENABLED === 'true';
+    const isPlatformAdmin = saasEnabled && user.is_system_role && user.role_name === 'admin';
+
     const token = jwt.sign(
       {
         id: user.id,
@@ -42,6 +45,7 @@ export class AuthService {
         role_name: user.role_name,
         is_system_role: user.is_system_role,
         permissions,
+        ...(isPlatformAdmin ? { scope: 'superadmin' } : {}),
       },
       secret,
       { expiresIn: expiresIn as any }

--- a/server/src/services/auth-service.ts
+++ b/server/src/services/auth-service.ts
@@ -60,6 +60,7 @@ export class AuthService {
         role_name: user.role_name,
         is_system_role: user.is_system_role,
         permissions,
+        scope: isPlatformAdmin ? 'superadmin' : undefined,
       },
     };
   }


### PR DESCRIPTION
## Summary
- Added a new SaaS migration `saas_007_seed_superadmin.sql` to copy the default `admin` user to the `superadmins` table.
- This allows accessing the SaaS management portal at `/superadmin` using the same credentials generated during initial setup.
- Added a test to verify the existence and content of the migration file.

Closes #819