### PR TITLE
🛡️ Sentinel: [HIGH] Fix rate limit exhaustion via JWT spoofing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,4 @@
-## 2026-04-10 - Express 5 path-to-regexp v8 wildcard routes issue
-**Vulnerability:** Unsafe string-based catch-all routes (`{*splat}`) in Express 5 cause `TypeError: Missing parameter name` rendering the API 404 handler broken.
-**Learning:** This exposes the application to potentially leaking SPA fallback logic (sending HTML) for API endpoints instead of properly formatted JSON 404 responses.
-**Prevention:** Always use safe native regular expressions (like `/^\/api(?:\/(.*))?$/`) for wildcard/catch-all routes in Express 5 apps utilizing `path-to-regexp` v8.
+## 2026-04-18 - Prevent Rate Limit Exhaustion via JWT Spoofing
+**Vulnerability:** The rate limiter's `authenticatedKeyGenerator` used `jwt.decode` instead of `jwt.verify` to extract user IDs for bucketing. This allowed an attacker to spoof arbitrary user IDs with unverified tokens, consuming their rate limit quotas and causing a targeted Denial of Service (DoS).
+**Learning:** Rate-limiting middleware often executes before authentication middleware. Relying on downstream validation for properties extracted upstream creates security gaps.
+**Prevention:** Always use `jwt.verify` with the correct cryptographic secret when extracting identity claims for any security or resource allocation mechanism, even if full authentication happens later.

--- a/server/src/middleware/rate-limit.test.ts
+++ b/server/src/middleware/rate-limit.test.ts
@@ -12,18 +12,23 @@ import {
   healthCheckLimiter,
 } from './rate-limit.js';
 
-// Helper: sign a minimal JWT for rate-limit key tests (secret doesn't matter — we use jwt.decode)
+const TEST_JWT_SECRET = 'a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6';
+
+// Helper: sign a minimal JWT for rate-limit key tests (must be verified against TEST_JWT_SECRET)
 const makeToken = (userId: number): string =>
-  jwt.sign({ id: userId, username: `user${userId}` }, 'test-secret');
+  jwt.sign({ id: userId, username: `user${userId}` }, TEST_JWT_SECRET);
 
 describe('Rate Limiting Middleware', () => {
   let app: express.Application;
 
   let originalNodeEnv: string | undefined;
+  let originalJwtSecret: string | undefined;
 
   beforeEach(() => {
     originalNodeEnv = process.env.NODE_ENV;
+    originalJwtSecret = process.env.JWT_SECRET;
     process.env.NODE_ENV = 'development';
+    process.env.JWT_SECRET = TEST_JWT_SECRET;
     app = express();
     app.use(express.json());
     // Trust proxy to enable rate limiting in tests
@@ -32,6 +37,11 @@ describe('Rate Limiting Middleware', () => {
 
   afterEach(() => {
     process.env.NODE_ENV = originalNodeEnv;
+    if (originalJwtSecret === undefined) {
+      delete process.env.JWT_SECRET;
+    } else {
+      process.env.JWT_SECRET = originalJwtSecret;
+    }
   });
 
   describe('generalLimiter', () => {

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -1,6 +1,7 @@
 import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import jwt from 'jsonwebtoken';
 import type { Request } from 'express';
+import { validateJWTSecret } from '../utils/jwt-secret-validator.js';
 
 // Helper to parse env var as number with fallback
 const parseEnvInt = (key: string, defaultValue: number): number => {
@@ -30,18 +31,26 @@ const skipTest = (req: any) => process.env.NODE_ENV === 'test' || !req.ip;
 // Window duration in milliseconds
 const WINDOW_MS = parseEnvInt('RATE_LIMIT_WINDOW_MS', 15 * 60 * 1000); // 15 min
 
+let _jwtSecret: string | null = null;
+const getJwtSecret = (): string => {
+  if (!_jwtSecret) {
+    _jwtSecret = validateJWTSecret();
+  }
+  return _jwtSecret;
+};
+
 /**
  * Key generator that buckets authenticated requests by user id.
  * Falls back to req.ip for unauthenticated requests.
- * Uses jwt.decode (not jwt.verify) — we only need the payload for bucketing;
- * security verification is already handled by the requireAuth middleware.
+ * Uses jwt.verify to ensure the token is legitimate before bucketing by user ID,
+ * preventing attackers from exhausting rate limits of arbitrary users by sending spoofed tokens.
  */
 export const authenticatedKeyGenerator = (req: Request): string => {
   try {
     const authHeader = req.headers.authorization;
     if (authHeader?.startsWith('Bearer ')) {
       const token = authHeader.split(' ')[1];
-      const decoded = jwt.decode(token) as { id?: number } | null;
+      const decoded = jwt.verify(token, getJwtSecret()) as { id?: number };
       if (decoded?.id) return `user:${decoded.id}`;
     }
   } catch {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The rate limiter's `authenticatedKeyGenerator` was using `jwt.decode` to extract the `id` from the authorization token without verifying its cryptographic signature. Since the `protectedLimiter` runs before the `requireAuth` middleware, an attacker could send a syntactically correct but unverified token containing an arbitrary `id`. The rate limiter would then bucket the request under that spoofed ID, allowing the attacker to exhaust the rate limit quota of any user and deny them service.
🎯 **Impact:** An attacker could perform a targeted Denial of Service (DoS) against specific users by continuously exhausting their API rate limits using spoofed tokens.
🔧 **Fix:** Imported `validateJWTSecret()` to lazily retrieve the secure secret, and replaced `jwt.decode()` with `jwt.verify()`. The key generator will now safely fall back to IP-based bucketing if the token signature is invalid. Mock JWTs in the test suite were updated to be signed with a valid test secret.
✅ **Verification:** Unit tests for `rate-limit.test.ts` have been updated and run successfully to verify the expected bucketing behavior.

---
*PR created automatically by Jules for task [7860261911085674850](https://jules.google.com/task/7860261911085674850) started by @PhBassin*