### PR TITLE
⚡ Bolt: Memoize filtered films array in HomePage

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,3 @@
-## 2026-04-08 - Use Promise.all() to run concurrent independent queries
-**Learning:** Found sequential independent database queries in `getScraperStatus` (`server/src/services/system-info.ts`) which unnecessarily block one another, thereby creating a response time bottleneck.
-**Action:** When working on backend queries and system services, always verify that independent queries execute concurrently (using `Promise.all()`) instead of sequentially to optimize application latency.
+## 2026-04-15 - React useMemo Optimization Pitfalls
+**Learning:** When using `useMemo` to optimize a calculation (like a filter/map operation), relying on inline empty arrays (e.g., `|| []`) for fallback values breaks the memoization by creating a new reference on every render during loading states.
+**Action:** Define stable fallback constants outside the React component (e.g., `const EMPTY_FILMS = [];`) to ensure `useMemo` dependencies remain strictly referentially equal and effectively prevent O(N*M*K) recalculations. Always double-check imports for hooks when adding them to an existing file.

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -7,6 +7,9 @@ import FilmSearchBar from '../components/FilmSearchBar';
 import ScrollToTop from '../components/ScrollToTop';
 import { AuthContext } from '../contexts/AuthContext';
 import CinemasQuickLinks from '../components/CinemasQuickLinks';
+import type { FilmWithShowtimes } from '../types';
+
+const EMPTY_FILMS: FilmWithShowtimes[] = [];
 
 export default function HomePage() {
   const queryClient = useQueryClient();
@@ -24,13 +27,19 @@ export default function HomePage() {
     queryFn: () => selectedDate ? getFilmsByDate(selectedDate) : getWeeklyFilms(),
   });
 
-  const allFilms = filmsData?.films || [];
-  // When "Maintenant" is active, hide films whose showtimes are all in the past
-  const films = afterTime
-    ? allFilms.filter(film =>
-        film.cinemas.some(c => c.showtimes.some(s => s.time >= afterTime))
-      )
-    : allFilms;
+  const allFilms = filmsData?.films || EMPTY_FILMS;
+
+  // ⚡ PERFORMANCE: Memoize the filtered films list to prevent expensive
+  // O(N*M*K) recalculation (films * cinemas * showtimes) on every render
+  // and reduce garbage collection pressure.
+  const films = useMemo(() => {
+    return afterTime
+      ? allFilms.filter(film =>
+          film.cinemas.some(c => c.showtimes.some(s => s.time >= afterTime))
+        )
+      : allFilms;
+  }, [allFilms, afterTime]);
+
   const weekStart = filmsData?.weekStart || '';
 
   const isLoading = isLoadingCinemas || isLoadingFilms;


### PR DESCRIPTION
💡 **What**: Wrapped the computation of the `films` array in `client/src/pages/HomePage.tsx` in a `useMemo` hook with a stable `EMPTY_FILMS` fallback dependency.
🎯 **Why**: Previously, the `films` array was being derived on every single React render using an `allFilms.filter` combined with two nested `.some` checks on `cinemas` and `showtimes`. This results in an `O(N*M*K)` time complexity that recalculates needlesly when unrelated component state changes or during loading states, causing unnecessary CPU work and triggering frequent garbage collection. 
📊 **Impact**: Reduces CPU utilization and garbage collection pressure in `HomePage` by avoiding recalculation of the visible films list on subsequent renders unless the source data (`allFilms`) or the time filter (`afterTime`) specifically change.
🔬 **Measurement**: Verified by running the client test suite successfully. The optimization effectively prevents the `allFilms.filter` loop from executing on every component update lifecycle.

---
*PR created automatically by Jules for task [5423184465067456011](https://jules.google.com/task/5423184465067456011) started by @PhBassin*