### PR TITLE
feat(observability): propagate org trace context across scraper flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,6 +695,12 @@ docker compose --profile monitoring up -d
 - Forged `org_id` values in request bodies are sanitized to the authenticated tenant context before handler execution.
 - Boundary violations are logged as structured security events with `org_id`, `requested_org_id`, `user_id`, `method`, and `path`.
 
+**Org-aware Trace and Log Correlation:**
+- Scraper trigger/resume jobs propagate tenant observability metadata through Redis job `traceContext` (`org_id`, `org_slug`, `user_id`, `endpoint`, `method`, optional `traceparent`).
+- Scraper workers log tenant-aware execution context for queued jobs, enabling cross-service correlation between API logs, worker logs, and queue operations.
+- SSE scraper progress connection lifecycle logs include `org_id`, `user_id`, `endpoint`, and `method` for tenant-specific troubleshooting.
+- Centralized API error logs include request context (`org_id`, `user_id`, `endpoint`, `error`) so Loki filters can isolate tenant incidents quickly.
+
 **JWT Token Scopes:**
 - Superadmin tokens include `scope: 'superadmin'` claim
 - Standard organization tokens include `scope: 'user'` and `orgId`

--- a/_bmad-output/implementation-artifacts/1-2-add-org-id-to-all-observability-traces.md
+++ b/_bmad-output/implementation-artifacts/1-2-add-org-id-to-all-observability-traces.md
@@ -1,0 +1,208 @@
+# Story 1.2: Add org_id to All Observability Traces
+
+Status: done
+
+## Story
+
+As a DevOps engineer,
+I want all OpenTelemetry traces to include org_id as a span attribute,
+so that I can filter traces by organization when debugging issues.
+
+## Acceptance Criteria
+
+1. **Given** a request is made by a user with `org_id=A`  
+   **When** the request is traced via OpenTelemetry  
+   **Then** the trace span includes attribute `org_id=A`  
+   **And** the attribute is present on all child spans  
+   **And** the trace is exportable to Tempo with org_id metadata
+
+2. **Given** a scraper job is triggered for `org_id=A`  
+   **When** the job executes  
+   **Then** all scraper trace spans include `org_id=A`  
+   **And** the Redis job metadata includes org_id  
+   **And** SSE progress events include org_id in trace context
+
+3. **Given** an error occurs during a request  
+   **When** the error is logged via Winston  
+   **Then** the log entry includes `org_id` field  
+   **And** the log is structured JSON with `{ org_id, user_id, endpoint, error }`  
+   **And** Loki can filter logs by org_id
+
+## Tasks / Subtasks
+
+- [x] Add RED tests for org-aware observability behavior before implementation (AC: 1, 2, 3)
+  - [x] Add/extend unit tests in `server/src/services/scraper-service.test.ts` to fail when queued jobs do not carry tenant trace metadata
+  - [x] Add/extend route/service tests in `server/src/routes/scraper.test.ts` for org-aware trigger paths and error logging payload shape
+  - [x] Add focused tests for trace metadata propagation in scraper queue handling (`scraper/src/redis/client.ts` and/or related tests)
+  - [x] Add test assertions for structured log metadata containing `org_id`, `user_id`, `endpoint`, and `error`
+
+- [x] Implement org-aware trace context propagation from API to scraper jobs (AC: 1, 2)
+  - [x] Extend server job publish path to include tenant context in `traceContext` metadata (`org_id`, `org_slug`, request path, actor id)
+  - [x] Keep payload typed (`Record<string, string>`) and deterministic across `trigger` and `resume` flows
+  - [x] Ensure scraper job consumer preserves and uses incoming trace metadata during execution paths
+  - [x] Do not introduce a second job envelope format; extend existing `ScrapeJob` contract in-place
+
+- [x] Enrich structured logging with tenant context in observability-critical paths (AC: 3)
+  - [x] Add/standardize org-aware log fields in request paths that already log security or operational events (notably scraper trigger/resume/status and error handler)
+  - [x] Ensure logs include `org_id`, `user_id`, and endpoint path when a tenant-scoped user is present
+  - [x] Keep standalone compatibility: tokens without `org_id` remain valid and log `org_id` as absent/undefined without throwing
+  - [x] Preserve Winston structured JSON format in production (no `console.log` in server or scraper code paths)
+
+- [x] Align SSE progress context with tenant trace metadata (AC: 2)
+  - [x] Ensure progress publishing path can carry org-aware trace context from queued job metadata
+  - [x] Validate that SSE-progress related diagnostics can be correlated to tenant context for Tempo/Loki triage
+  - [x] Keep existing SSE event schema backward compatible for client consumers
+
+- [x] Validate OpenTelemetry integration boundaries and avoid scope creep (AC: 1, 2)
+  - [x] Reuse current tracing entry points in scraper (`scraper/src/utils/tracer.ts`) and existing `traceContext` fields in queue job types
+  - [x] If server-side span instrumentation is incomplete, implement org-aware metadata propagation without introducing unplanned framework migration
+  - [x] Document any deferred gap explicitly in completion notes (e.g., full child-span enforcement in packages without active spans)
+
+- [x] Documentation updates for observability contracts (AC: 1, 2, 3)
+  - [x] Update `README.md` observability/security sections with org-aware logging/tracing guarantees
+  - [x] Add or update test guidance for validating `org_id` in logs/traces for multi-tenant requests
+
+### Review Findings
+
+- [x] [Review][Patch] Span-level OpenTelemetry propagation is still missing for `org_id` — AC1/AC2 require `org_id` on request spans and child spans (including scraper spans), but current implementation only propagates queue/log metadata (`traceContext`) and does not set span attributes.
+- [x] [Review][Patch] SSE progress events still do not carry tenant trace context — AC2 requires progress events to include `org_id` trace context, but only connection lifecycle logs were enriched; emitted SSE payloads remain unchanged.
+- [x] [Review][Patch] Missing observability context in schedule immediate-trigger path [`server/src/routes/scraper.ts:391`]
+- [x] [Review][Patch] `traceparent` is forwarded without validation or size bounds [`server/src/routes/scraper.ts:52`]
+- [x] [Review][Patch] Scraper failure logs lost error object/stack detail after refactor [`scraper/src/index.ts:89`]
+- [x] [Review][Patch] Logging `originalUrl` can leak query-string data; prefer sanitized path fields [`server/src/middleware/error-handler.ts:12`]
+
+## Dev Notes
+
+### Scope and Guardrails
+
+- This story is the observability companion to Story 1.1 security boundary enforcement. Keep scope focused on `org_id` trace/log propagation, not broader auth redesign.
+- Reuse existing `traceContext` fields in queue contracts; do not invent new transport layers for scraper context.
+- Keep multi-tenant behavior additive and backward compatible with standalone mode where JWT may not contain `org_id`.
+- Do not add `any` in auth, trace, or log contexts; security-sensitive typing must remain strict.
+
+### Reinvention Prevention
+
+- Extend these existing locations instead of creating parallel systems:
+  - `server/src/services/scraper-service.ts`
+  - `server/src/services/redis-client.ts`
+  - `server/src/routes/scraper.ts`
+  - `server/src/middleware/error-handler.ts`
+  - `scraper/src/redis/client.ts`
+  - `scraper/src/index.ts`
+- Keep logger creation centralized via `server/src/utils/logger.ts` and `packages/logger/src/index.ts`.
+- Reuse JWT org context from `AuthRequest` (`org_id`, `org_slug`) instead of reparsing tokens.
+
+### Previous Story Intelligence (from 1.1)
+
+- Story 1.1 established strict org-boundary behavior with stable 403 contract (`Cross-tenant access denied`) and structured security logs; preserve field naming consistency (`org_id`, `requested_org_id`, `user_id`).
+- Route-chain ordering is already guarded in tests (limiter -> auth -> permission -> org-boundary -> handler). Keep this intact while adding observability fields.
+- Prior fixes addressed falsy-org edge handling; avoid introducing truthiness regressions when mapping optional `org_id` into metadata.
+- Org-scoped SaaS routing in `packages/saas/src/routes/org.ts` remains the primary tenant-aware path; observability coverage must include this usage pattern.
+
+### Git Intelligence Summary
+
+- Recent commits show completed tenant fixture APIs and org boundary middleware enforcement; this story should leverage those foundations, not duplicate tenancy checks.
+- Current commit style and implementation pattern favor focused route/service updates with test expansion in-place; follow that pattern for observability enrichment.
+
+### Architecture Compliance Notes
+
+- Keep ESM imports and strict TypeScript conventions.
+- Preserve middleware and service separation: routes orchestrate, services handle queue/tracking logic.
+- Respect production logging requirements (Winston JSON in production for Loki ingestion).
+- Keep compatibility with current OpenTelemetry footprint (scraper instrumentation active, server instrumentation limited).
+
+### Suggested Test Matrix
+
+- `POST /api/scraper/trigger` with org-aware JWT publishes job containing tenant trace metadata
+- `POST /api/scraper/resume/:reportId` carries same tenant metadata contract
+- Scraper job consumer receives trace metadata and maintains tenant correlation
+- Error handling paths produce structured log metadata with `org_id`, `user_id`, `endpoint`, `error`
+- Standalone JWT (no `org_id`) still succeeds while producing safe, non-crashing log output
+
+### Concrete File Targets
+
+- `server/src/services/scraper-service.ts` - include org-aware trace metadata in queued jobs
+- `server/src/services/redis-client.ts` - keep typed queue payload support for trace context
+- `server/src/routes/scraper.ts` - pass authenticated org context into service trigger/resume flows
+- `server/src/middleware/error-handler.ts` - enrich structured error logs with request tenant metadata
+- `server/src/services/scraper-service.test.ts` - RED/GREEN tests for trace context propagation
+- `server/src/routes/scraper.test.ts` - route-level observability and payload regression tests
+- `scraper/src/redis/client.ts` - consume/preserve org-aware trace metadata contract
+- `scraper/src/index.ts` - include tenant metadata in operational logs where available
+- `README.md` - document org-aware observability guarantees
+
+### Implementation Order (Mandatory)
+
+1. RED: add failing tests for org-aware trace/log propagation and structured error metadata.
+2. GREEN: minimally wire org context through route -> service -> Redis job metadata.
+3. HARDEN: ensure scraper-side usage + error-path logging includes tenant fields consistently.
+4. DOCS: update README/testing guidance for org-aware observability assertions.
+
+### Pitfalls to Avoid
+
+- Do not trust client-provided org identifiers in body/query for trace metadata; source from authenticated JWT context.
+- Do not break existing SSE payload contract while adding trace correlation fields.
+- Do not add heavy server-side tracing framework migrations in this story unless absolutely required by failing AC coverage.
+- Do not omit `org_id` from error logs in tenant-scoped requests.
+
+### References
+
+- Story source: `_bmad-output/planning-artifacts/epics.md:479`
+- Epic dependency context: `_bmad-output/planning-artifacts/epics.md:448`
+- Sprint tracker row: `_bmad-output/implementation-artifacts/sprint-status.yaml:62`
+- Previous story intelligence: `_bmad-output/implementation-artifacts/1-1-implement-org-id-validation-middleware.md`
+- Project rules: `_bmad-output/project-context.md:56`
+- Test architecture handoff (RISK-007): `_bmad-output/test-artifacts/test-design/test-design-architecture.md:116`
+- QA coverage mapping (RISK007-INT-002): `_bmad-output/test-artifacts/test-design/test-design-qa.md:310`
+- Auth org context shape: `server/src/middleware/auth.ts:16`
+- Queue trace metadata contract (server): `server/src/services/redis-client.ts:9`
+- Queue trace metadata contract (scraper): `scraper/src/redis/client.ts:21`
+- Scraper trigger service: `server/src/services/scraper-service.ts:16`
+- SSE route integration point: `server/src/routes/scraper.ts:146`
+- Logger implementation: `packages/logger/src/index.ts:12`
+
+## Dev Agent Record
+
+### Agent Model Used
+
+github-copilot/gpt-5.3-codex
+
+### Debug Log References
+
+- CS execution for story 1.2 using sprint tracker + epic context + Story 1.1 learnings
+- `cd server && npm run test:run -- src/services/scraper-service.test.ts src/routes/scraper.test.ts src/middleware/error-handler.test.ts`
+- `cd server && npm run test:run`
+- `cd server && npx tsc --noEmit`
+- `cd scraper && npm run test:run -- src/redis/client.test.ts tests/unit/tracer.test.ts`
+- `cd scraper && npx tsc --noEmit`
+- `cd scraper && npm run test:run` (known pre-existing unrelated failure in `tests/unit/scraper/concurrency.test.ts`)
+
+### Completion Notes List
+
+- Added org-aware trace context propagation from API routes to Redis scraper jobs for trigger/resume flows (`org_id`, `org_slug`, `user_id`, `endpoint`, `method`, optional `traceparent`).
+- Extended scraper route observability logging for trigger/resume/status requests with structured tenant fields.
+- Enriched API error-handler structured logs with request context (`org_id`, `user_id`, `endpoint`, `error`) for Loki filtering.
+- Added scraper worker-side trace-context correlation logs in queue consumer/executor paths while preserving existing job contracts.
+- Added RED/GREEN tests covering trace metadata propagation, route observability context forwarding, and error log payload structure.
+- Updated README and testing guide with org-aware observability validation guidance.
+- Deferred full server-side span attribute propagation to child spans because server-wide OpenTelemetry span instrumentation is not currently present; implemented safe metadata propagation path without framework migration.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/1-2-add-org-id-to-all-observability-traces.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `server/src/services/scraper-service.ts`
+- `server/src/routes/scraper.ts`
+- `server/src/middleware/error-handler.ts`
+- `server/src/services/scraper-service.test.ts`
+- `server/src/routes/scraper.test.ts`
+- `server/src/middleware/error-handler.test.ts`
+- `scraper/src/redis/client.ts`
+- `scraper/src/index.ts`
+- `scraper/src/redis/client.test.ts`
+- `README.md`
+- `server/tests/README.md`
+
+## Change Log
+
+- 2026-04-18: Implemented org-aware observability context propagation from API to scraper queue metadata, enriched structured tenant logging in API and worker paths, added focused tests for trace/log context propagation, and documented observability assertions.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-04-15
-last_updated: 2026-04-17T21:55:00Z
+last_updated: 2026-04-18T08:00:00Z
 project: allo-scrapper
 project_key: NOKEY
 tracking_system: file-system
@@ -59,7 +59,7 @@ development_status:
   # ─────────────────────────────────────────────────────────────
   epic-1: in-progress
   1-1-implement-org-id-validation-middleware: done
-  1-2-add-org-id-to-all-observability-traces: backlog
+  1-2-add-org-id-to-all-observability-traces: done
   1-3-e2e-multi-tenant-cinema-isolation-test: backlog
   1-4-e2e-multi-tenant-user-management-isolation-test: backlog
   1-5-e2e-multi-tenant-schedule-isolation-test: backlog

--- a/scraper/src/index.ts
+++ b/scraper/src/index.ts
@@ -60,6 +60,15 @@ export async function executeJob(job: ScrapeJob): Promise<void> {
   // Support legacy jobs that predate the discriminated union (no 'type' field)
   const jobType = ('type' in job) ? job.type : 'scrape';
 
+  const traceLogContext = {
+    org_id: job.traceContext?.org_id,
+    org_slug: job.traceContext?.org_slug,
+    user_id: job.traceContext?.user_id,
+    endpoint: job.traceContext?.endpoint,
+    method: job.traceContext?.method,
+    traceparent: job.traceContext?.traceparent,
+  };
+
   // Update report status
   try {
     await updateScrapeReport(db, job.reportId, { status: 'running' });
@@ -76,10 +85,14 @@ export async function executeJob(job: ScrapeJob): Promise<void> {
         status: 'success',
         completed_at: new Date().toISOString(),
       });
-      logger.info(`[scraper] add_cinema job ${job.reportId} completed successfully`);
+      logger.info(`[scraper] add_cinema job ${job.reportId} completed successfully`, traceLogContext);
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err);
-      logger.error(`[scraper] add_cinema job ${job.reportId} failed:`, err);
+      logger.error(`[scraper] add_cinema job ${job.reportId} failed`, {
+        ...traceLogContext,
+        error: errorMessage,
+        stack: err instanceof Error ? err.stack : undefined,
+      });
       await updateScrapeReport(db, job.reportId, {
         status: 'failed',
         completed_at: new Date().toISOString(),
@@ -94,7 +107,10 @@ export async function executeJob(job: ScrapeJob): Promise<void> {
 
   try {
     const scrapeJob = job as ScrapeJobScrape;
-    const summary = await runScraper(publisher, scrapeJob.options);
+    const summary = await runScraper(publisher, {
+      ...scrapeJob.options,
+      traceContext: job.traceContext,
+    });
 
     const status = summary.failed_cinemas === 0
       ? 'success'
@@ -118,10 +134,14 @@ export async function executeJob(job: ScrapeJob): Promise<void> {
       errors: summary.errors,
     });
 
-    logger.info(`[scraper] Job ${job.reportId} completed with status: ${status}`);
+    logger.info(`[scraper] Job ${job.reportId} completed with status: ${status}`, traceLogContext);
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err);
-    logger.error(`[scraper] Job ${job.reportId} failed:`, err);
+    logger.error(`[scraper] Job ${job.reportId} failed`, {
+      ...traceLogContext,
+      error: errorMessage,
+      stack: err instanceof Error ? err.stack : undefined,
+    });
     scrapeJobsTotal.inc({ status: 'failed', trigger: job.triggerType });
 
     await updateScrapeReport(db, job.reportId, {
@@ -152,7 +172,14 @@ async function runOneshot(): Promise<void> {
     }
 
     const job: ScrapeJob = JSON.parse(raw);
-    logger.info(`[scraper] Processing job: reportId=${job.reportId}`);
+    logger.info('[scraper] Processing job', {
+      report_id: job.reportId,
+      org_id: job.traceContext?.org_id,
+      org_slug: job.traceContext?.org_slug,
+      user_id: job.traceContext?.user_id,
+      endpoint: job.traceContext?.endpoint,
+      method: job.traceContext?.method,
+    });
     await executeJob(job);
   } finally {
     await redis.quit();

--- a/scraper/src/redis/client.test.ts
+++ b/scraper/src/redis/client.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const subscribeMock = vi.fn();
+const onMock = vi.fn();
+const quitMock = vi.fn();
+const blpopMock = vi.fn();
+const publishMock = vi.fn();
+const lpopMock = vi.fn();
+
+vi.mock('ioredis', () => {
+  class MockRedis {
+    subscribe = subscribeMock;
+    on = onMock;
+    quit = quitMock;
+    blpop = blpopMock;
+    lpop = lpopMock;
+    publish = publishMock;
+  }
+
+  return {
+    default: MockRedis,
+  };
+});
+
+const loggerInfoMock = vi.fn();
+
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    info: (...args: unknown[]) => loggerInfoMock(...args),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe('scraper redis client trace context', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loggerInfoMock.mockReset();
+  });
+
+  it('keeps traceContext metadata when parsing queued jobs', async () => {
+    const { RedisJobConsumer } = await import('./client.js');
+
+    const traceJob = {
+      type: 'scrape',
+      triggerType: 'manual',
+      reportId: 91,
+      traceContext: {
+        org_id: '42',
+        org_slug: 'acme',
+        user_id: '7',
+        endpoint: '/api/org/acme/scraper/trigger',
+        method: 'POST',
+      },
+    };
+
+    blpopMock
+      .mockResolvedValueOnce(['scrape:jobs', JSON.stringify(traceJob)])
+      .mockResolvedValueOnce(null);
+
+    const consumer = new RedisJobConsumer('redis://localhost:6379');
+    const handler = vi.fn(async () => {
+      consumer.stop();
+    });
+
+    await consumer.start(handler);
+
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({
+      reportId: 91,
+      traceContext: expect.objectContaining({
+        org_id: '42',
+        org_slug: 'acme',
+        user_id: '7',
+      }),
+    }));
+
+    expect(loggerInfoMock).toHaveBeenCalledWith(
+      '[RedisJobConsumer] Job trace context',
+      expect.objectContaining({
+        org_id: '42',
+        org_slug: 'acme',
+        user_id: '7',
+        endpoint: '/api/org/acme/scraper/trigger',
+      })
+    );
+  });
+
+  it('keeps traceparent metadata when parsing queued jobs', async () => {
+    const { RedisJobConsumer } = await import('./client.js');
+
+    const traceJob = {
+      type: 'scrape',
+      triggerType: 'manual',
+      reportId: 92,
+      traceContext: {
+        org_id: '42',
+        traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+      },
+    };
+
+    blpopMock
+      .mockResolvedValueOnce(['scrape:jobs', JSON.stringify(traceJob)])
+      .mockResolvedValueOnce(null);
+
+    const consumer = new RedisJobConsumer('redis://localhost:6379');
+    const handler = vi.fn(async () => {
+      consumer.stop();
+    });
+
+    await consumer.start(handler);
+
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({
+      reportId: 92,
+      traceContext: expect.objectContaining({
+        org_id: '42',
+        traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+      }),
+    }));
+  });
+});

--- a/scraper/src/redis/client.ts
+++ b/scraper/src/redis/client.ts
@@ -108,6 +108,16 @@ export class RedisJobConsumer {
         }
 
         logger.info('[RedisJobConsumer] Received job', { reportId: job.reportId, type: job.type, trigger: job.triggerType });
+        if (job.traceContext) {
+          logger.info('[RedisJobConsumer] Job trace context', {
+            reportId: job.reportId,
+            org_id: job.traceContext.org_id,
+            org_slug: job.traceContext.org_slug,
+            user_id: job.traceContext.user_id,
+            endpoint: job.traceContext.endpoint,
+            method: job.traceContext.method,
+          });
+        }
 
         try {
           await handler(job);

--- a/scraper/src/scraper/index.ts
+++ b/scraper/src/scraper/index.ts
@@ -9,6 +9,8 @@ import { getStrategyByUrl, getStrategyBySource } from './strategy-factory.js';
 import { RateLimitError } from '../utils/errors.js';
 import { classifyError } from '../utils/error-classifier.js';
 import { CircuitOpenError } from './circuit-breaker.js';
+import { getTracer } from '../utils/tracer.js';
+import { context, trace } from '@opentelemetry/api';
 import {
   createScrapeAttempt,
   updateScrapeAttempt,
@@ -17,6 +19,28 @@ import {
 // Progress publisher interface – allows injecting Redis publisher or a no-op
 export interface ProgressPublisher {
   emit(event: ProgressEvent): Promise<void>;
+}
+
+function setOrgSpanAttributes(traceContext?: Record<string, string>): void {
+  if (!traceContext) return;
+
+  const activeSpan = trace.getSpan(context.active());
+  if (activeSpan) {
+    if (traceContext.org_id) activeSpan.setAttribute('org_id', traceContext.org_id);
+    if (traceContext.org_slug) activeSpan.setAttribute('org_slug', traceContext.org_slug);
+    if (traceContext.user_id) activeSpan.setAttribute('user_id', traceContext.user_id);
+    if (traceContext.endpoint) activeSpan.setAttribute('endpoint', traceContext.endpoint);
+    if (traceContext.method) activeSpan.setAttribute('method', traceContext.method);
+    return;
+  }
+
+  const span = getTracer().startSpan('scraper.job.org-context');
+  if (traceContext.org_id) span.setAttribute('org_id', traceContext.org_id);
+  if (traceContext.org_slug) span.setAttribute('org_slug', traceContext.org_slug);
+  if (traceContext.user_id) span.setAttribute('user_id', traceContext.user_id);
+  if (traceContext.endpoint) span.setAttribute('endpoint', traceContext.endpoint);
+  if (traceContext.method) span.setAttribute('method', traceContext.method);
+  span.end();
 }
 
 // No-op publisher for standalone use
@@ -103,6 +127,7 @@ export interface ScrapeOptions {
   reportId?: number;  // For tracking attempts in database
   resumeMode?: boolean;  // Skip already-successful attempts
   pendingAttempts?: Array<{ cinema_id: string; date: string }>;  // For resume mode
+  traceContext?: Record<string, string>;
 }
 
 /**
@@ -378,6 +403,7 @@ export async function runScraper(
   progress?: ProgressPublisher,
   options?: ScrapeOptions
 ): Promise<ScrapeSummary> {
+  setOrgSpanAttributes(options?.traceContext);
   logger.info('Starting scraper');
 
   const summary: ScrapeSummary = {

--- a/server/src/middleware/error-handler.test.ts
+++ b/server/src/middleware/error-handler.test.ts
@@ -1,9 +1,27 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import express from 'express';
 import request from 'supertest';
+import { AppError } from '../utils/errors.js';
+
+const { loggerErrorMock, loggerWarnMock } = vi.hoisted(() => ({
+  loggerErrorMock: vi.fn(),
+  loggerWarnMock: vi.fn(),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    error: loggerErrorMock,
+    warn: loggerWarnMock,
+  },
+}));
+
 import { errorHandler } from './error-handler.js';
 
 describe('errorHandler middleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('should handle SyntaxError from express.json() with 400 status', async () => {
     const app = express();
     app.use(express.json());
@@ -23,5 +41,56 @@ describe('errorHandler middleware', () => {
       success: false,
       error: 'Invalid JSON payload'
     });
+  });
+
+  it('logs tenant context fields for AppError payloads', async () => {
+    const app = express();
+
+    app.get('/tenant', (req, _res, next) => {
+      (req as express.Request & { user?: { id: number; org_id: number } }).user = {
+        id: 11,
+        org_id: 22,
+      };
+      next(new AppError('Forbidden', 403, { code: 'INSUFFICIENT_PRIVILEGES' }));
+    });
+
+    app.use(errorHandler);
+
+    const res = await request(app).get('/tenant');
+
+    expect(res.status).toBe(403);
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      'App Error [403]',
+      expect.objectContaining({
+        org_id: 22,
+        user_id: 11,
+        endpoint: '/tenant',
+        error: 'Forbidden',
+      })
+    );
+  });
+
+  it('logs sanitized endpoint path without query string', async () => {
+    const app = express();
+
+    app.get('/tenant', (req, _res, next) => {
+      (req as express.Request & { user?: { id: number; org_id: number } }).user = {
+        id: 11,
+        org_id: 22,
+      };
+      next(new AppError('Forbidden', 403));
+    });
+
+    app.use(errorHandler);
+
+    const res = await request(app).get('/tenant?token=secret');
+
+    expect(res.status).toBe(403);
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      'App Error [403]',
+      expect.objectContaining({
+        endpoint: '/tenant',
+      })
+    );
   });
 });

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -4,10 +4,17 @@ import { AppError } from '../utils/errors.js';
 
 export const errorHandler = (
   err: Error,
-  _req: Request,
+  req: Request,
   res: Response,
   _next: NextFunction
 ) => {
+  const endpoint = req.path || req.originalUrl;
+  const requestContext = {
+    org_id: (req as Request & { user?: { org_id?: number } }).user?.org_id,
+    user_id: (req as Request & { user?: { id?: number } }).user?.id,
+    endpoint,
+  };
+
   // Handle JSON syntax errors from express.json()
   if (err instanceof SyntaxError && 'status' in err && (err as any).status === 400 && 'body' in err) {
     return res.status(400).json({
@@ -19,9 +26,9 @@ export const errorHandler = (
   if (err && (err instanceof AppError || ('statusCode' in err && typeof (err as any).statusCode === 'number'))) {
     const error = err as AppError;
     if (error.statusCode >= 500) {
-      logger.error('App Error [5xx]', { error: error.message, stack: error.stack, details: error.details });
+      logger.error('App Error [5xx]', { ...requestContext, error: error.message, stack: error.stack, details: error.details });
     } else {
-      logger.warn(`App Error [${error.statusCode}]`, { error: error.message, details: error.details });
+      logger.warn(`App Error [${error.statusCode}]`, { ...requestContext, error: error.message, details: error.details });
     }
 
     return res.status(error.statusCode).json({
@@ -41,7 +48,7 @@ export const errorHandler = (
     });
   }
 
-  logger.error('Unhandled System Error', { error: err.message, stack: err.stack });
+  logger.error('Unhandled System Error', { ...requestContext, error: err.message, stack: err.stack });
 
   return res.status(500).json({
     success: false,

--- a/server/src/routes/scraper.test.ts
+++ b/server/src/routes/scraper.test.ts
@@ -4,9 +4,13 @@ import request from 'supertest';
 import express from 'express';
 
 const mockTriggerScrape = vi.fn();
+const mockTriggerResume = vi.fn();
 const mockGetStatus = vi.fn();
 const mockSubscribeToProgress = vi.fn();
 const mockPublishScheduleChange = vi.fn();
+const mockGetScrapeReport = vi.fn();
+const mockGetPendingScrapeAttempts = vi.fn();
+const mockLoggerInfo = vi.fn();
 
 let currentMockUser = { role_name: 'admin', is_system_role: true, permissions: [], id: 1, username: 'admin' };
 let failAuth = false;
@@ -16,6 +20,7 @@ vi.mock('../services/scraper-service.js', () => {
     ScraperService: vi.fn().mockImplementation(function() {
       return {
         triggerScrape: mockTriggerScrape,
+        triggerResume: mockTriggerResume,
         getStatus: mockGetStatus,
         subscribeToProgress: mockSubscribeToProgress,
       };
@@ -25,6 +30,14 @@ vi.mock('../services/scraper-service.js', () => {
 
 vi.mock('../db/client.js', () => ({
   db: { query: vi.fn() }
+}));
+
+vi.mock('../db/report-queries.js', () => ({
+  getScrapeReport: (...args: unknown[]) => mockGetScrapeReport(...args),
+}));
+
+vi.mock('../db/scrape-attempt-queries.js', () => ({
+  getPendingScrapeAttempts: (...args: unknown[]) => mockGetPendingScrapeAttempts(...args),
 }));
 
 vi.mock('../middleware/auth.js', () => ({
@@ -51,6 +64,15 @@ vi.mock('../services/redis-client.js', () => ({
   getRedisClient: () => ({
     publishScheduleChange: mockPublishScheduleChange,
   }),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    info: (...args: unknown[]) => mockLoggerInfo(...args),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
 }));
 
 // Mock schedule queries
@@ -86,8 +108,14 @@ describe('Routes - Scraper', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockTriggerScrape.mockResolvedValue({ reportId: 42, queueDepth: 1 });
+    mockTriggerResume.mockResolvedValue({ reportId: 43, queueDepth: 1 });
     mockGetStatus.mockResolvedValue({ isRunning: false, latestReport: null });
     mockPublishScheduleChange.mockResolvedValue(undefined);
+    mockGetScrapeReport.mockResolvedValue({ id: 123, status: 'failed' });
+    mockGetPendingScrapeAttempts.mockResolvedValue([
+      { cinema_id: 'C0042', date: '2026-03-26' },
+    ]);
+    mockLoggerInfo.mockReset();
     failAuth = false;
   });
 
@@ -101,7 +129,14 @@ describe('Routes - Scraper', () => {
       
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
-      expect(mockTriggerScrape).toHaveBeenCalledWith({});
+      expect(mockTriggerScrape).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({
+          endpoint: '/api/scraper/trigger',
+          method: 'POST',
+          user: expect.objectContaining({ id: 1 }),
+        })
+      );
     });
 
     it('should return 403 if user lacks permissions', async () => {
@@ -121,7 +156,14 @@ describe('Routes - Scraper', () => {
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
       expect(response.body.data.reportId).toBe(42);
-      expect(mockTriggerScrape).toHaveBeenCalledWith({});
+      expect(mockTriggerScrape).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({
+          endpoint: '/api/scraper/trigger',
+          method: 'POST',
+          user: expect.objectContaining({ id: 1 }),
+        })
+      );
     });
 
     it('should pass cinemaId and filmId to the service', async () => {
@@ -133,7 +175,25 @@ describe('Routes - Scraper', () => {
       });
       
       expect(response.status).toBe(200);
-      expect(mockTriggerScrape).toHaveBeenCalledWith({ cinemaId: 'C0153', filmId: 12345 });
+      expect(mockTriggerScrape).toHaveBeenCalledWith(
+        { cinemaId: 'C0153', filmId: 12345 },
+        expect.objectContaining({
+          endpoint: '/api/scraper/trigger',
+          method: 'POST',
+          user: expect.objectContaining({ id: 1 }),
+        })
+      );
+      expect(mockLoggerInfo).toHaveBeenCalledWith(
+        'Scraper trigger requested',
+        expect.objectContaining({
+          org_id: undefined,
+          user_id: 1,
+          endpoint: '/api/scraper/trigger',
+          method: 'POST',
+          cinema_id: 'C0153',
+          film_id: 12345,
+        })
+      );
     });
 
     it('should handle service errors gracefully (e.g., Cinema not found)', async () => {
@@ -176,6 +236,79 @@ describe('Routes - Scraper', () => {
       expect(response.body.data.isRunning).toBe(true);
       expect(response.body.data.latestReport.id).toBe(99);
       expect(mockGetStatus).toHaveBeenCalled();
+      expect(mockLoggerInfo).toHaveBeenCalledWith(
+        'Scraper status requested',
+        expect.objectContaining({
+          org_id: undefined,
+          user_id: 1,
+          endpoint: '/api/scraper/status',
+          method: 'GET',
+        })
+      );
+    });
+  });
+
+  describe('POST /api/scraper/resume/:reportId', () => {
+    it('should pass observability context to triggerResume', async () => {
+      const app = await setupApp();
+
+      const response = await request(app).post('/api/scraper/resume/123');
+
+      expect(response.status).toBe(200);
+      expect(mockTriggerResume).toHaveBeenCalledWith(
+        123,
+        expect.any(Array),
+        expect.objectContaining({
+          endpoint: '/api/scraper/resume/123',
+          method: 'POST',
+          user: expect.objectContaining({ id: 1 }),
+        })
+      );
+      expect(mockLoggerInfo).toHaveBeenCalledWith(
+        'Scraper resume requested',
+        expect.objectContaining({
+          org_id: undefined,
+          user_id: 1,
+          endpoint: '/api/scraper/resume/123',
+          method: 'POST',
+          report_id: 123,
+          pending_attempts: 1,
+        })
+      );
+    });
+
+    it('forwards traceparent header to observability context', async () => {
+      const app = await setupApp();
+
+      const response = await request(app)
+        .post('/api/scraper/trigger')
+        .set('traceparent', '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01')
+        .send({});
+
+      expect(response.status).toBe(200);
+      expect(mockTriggerScrape).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({
+          traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+        })
+      );
+    });
+
+    it('rejects invalid traceparent header values', async () => {
+      const app = await setupApp();
+
+      const response = await request(app)
+        .post('/api/scraper/trigger')
+        .set('traceparent', 'invalid-value')
+        .send({});
+
+      expect(response.status).toBe(200);
+      expect(mockTriggerScrape).toHaveBeenCalledWith(
+        {},
+        expect.not.objectContaining({
+          traceparent: expect.any(String),
+        })
+      );
     });
   });
 
@@ -235,7 +368,14 @@ describe('Routes - Scraper', () => {
       expect(response.body.success).toBe(true);
       expect(response.body.data.reportId).toBe(99);
       expect(response.body.data.scheduleId).toBe(1);
-      expect(mockTriggerScrape).toHaveBeenCalled();
+      expect(mockTriggerScrape).toHaveBeenCalledWith(
+        { cinemaId: undefined },
+        expect.objectContaining({
+          endpoint: '/api/scraper/schedules/1/trigger',
+          method: 'POST',
+          user: expect.objectContaining({ id: 1 }),
+        })
+      );
     });
   });
 });

--- a/server/src/routes/scraper.ts
+++ b/server/src/routes/scraper.ts
@@ -8,6 +8,7 @@ import { scraperLimiter, protectedLimiter } from '../middleware/rate-limit.js';
 import { ScraperService } from '../services/scraper-service.js';
 import { getRedisClient } from '../services/redis-client.js';
 import { AuthError, NotFoundError, ValidationError } from '../utils/errors.js';
+import { logger } from '../utils/logger.js';
 import {
   getAllSchedules,
   getScheduleById,
@@ -22,6 +23,19 @@ import { getPendingScrapeAttempts } from '../db/scrape-attempt-queries.js';
 import { getDbFromRequest } from '../utils/db-from-request.js';
 
 const router = express.Router();
+
+const TRACEPARENT_REGEX = /^[\da-f]{2}-[\da-f]{32}-[\da-f]{16}-[\da-f]{2}$/i;
+
+function getSanitizedEndpoint(req: AuthRequest): string {
+  return req.originalUrl.split('?')[0];
+}
+
+function getValidTraceparentHeader(req: AuthRequest): string | undefined {
+  const raw = req.headers.traceparent;
+  if (typeof raw !== 'string') return undefined;
+  if (!TRACEPARENT_REGEX.test(raw)) return undefined;
+  return raw;
+}
 
 router.use(validateInputSize({ maxArrayLength: 100, maxTotalSize: 50 * 1024 }));
 
@@ -48,7 +62,23 @@ router.post('/trigger', scraperLimiter, requireAuth, async (req: AuthRequest, re
       }
     }
 
-    const { reportId, queueDepth } = await scraperService.triggerScrape({ cinemaId, filmId });
+    const observabilityContext = {
+      endpoint: getSanitizedEndpoint(req),
+      method: req.method,
+      user: req.user,
+      traceparent: getValidTraceparentHeader(req),
+    };
+
+    logger.info('Scraper trigger requested', {
+      org_id: req.user?.org_id,
+      user_id: req.user?.id,
+      endpoint: getSanitizedEndpoint(req),
+      method: req.method,
+      cinema_id: cinemaId,
+      film_id: filmId,
+    });
+
+    const { reportId, queueDepth } = await scraperService.triggerScrape({ cinemaId, filmId }, observabilityContext);
 
     const response: ApiResponse = {
       success: true,
@@ -103,9 +133,26 @@ router.post('/resume/:reportId', scraperLimiter, requireAuth, async (req: AuthRe
     }
 
     // Trigger a new scrape in resume mode
+    const observabilityContext = {
+      endpoint: getSanitizedEndpoint(req),
+      method: req.method,
+      user: req.user,
+      traceparent: getValidTraceparentHeader(req),
+    };
+
+    logger.info('Scraper resume requested', {
+      org_id: req.user?.org_id,
+      user_id: req.user?.id,
+      endpoint: getSanitizedEndpoint(req),
+      method: req.method,
+      report_id: reportId,
+      pending_attempts: pendingAttempts.length,
+    });
+
     const { reportId: newReportId, queueDepth } = await scraperService.triggerResume(
       reportId,
-      pendingAttempts
+      pendingAttempts,
+      observabilityContext
     );
 
     const response: ApiResponse = {
@@ -125,12 +172,19 @@ router.post('/resume/:reportId', scraperLimiter, requireAuth, async (req: AuthRe
 });
 
 // GET /api/scraper/status - Get current scrape status
-router.get('/status', scraperLimiter, requireAuth, async (req, res, next) => {
+router.get('/status', scraperLimiter, requireAuth, async (req: AuthRequest, res, next) => {
   const dbConn = getDbFromRequest(req);
   const scraperService = new ScraperService(dbConn);
 
   try {
     const statusData = await scraperService.getStatus();
+
+    logger.info('Scraper status requested', {
+      org_id: req.user?.org_id,
+      user_id: req.user?.id,
+      endpoint: getSanitizedEndpoint(req),
+      method: req.method,
+    });
 
     const response: ApiResponse = {
       success: true,
@@ -149,9 +203,15 @@ router.get('/progress', scraperLimiter, (req, res, next) => {
     const dbConn = getDbFromRequest(req);
     const scraperService = new ScraperService(dbConn);
     
+    const observabilityContext = {
+      endpoint: getSanitizedEndpoint(req as AuthRequest),
+      method: req.method,
+      user: (req as AuthRequest).user,
+    };
+
     const cleanup = scraperService.subscribeToProgress(res, () => {
       // Optional additional cleanup on route level if needed
-    });
+    }, observabilityContext);
 
     req.on('close', cleanup);
   } catch (error) {
@@ -364,6 +424,11 @@ router.post(
 
       const { reportId, queueDepth } = await scraperService.triggerScrape({
         cinemaId: schedule.target_cinemas?.[0],
+      }, {
+        endpoint: getSanitizedEndpoint(req),
+        method: req.method,
+        user: req.user,
+        traceparent: getValidTraceparentHeader(req),
       });
 
       const response: ApiResponse = {

--- a/server/src/services/progress-tracker.test.ts
+++ b/server/src/services/progress-tracker.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { ProgressTracker } from './progress-tracker.js';
+
+describe('ProgressTracker', () => {
+  it('enriches SSE payloads with listener trace context', () => {
+    const tracker = new ProgressTracker();
+    const writes: string[] = [];
+
+    const listener = {
+      write: (chunk: string) => {
+        writes.push(chunk);
+      },
+      end: () => {},
+    } as any;
+
+    tracker.addListener(listener, {
+      org_id: '9',
+      org_slug: 'acme',
+      user_id: '55',
+      endpoint: '/api/scraper/progress',
+      method: 'GET',
+    });
+
+    tracker.emit({ type: 'started', total_cinemas: 1, total_dates: 2 });
+
+    expect(writes.length).toBe(1);
+    const payload = writes[0].replace(/^data:\s*/, '').trim();
+    const parsed = JSON.parse(payload);
+
+    expect(parsed.type).toBe('started');
+    expect(parsed.traceContext).toEqual(expect.objectContaining({
+      org_id: '9',
+      org_slug: 'acme',
+      user_id: '55',
+      endpoint: '/api/scraper/progress',
+      method: 'GET',
+    }));
+  });
+});

--- a/server/src/services/progress-tracker.ts
+++ b/server/src/services/progress-tracker.ts
@@ -1,7 +1,16 @@
 import { Response } from 'express';
 
+export interface ProgressTraceContext {
+  org_id?: string;
+  org_slug?: string;
+  user_id?: string;
+  endpoint?: string;
+  method?: string;
+  traceparent?: string;
+}
+
 // Progress event types
-export type ProgressEvent =
+type ProgressEventPayload =
   | { type: 'started'; total_cinemas: number; total_dates: number }
   | { type: 'cinema_started'; cinema_name: string; cinema_id: string; index: number }
   | { type: 'date_started'; date: string; cinema_name: string }
@@ -15,6 +24,10 @@ export type ProgressEvent =
   | { type: 'cinema_failed'; cinema_name: string; error: string }
   | { type: 'completed'; summary: ScrapeSummary }
   | { type: 'failed'; error: string };
+
+export type ProgressEvent = ProgressEventPayload & {
+  traceContext?: ProgressTraceContext;
+};
 
 export interface ScrapeSummary {
   total_cinemas: number;
@@ -40,10 +53,12 @@ export class ProgressTracker {
   private listeners: Set<Response> = new Set();
   private events: ProgressEvent[] = [];
   private heartbeatInterval?: NodeJS.Timeout;
+  private traceContextByListener: Map<Response, ProgressTraceContext | undefined> = new Map();
 
   // Add a new SSE listener
-  addListener(res: Response): void {
+  addListener(res: Response, traceContext?: ProgressTraceContext): void {
     this.listeners.add(res);
+    this.traceContextByListener.set(res, traceContext);
 
     // Send existing events to new listener
     for (const event of this.events) {
@@ -59,6 +74,7 @@ export class ProgressTracker {
   // Remove a listener
   removeListener(res: Response): void {
     this.listeners.delete(res);
+    this.traceContextByListener.delete(res);
 
     // Stop heartbeat if no more listeners
     if (this.listeners.size === 0) {
@@ -79,10 +95,16 @@ export class ProgressTracker {
   // Send an event to a specific listener
   private sendToListener(res: Response, event: ProgressEvent): void {
     try {
-      res.write(`data: ${JSON.stringify(event)}\n\n`);
+      const listenerTrace = this.traceContextByListener.get(res);
+      const payload: ProgressEvent = listenerTrace
+        ? { ...event, traceContext: listenerTrace }
+        : event;
+
+      res.write(`data: ${JSON.stringify(payload)}\n\n`);
     } catch (error) {
       // Listener disconnected, remove it
       this.listeners.delete(res);
+      this.traceContextByListener.delete(res);
     }
   }
 
@@ -94,6 +116,7 @@ export class ProgressTracker {
           listener.write(': heartbeat\n\n');
         } catch (error) {
           this.listeners.delete(listener);
+          this.traceContextByListener.delete(listener);
         }
       }
     }, 15000); // Every 15 seconds
@@ -121,6 +144,7 @@ export class ProgressTracker {
       }
     }
     this.listeners.clear();
+    this.traceContextByListener.clear();
   }
 
   // Get all events (for debugging or storing in database)

--- a/server/src/services/scraper-service.test.ts
+++ b/server/src/services/scraper-service.test.ts
@@ -49,6 +49,68 @@ describe('ScraperService', () => {
         options: { cinemaId: 'C1', filmId: 123 }
       }));
     });
+
+    it('should attach org observability context to queued job metadata', async () => {
+      const mockPublish = vi.fn().mockResolvedValue(1);
+      vi.mocked(redisClient.getRedisClient).mockReturnValue({ publishJob: mockPublish } as any);
+      vi.mocked(reportQueries.createScrapeReport).mockResolvedValue(45 as any);
+      vi.mocked(cinemaQueries.getCinemas).mockResolvedValue([{ id: 'C1' }] as any);
+
+      await scraperService.triggerScrape(
+        { cinemaId: 'C1' },
+        {
+          endpoint: '/api/org/acme/scraper/trigger',
+          method: 'POST',
+          user: {
+            id: 101,
+            username: 'tenant-admin',
+            role_name: 'admin',
+            is_system_role: false,
+            permissions: [],
+            org_id: 77,
+            org_slug: 'acme',
+          },
+        }
+      );
+
+      expect(mockPublish).toHaveBeenCalledWith(expect.objectContaining({
+        traceContext: expect.objectContaining({
+          org_id: '77',
+          org_slug: 'acme',
+          user_id: '101',
+          endpoint: '/api/org/acme/scraper/trigger',
+          method: 'POST',
+        }),
+      }));
+    });
+
+    it('should include traceparent in trace context when provided', async () => {
+      const mockPublish = vi.fn().mockResolvedValue(1);
+      vi.mocked(redisClient.getRedisClient).mockReturnValue({ publishJob: mockPublish } as any);
+      vi.mocked(reportQueries.createScrapeReport).mockResolvedValue(47 as any);
+
+      await scraperService.triggerScrape(
+        {},
+        {
+          endpoint: '/api/scraper/trigger',
+          method: 'POST',
+          traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+          user: {
+            id: 1,
+            username: 'admin',
+            role_name: 'admin',
+            is_system_role: true,
+            permissions: [],
+          },
+        }
+      );
+
+      expect(mockPublish).toHaveBeenCalledWith(expect.objectContaining({
+        traceContext: expect.objectContaining({
+          traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+        }),
+      }));
+    });
   });
 
   describe('getStatus', () => {
@@ -112,6 +174,40 @@ describe('ScraperService', () => {
         },
       }));
     });
+
+    it('should attach org observability context on resume jobs', async () => {
+      const mockPublish = vi.fn().mockResolvedValue(1);
+      vi.mocked(redisClient.getRedisClient).mockReturnValue({ publishJob: mockPublish } as any);
+      vi.mocked(reportQueries.createScrapeReport).mockResolvedValue(46 as any);
+
+      await scraperService.triggerResume(
+        123,
+        [{ cinema_id: 'C0042', date: '2026-03-26' }] as any,
+        {
+          endpoint: '/api/org/acme/scraper/resume/123',
+          method: 'POST',
+          user: {
+            id: 9,
+            username: 'org-user',
+            role_name: 'admin',
+            is_system_role: false,
+            permissions: [],
+            org_id: 88,
+            org_slug: 'acme',
+          },
+        }
+      );
+
+      expect(mockPublish).toHaveBeenCalledWith(expect.objectContaining({
+        traceContext: expect.objectContaining({
+          org_id: '88',
+          org_slug: 'acme',
+          user_id: '9',
+          endpoint: '/api/org/acme/scraper/resume/123',
+          method: 'POST',
+        }),
+      }));
+    });
   });
 
   describe('subscribeToProgress', () => {
@@ -122,12 +218,44 @@ describe('ScraperService', () => {
       const cleanup = scraperService.subscribeToProgress(mockRes, mockOnClose);
       
       expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Type', 'text/event-stream');
-      expect(progressTracker.addListener).toHaveBeenCalledWith(mockRes);
+      expect(progressTracker.addListener).toHaveBeenCalledWith(mockRes, undefined);
       
       cleanup();
       
       expect(progressTracker.removeListener).toHaveBeenCalledWith(mockRes);
       expect(mockOnClose).toHaveBeenCalled();
+    });
+
+    it('should pass tenant trace context to progress tracker', () => {
+      const mockRes = { setHeader: vi.fn() };
+      const mockOnClose = vi.fn();
+
+      scraperService.subscribeToProgress(mockRes, mockOnClose, {
+        endpoint: '/api/org/acme/scraper/progress',
+        method: 'GET',
+        traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+        user: {
+          id: 3,
+          username: 'tenant-user',
+          role_name: 'admin',
+          is_system_role: false,
+          permissions: [],
+          org_id: 42,
+          org_slug: 'acme',
+        },
+      });
+
+      expect(progressTracker.addListener).toHaveBeenCalledWith(
+        mockRes,
+        expect.objectContaining({
+          org_id: '42',
+          org_slug: 'acme',
+          user_id: '3',
+          endpoint: '/api/org/acme/scraper/progress',
+          method: 'GET',
+          traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+        })
+      );
     });
   });
 });

--- a/server/src/services/scraper-service.ts
+++ b/server/src/services/scraper-service.ts
@@ -5,15 +5,79 @@ import { getCinemas } from '../db/cinema-queries.js';
 import type { DB } from '../db/client.js';
 import { logger } from '../utils/logger.js';
 import type { ScrapeAttempt } from '../db/scrape-attempt-queries.js';
+import type { AuthRequest } from '../middleware/auth.js';
+import type { ProgressTraceContext } from './progress-tracker.js';
+
+interface ScrapeTriggerOptions {
+  cinemaId?: string;
+  filmId?: number;
+}
+
+interface ScrapeObservabilityContext {
+  endpoint?: string;
+  method?: string;
+  traceparent?: string;
+  user?: AuthRequest['user'];
+}
 
 export class ScraperService {
   constructor(private db: DB) {}
+
+  private buildTraceContext(context?: ScrapeObservabilityContext): Record<string, string> | undefined {
+    if (!context) return undefined;
+
+    const traceContext: Record<string, string> = {};
+
+    if (context.endpoint) {
+      traceContext.endpoint = context.endpoint;
+    }
+
+    if (context.method) {
+      traceContext.method = context.method;
+    }
+
+    if (context.traceparent) {
+      traceContext.traceparent = context.traceparent;
+    }
+
+    if (context.user?.id !== undefined) {
+      traceContext.user_id = String(context.user.id);
+    }
+
+    if (context.user?.username) {
+      traceContext.username = context.user.username;
+    }
+
+    if (context.user?.org_id !== undefined) {
+      traceContext.org_id = String(context.user.org_id);
+    }
+
+    if (context.user?.org_slug) {
+      traceContext.org_slug = context.user.org_slug;
+    }
+
+    return Object.keys(traceContext).length > 0 ? traceContext : undefined;
+  }
+
+  private buildProgressTraceContext(context?: ScrapeObservabilityContext): ProgressTraceContext | undefined {
+    const traceContext = this.buildTraceContext(context);
+    if (!traceContext) return undefined;
+
+    return {
+      org_id: traceContext.org_id,
+      org_slug: traceContext.org_slug,
+      user_id: traceContext.user_id,
+      endpoint: traceContext.endpoint,
+      method: traceContext.method,
+      traceparent: traceContext.traceparent,
+    };
+  }
 
   /**
    * Triggers a new scrape job by publishing it to the Redis queue.
    * Validates the cinemaId if provided.
    */
-  async triggerScrape(options: { cinemaId?: string; filmId?: number } = {}) {
+  async triggerScrape(options: ScrapeTriggerOptions = {}, context?: ScrapeObservabilityContext) {
     const { cinemaId, filmId } = options;
 
     // Validate cinemaId exists in database if provided
@@ -32,6 +96,8 @@ export class ScraperService {
     // completed/failed events and immediately dismiss the progress panel.
     progressTracker.reset();
 
+    const traceContext = this.buildTraceContext(context);
+
     const queueDepth = await getRedisClient().publishJob({
       type: 'scrape',
       reportId,
@@ -40,6 +106,7 @@ export class ScraperService {
         ...(cinemaId && { cinemaId }),
         ...(filmId && { filmId }),
       },
+      ...(traceContext && { traceContext }),
     });
 
     return { reportId, queueDepth };
@@ -49,7 +116,7 @@ export class ScraperService {
    * Triggers a resume job for a previous failed/rate-limited scrape.
    * Creates a new report linked to the parent and queues only pending attempts.
    */
-  async triggerResume(parentReportId: number, pendingAttempts: ScrapeAttempt[]) {
+  async triggerResume(parentReportId: number, pendingAttempts: ScrapeAttempt[], context?: ScrapeObservabilityContext) {
     // Create new report with parent link
     const reportId = await createScrapeReport(this.db, 'manual', parentReportId);
 
@@ -62,6 +129,8 @@ export class ScraperService {
       date: a.date,
     }));
 
+    const traceContext = this.buildTraceContext(context);
+
     const queueDepth = await getRedisClient().publishJob({
       type: 'scrape',
       reportId,
@@ -70,6 +139,7 @@ export class ScraperService {
         resumeMode: true,
         pendingAttempts: pendingList,
       },
+      ...(traceContext && { traceContext }),
     });
 
     return { reportId, queueDepth };
@@ -89,18 +159,30 @@ export class ScraperService {
   /**
    * Subscribes an HTTP response stream to the progress tracker events.
    */
-  subscribeToProgress(res: any, onClose: () => void) {
+  subscribeToProgress(res: any, onClose: () => void, context?: ScrapeObservabilityContext) {
     res.setHeader('Content-Type', 'text/event-stream');
     res.setHeader('Cache-Control', 'no-cache');
     res.setHeader('Connection', 'keep-alive');
     res.setHeader('X-Accel-Buffering', 'no'); // Disable nginx buffering
 
-    progressTracker.addListener(res);
-    logger.info(`📡 SSE client connected (${progressTracker.getListenerCount()} total)`);
+    progressTracker.addListener(res, this.buildProgressTraceContext(context));
+    logger.info('SSE client connected', {
+      listeners: progressTracker.getListenerCount(),
+      org_id: context?.user?.org_id,
+      user_id: context?.user?.id,
+      endpoint: context?.endpoint,
+      method: context?.method,
+    });
 
     return () => {
       progressTracker.removeListener(res);
-      logger.info(`📡 SSE client disconnected (${progressTracker.getListenerCount()} remaining)`);
+      logger.info('SSE client disconnected', {
+        listeners: progressTracker.getListenerCount(),
+        org_id: context?.user?.org_id,
+        user_id: context?.user?.id,
+        endpoint: context?.endpoint,
+        method: context?.method,
+      });
       onClose();
     };
   }

--- a/server/tests/README.md
+++ b/server/tests/README.md
@@ -240,3 +240,20 @@ When validating multi-tenant org-boundary behavior for cinemas routes:
 - Assert middleware chain guarantees remain present on cinemas routes:
   - Read path includes org-aware auth/permission wrappers + `enforceOrgBoundary`
   - Write path includes `requireAuth`, `requirePermission`, and `enforceOrgBoundary`
+
+## Observability Assertions (SaaS)
+
+When validating org-aware observability across API and scraper flows:
+
+- Queue metadata propagation:
+  - `POST /api/scraper/trigger` and `POST /api/scraper/resume/:reportId` should pass tenant context to queue job `traceContext`
+  - Expected fields in trace context: `org_id`, `org_slug`, `user_id`, `endpoint`, `method`
+  - Optional distributed tracing passthrough: `traceparent` header -> `traceContext.traceparent`
+
+- Structured request logging:
+  - Scraper trigger/resume/status request logs should include `org_id`, `user_id`, and `endpoint`
+  - Error-handler logs should include tenant-aware context payload: `{ org_id, user_id, endpoint, error }`
+
+- Scraper worker correlation logs:
+  - Redis job consumer should log trace context fields when `traceContext` exists on job payload
+  - This enables Loki/Tempo drill-down by tenant during queue processing incidents


### PR DESCRIPTION
## Summary
- propagate tenant observability context (`org_id`, `org_slug`, `user_id`, `endpoint`, `method`, optional `traceparent`) from scraper API routes into queued Redis job metadata
- enrich SSE progress payload delivery and API/worker structured logs for tenant-level Loki/Tempo correlation, with endpoint sanitization and traceparent validation
- add focused tests for route/service/error/progress behavior and update observability documentation and story tracking status

Closes #884