### PR TITLE
test(e2e): add multi-tenant cinema isolation regression

### DIFF
--- a/_bmad-output/implementation-artifacts/1-3-e2e-multi-tenant-cinema-isolation-test.md
+++ b/_bmad-output/implementation-artifacts/1-3-e2e-multi-tenant-cinema-isolation-test.md
@@ -1,0 +1,211 @@
+# Story 1.3: E2E Multi-Tenant Cinema Isolation Test
+
+Status: in-progress
+
+## Story
+
+As a QA engineer,
+I want E2E tests that validate cinema data isolation between organizations,
+so that I can prove users cannot view other organizations' cinemas.
+
+## Acceptance Criteria
+
+1. **Given** organization A has cinemas [Cinema A1, Cinema A2]  
+   **And** organization B has cinemas [Cinema B1, Cinema B2]  
+   **When** user from org A views the cinema list page  
+   **Then** only Cinema A1 and Cinema A2 are displayed  
+   **And** Cinema B1 and Cinema B2 are NOT visible  
+   **And** the `data-testid="cinema-list"` element contains exactly 2 items
+
+2. **Given** user from org A is authenticated  
+   **When** they manually navigate to `/cinemas/:id` (Cinema B1's ID)  
+   **Then** the page shows `403 Forbidden` error  
+   **And** the `data-testid="403-error-message"` element is visible  
+   **And** the error message explains cross-tenant access is blocked
+
+3. **Given** user from org A is authenticated  
+   **When** they inspect network requests in browser DevTools  
+   **Then** `GET /api/cinemas` response contains only org A cinemas  
+   **And** no org B cinema IDs are leaked in any API response
+
+4. **Performance & Cleanup**  
+   **Given** this test runs with Playwright `workers: 4`  
+   **When** the test executes  
+   **Then** the test completes in `<2 minutes` (single worker)  
+   **And** parallel execution with 4 workers completes in `<5 minutes` total  
+   **And** test cleanup removes all seeded organizations within `500ms`  
+   **And** no orphan data remains after test completion
+
+5. **Parallel Isolation**  
+   **Given** multiple instances of this test run in parallel  
+   **When** each creates test organizations via `/test/seed-org`  
+   **Then** organizations are isolated (no cross-test data pollution)  
+   **And** cleanup only removes each test's own data  
+   **And** parallel tests do not interfere with each other
+
+## Tasks / Subtasks
+
+- [x] Add RED E2E spec for cinema isolation between two tenant orgs (AC: 1, 2, 3)
+  - [x] Create `e2e/multi-tenant-cinema-isolation.spec.ts` (new dedicated spec, do not overload existing generic specs)
+  - [x] Use shared org fixture: `import { test, expect } from './fixtures/org-fixture'`
+  - [x] Seed two orgs in test (`orgA`, `orgB`) with `seedTestOrg()` and store returned `orgId`, `orgSlug`, `admin` credentials
+  - [x] Keep scenario deterministic by creating/using known cinema labels per org (or infer from fixture payload if already deterministic)
+
+- [x] Implement tenant-authenticated navigation and assertions for org A view (AC: 1)
+  - [x] Login with org A admin credentials from seeded fixture (do not hardcode `admin/admin`)
+  - [x] Navigate to org A tenant route (`/org/:slug/...`) and assert cinema list visibility
+  - [x] Assert `data-testid="cinema-list"` exists and contains exactly 2 org A items
+  - [x] Assert org B cinema names are not visible in org A UI
+
+- [x] Implement cross-tenant direct access denial checks (AC: 2)
+  - [x] Attempt manual navigation to org B cinema detail while authenticated as org A
+  - [x] Assert `403` behavior and visible `data-testid="403-error-message"`
+  - [x] Assert denial message communicates cross-tenant access is blocked
+  - [x] Ensure denial behavior is route/API driven (not only client-side redirect)
+
+- [x] Validate API/network isolation for org A session (AC: 3)
+  - [x] Capture network response for cinemas fetch used by org A page session
+  - [x] Assert no org B cinema IDs/names appear in any relevant cinemas payload
+  - [x] Add negative assertion for known org B identifiers to prevent regression leaks
+
+- [x] Close UX testability gaps required by this story (AC: 1, 2)
+  - [x] If missing, add `data-testid="cinema-list"` on the cinema list container rendered on tenant home
+  - [x] If missing, add stable row/item test hooks under cinema list (e.g. `data-testid="cinema-list-item"`) without breaking existing selectors
+  - [x] If missing, add `data-testid="403-error-message"` on the explicit forbidden error message component/state for cinema access denial
+
+- [x] Keep fixture cleanup and parallel safety intact (AC: 4, 5)
+  - [x] Reuse existing auto-cleanup fixture behavior from `e2e/fixtures/org-fixture.ts` and `e2e/global-teardown.ts`
+  - [x] Do not add ad-hoc cleanup logic that bypasses tracked registry cleanup
+  - [x] Keep unique org slug generation per test worker to avoid collisions
+
+- [x] Add execution/documentation updates for this new E2E contract (AC: 4, 5)
+  - [x] Update `docs/guides/development/testing.md` E2E section if new spec or required env usage needs documentation
+  - [x] Document expected runtime toggle (`E2E_ENABLE_ORG_FIXTURE=true`) for fixture-backed tenant tests
+
+### Review Findings
+
+- [x] [Review][Patch] Replace hardcoded superadmin auth/impersonation flow with seeded org-A admin login flow (story guardrail violation) [e2e/multi-tenant-cinema-isolation.spec.ts:38]
+- [x] [Review][Patch] Make forbidden UI state API-driven; do not infer cross-tenant denial from generic `!cinema` in org-scoped routes [client/src/pages/CinemaPage.tsx:134]
+- [x] [Review][Patch] Show explicit `403 Forbidden` state text for denied cinema detail access (AC2 expectation) [client/src/pages/CinemaPage.tsx:139]
+- [x] [Review][Patch] Add explicit negative assertion that known org-B cinema IDs are absent from org-A cinemas payload (AC3) [e2e/multi-tenant-cinema-isolation.spec.ts:141]
+- [x] [Review][Patch] Avoid order-sensitive ID equality in network payload assertion to prevent flaky failures on nondeterministic ordering [e2e/multi-tenant-cinema-isolation.spec.ts:142]
+- [x] [Review][Patch] Use a single request-base strategy (relative or configured baseURL) for all API calls; remove mixed absolute localhost call [e2e/multi-tenant-cinema-isolation.spec.ts:152]
+- [ ] [Review][Patch] Add AC4 verification hooks (runtime/cleanup assertions or measurable checks) instead of leaving performance+cleanup criteria unvalidated [e2e/multi-tenant-cinema-isolation.spec.ts:34] — skipped in batch mode (requires broader test harness/metrics strategy)
+- [ ] [Review][Patch] Remove unrelated machine-specific tooling config changes from this story scope (local path/plugin wiring in `opencode.json`) [opencode.json:1]
+
+## Dev Notes
+
+### Scope and Guardrails
+
+- This story is an E2E security regression for multi-tenant cinema isolation, not a broad SaaS routing rewrite.
+- Prefer test and minimal selector instrumentation changes; avoid refactoring unrelated pages/components.
+- Keep implementation constrained to cinema isolation behavior in Epic 1.3; user/schedule isolation belongs to Stories 1.4/1.5.
+
+### Reinvention Prevention
+
+- Reuse existing fixture and cleanup utilities already delivered in Epic 0:
+  - `e2e/fixtures/org-fixture.ts`
+  - `e2e/fixtures/org-cleanup.ts`
+  - `e2e/global-teardown.ts`
+- Reuse current Playwright project settings and parallel behavior in `playwright.config.ts`; do not introduce a separate Playwright config.
+- Reuse current SaaS route structure in `client/src/App.tsx` and tenant ping/bootstrap in `client/src/contexts/TenantProvider.tsx`.
+
+### Previous Story Intelligence (from 1.2)
+
+- Story 1.2 propagated org-aware context in scraper/observability paths; keep field naming consistency (`org_id`, `org_slug`, `user_id`) for any log assertions.
+- Follow existing commit/test style: focused route/spec updates and incremental RED->GREEN changes.
+- Keep compatibility with standalone mode while writing SaaS-specific assertions guarded by fixture-enabled execution.
+
+### Architecture Compliance Notes
+
+- Monorepo ESM + strict TypeScript conventions remain mandatory (`_bmad-output/project-context.md`).
+- For E2E, stable selectors must use `data-testid` (testing guide recommendation).
+- Do not rely on text-only selectors for isolation-critical assertions where test IDs are available.
+- Preserve existing middleware security contracts from Story 1.1 (`Cross-tenant access denied`) and assert on that stable behavior.
+
+### LLM-Dev Implementation Strategy
+
+1. RED: add failing spec showing cross-tenant leakage/denial expectations.
+2. GREEN: implement minimal UI selector hooks and any missing forbidden-state rendering hooks needed for deterministic assertions.
+3. HARDEN: add network payload negative assertions and parallel cleanup safety checks.
+4. VERIFY: run targeted Playwright spec, then broader impacted E2E subset.
+5. DOCS: update testing guide if workflow/env details changed.
+
+### Suggested Test Matrix
+
+- Happy path: org A login -> tenant home cinema list -> only org A cinemas visible.
+- Negative path: org A session -> direct navigation to org B cinema detail -> 403 error test id visible.
+- Network assertion: org A cinema payload contains no org B identifiers.
+- Parallel sanity: repeated runs with workers=4 do not leak data across tests.
+- Cleanup sanity: no orphan fixture orgs after test completion.
+
+### Concrete File Targets
+
+- `e2e/multi-tenant-cinema-isolation.spec.ts` (new)
+- `e2e/fixtures/org-fixture.ts` (reuse only; edit only if required for helper ergonomics)
+- `client/src/components/CinemasQuickLinks.tsx` (if adding `cinema-list` hooks)
+- `client/src/pages/CinemaPage.tsx` and/or shared error UI location (if adding `403-error-message` hook)
+- `docs/guides/development/testing.md` (if execution guidance changes)
+
+### Pitfalls to Avoid
+
+- Do not hardcode global admin credentials in this spec; use seeded org admin credentials.
+- Do not assert only visible UI text while ignoring underlying network payload leakage.
+- Do not introduce flaky timing waits; prefer deterministic waits on route responses and test IDs.
+- Do not bypass fixture cleanup with direct SQL/manual deletes in tests.
+- Do not weaken existing auth/permission middleware to make test pass.
+
+### References
+
+- Story source: `_bmad-output/planning-artifacts/epics.md:505`
+- Epic dependency context: `_bmad-output/planning-artifacts/epics.md:448`
+- Sprint tracker row: `_bmad-output/implementation-artifacts/sprint-status.yaml:63`
+- Previous story context: `_bmad-output/implementation-artifacts/1-2-add-org-id-to-all-observability-traces.md`
+- Org fixture utilities: `e2e/fixtures/org-fixture.ts:33`
+- Fixture cleanup internals: `e2e/fixtures/org-cleanup.ts:111`
+- Global cleanup hook: `e2e/global-teardown.ts:1`
+- Playwright parallel baseline: `playwright.config.ts:29`
+- SaaS tenant route shell: `client/src/App.tsx:175`
+- Tenant bootstrap provider: `client/src/contexts/TenantProvider.tsx:40`
+- Cinema quick-links UI: `client/src/components/CinemasQuickLinks.tsx:11`
+- Cinema route/API wiring: `server/src/routes/cinemas.ts:37`
+- Testing guide (E2E + fixture usage): `docs/guides/development/testing.md:249`
+
+## Dev Agent Record
+
+### Agent Model Used
+
+github-copilot/gpt-5.3-codex
+
+### Debug Log References
+
+- CS execution for story 1.3 based on sprint auto-discovery and prior stories 1.1/1.2 context
+- `npm run test:run --workspace=client -- src/components/CinemasQuickLinks.test.tsx src/pages/CinemaPage.test.tsx`
+- `npx playwright install chromium`
+- `E2E_ENABLE_ORG_FIXTURE=true npx playwright test e2e/multi-tenant-cinema-isolation.spec.ts --project=chromium --no-deps` (failed in local env: `/test/seed-org` returned `404`, runtime not in fixture test mode)
+- `npx playwright test e2e/multi-tenant-cinema-isolation.spec.ts --project=chromium --list --no-deps`
+
+### Completion Notes List
+
+- Created implementation-ready story file with AC-aligned tasks for multi-tenant cinema E2E isolation.
+- Included explicit guardrails for fixture reuse, tenant credentials usage, selector stability, and anti-flake patterns.
+- Added concrete file targets and failure-mode pitfalls to reduce LLM dev agent ambiguity.
+- Added dedicated Playwright spec `e2e/multi-tenant-cinema-isolation.spec.ts` covering org A vs org B cinema list isolation, API-level cross-tenant denial, and forbidden detail navigation checks.
+- Reused fixture lifecycle (`seedTestOrg`, auto afterEach cleanup, global teardown) with no custom cleanup bypass.
+- Added stable UI selectors for cinema isolation assertions in `CinemasQuickLinks` (`cinema-list`, `cinema-list-item`) and forbidden message selector in `CinemaPage` (`403-error-message`).
+- Added client unit tests for new selectors and org-scoped forbidden message behavior.
+- Targeted E2E execution is blocked in current local runtime due to fixture endpoints returning `404` (environment not started in SaaS test fixture mode), but spec parses and is discoverable by Playwright.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/1-3-e2e-multi-tenant-cinema-isolation-test.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `e2e/multi-tenant-cinema-isolation.spec.ts`
+- `client/src/components/CinemasQuickLinks.tsx`
+- `client/src/components/CinemasQuickLinks.test.tsx`
+- `client/src/pages/CinemaPage.tsx`
+- `client/src/pages/CinemaPage.test.tsx`
+
+## Change Log
+
+- 2026-04-19: Implemented multi-tenant cinema isolation E2E story with dedicated Playwright spec, selector instrumentation (`cinema-list`, `cinema-list-item`, `403-error-message`), and supporting client tests; validated unit tests locally and documented fixture-mode E2E runtime dependency.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-04-15
-last_updated: 2026-04-18T08:00:00Z
+last_updated: 2026-04-19T21:12:00Z
 project: allo-scrapper
 project_key: NOKEY
 tracking_system: file-system
@@ -60,7 +60,7 @@ development_status:
   epic-1: in-progress
   1-1-implement-org-id-validation-middleware: done
   1-2-add-org-id-to-all-observability-traces: done
-  1-3-e2e-multi-tenant-cinema-isolation-test: backlog
+  1-3-e2e-multi-tenant-cinema-isolation-test: in-progress
   1-4-e2e-multi-tenant-user-management-isolation-test: backlog
   1-5-e2e-multi-tenant-schedule-isolation-test: backlog
   1-6-api-level-tenant-isolation-enforcement-tests: backlog

--- a/client/src/components/CinemasQuickLinks.test.tsx
+++ b/client/src/components/CinemasQuickLinks.test.tsx
@@ -28,6 +28,13 @@ describe('CinemasQuickLinks', () => {
     expect(screen.getByText('Pathé Wepler')).toBeInTheDocument();
   });
 
+  it('exposes stable test ids for cinema isolation e2e checks', () => {
+    renderComponent();
+
+    expect(screen.getByTestId('cinema-list')).toBeInTheDocument();
+    expect(screen.getAllByTestId('cinema-list-item')).toHaveLength(2);
+  });
+
   it('shows "+ Ajouter un cinéma" button when canAddCinema is true', () => {
     renderComponent({ canAddCinema: true });
 

--- a/client/src/components/CinemasQuickLinks.tsx
+++ b/client/src/components/CinemasQuickLinks.tsx
@@ -10,12 +10,13 @@ interface CinemasQuickLinksProps {
 
 function CinemasQuickLinks({ cinemas, canAddCinema, onAddCinema }: CinemasQuickLinksProps) {
   return (
-    <div className="bg-white rounded-xl border border-gray-100 p-3 shadow-sm mb-6">
+    <div className="bg-white rounded-xl border border-gray-100 p-3 shadow-sm mb-6" data-testid="cinema-list">
       <div className="flex flex-wrap gap-2">
         {cinemas.map((cinema) => (
           <Link
             key={cinema.id}
             to={`/cinema/${cinema.id}`}
+            data-testid="cinema-list-item"
             className="px-3 py-1.5 bg-gray-50 text-gray-700 text-sm rounded-lg hover:bg-primary hover:text-black transition font-semibold"
           >
             {cinema.name}

--- a/client/src/pages/CinemaPage.test.tsx
+++ b/client/src/pages/CinemaPage.test.tsx
@@ -116,6 +116,25 @@ describe('CinemaPage - renders cinema details', () => {
     await waitFor(() => {
       expect(screen.getByText(/Cinema not found/i)).toBeInTheDocument();
     });
+    expect(screen.queryByTestId('403-error-message')).not.toBeInTheDocument();
+  });
+
+  it('shows cross-tenant message for authenticated org-scoped missing cinema', async () => {
+    vi.mocked(clientApi.getCinemas).mockResolvedValue([mockCinema]);
+    vi.mocked(clientApi.getCinemaSchedule).mockRejectedValue(new Error('Cross-tenant access denied'));
+
+    renderWithClient(
+      <MemoryRouter initialEntries={['/org/acme/cinema/C9999']}>
+        <Routes>
+          <Route path="/org/:slug/cinema/:id" element={<CinemaPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('403-error-message')).toHaveTextContent(/Cross-tenant access denied/i);
+    });
+    expect(screen.getByRole('heading', { name: /403 Forbidden/i })).toBeInTheDocument();
   });
 
   it('shows first available showtimes when no showtimes exist for today', async () => {

--- a/client/src/pages/CinemaPage.tsx
+++ b/client/src/pages/CinemaPage.tsx
@@ -129,10 +129,17 @@ export default function CinemaPage() {
   }
 
   if (error || !cinema) {
+    const isForbidden = Boolean(error) && error.toLowerCase().includes('cross-tenant access denied');
+    const errorMessage = error || 'Cinema not found';
+
     return (
       <div className="bg-red-50 border border-red-200 rounded-lg p-6">
-        <h2 className="text-xl font-bold text-red-800 mb-2">Erreur</h2>
-        <p className="text-red-600">{error || 'Cinema not found'}</p>
+        <h2 className="text-xl font-bold text-red-800 mb-2">{isForbidden ? '403 Forbidden' : 'Erreur'}</h2>
+        {isForbidden ? (
+          <p className="text-red-600" data-testid="403-error-message">{errorMessage}</p>
+        ) : (
+          <p className="text-red-600">{errorMessage}</p>
+        )}
       </div>
     );
   }

--- a/client/src/pages/CinemaPage.tsx
+++ b/client/src/pages/CinemaPage.tsx
@@ -129,7 +129,7 @@ export default function CinemaPage() {
   }
 
   if (error || !cinema) {
-    const isForbidden = Boolean(error) && error.toLowerCase().includes('cross-tenant access denied');
+    const isForbidden = typeof error === 'string' && error.toLowerCase().includes('cross-tenant access denied');
     const errorMessage = error || 'Cinema not found';
 
     return (

--- a/docs/guides/development/testing.md
+++ b/docs/guides/development/testing.md
@@ -271,6 +271,12 @@ Enable fixture-backed seeding in migrated specs:
 E2E_ENABLE_ORG_FIXTURE=true npx playwright test
 ```
 
+Run the dedicated multi-tenant cinema isolation scenario:
+
+```bash
+E2E_ENABLE_ORG_FIXTURE=true npx playwright test e2e/multi-tenant-cinema-isolation.spec.ts --project=chromium --no-deps
+```
+
 Troubleshooting:
 - If teardown reports failures, inspect logs with `org_id`, `test_id`, `worker_id`
 - Repeated cleanup is idempotent; `404` on already-deleted orgs is treated as skipped
@@ -327,7 +333,8 @@ e2e/                              # Playwright E2E tests (12 comprehensive specs
 ├── scrape-progress.spec.ts       # Scrape progress monitoring
 ├── showtime-buttons.spec.ts      # Showtime button interactions
 ├── theme-application.spec.ts     # Theme customization
-└── user-management.spec.ts       # User CRUD operations
+├── user-management.spec.ts       # User CRUD operations
+└── multi-tenant-cinema-isolation.spec.ts  # Cross-tenant cinema isolation checks
 
 playwright.config.ts              # Playwright configuration
 scripts/integration-test.sh       # Automated full-stack test script

--- a/e2e/multi-tenant-cinema-isolation.spec.ts
+++ b/e2e/multi-tenant-cinema-isolation.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect } from './fixtures/org-fixture';
+
+const useOrgFixture = process.env['E2E_ENABLE_ORG_FIXTURE'] === 'true';
+
+interface LoginResponse {
+  success: boolean;
+  data: {
+    token: string;
+    user: {
+      org_slug?: string;
+    };
+  };
+}
+
+interface CinemasResponse {
+  success: boolean;
+  data: Array<{ id: string; name: string }>;
+}
+
+test.describe('Multi-tenant cinema isolation', () => {
+  test.skip(!useOrgFixture, 'Requires fixture-backed SaaS runtime (E2E_ENABLE_ORG_FIXTURE=true)');
+
+  test('org A only sees org A cinemas and cannot access org B cinema details', async ({ page, request, seedTestOrg }) => {
+    const orgA = await seedTestOrg();
+    const orgB = await seedTestOrg();
+
+    const orgALogin = await request.post('/api/auth/login', {
+      data: {
+        username: orgA.admin.username,
+        password: orgA.admin.password,
+      },
+    });
+    expect(orgALogin.ok()).toBe(true);
+    const orgALoginBody = await orgALogin.json() as LoginResponse;
+    const orgAToken = orgALoginBody.data.token;
+    expect(orgALoginBody.data.user.org_slug).toBe(orgA.orgSlug);
+
+    const orgBLogin = await request.post('/api/auth/login', {
+      data: {
+        username: orgB.admin.username,
+        password: orgB.admin.password,
+      },
+    });
+    expect(orgBLogin.ok()).toBe(true);
+    const orgBLoginBody = await orgBLogin.json() as LoginResponse;
+    const orgBToken = orgBLoginBody.data.token;
+    expect(orgBLoginBody.data.user.org_slug).toBe(orgB.orgSlug);
+
+    const orgBCinemasForId = await request.get(`/api/org/${orgB.orgSlug}/cinemas`, {
+      headers: { Authorization: `Bearer ${orgBToken}` },
+    });
+    expect(orgBCinemasForId.ok()).toBe(true);
+    const orgBCinemasForIdBody = await orgBCinemasForId.json() as CinemasResponse;
+    const orgBFirstCinemaId = orgBCinemasForIdBody.data[0]?.id;
+    expect(orgBFirstCinemaId).toBeTruthy();
+
+    const orgASeededCinemas = await request.get(`/api/org/${orgA.orgSlug}/cinemas`, {
+      headers: { Authorization: `Bearer ${orgAToken}` },
+    });
+    expect(orgASeededCinemas.ok()).toBe(true);
+    const orgASeededCinemasBody = await orgASeededCinemas.json() as CinemasResponse;
+    const orgACinemaIds = orgASeededCinemasBody.data.map((item) => item.id);
+    const orgAExtraCinemaIds = orgACinemaIds.slice(2);
+
+    for (const cinemaId of orgAExtraCinemaIds) {
+      const deleteResponse = await request.delete(`/api/org/${orgA.orgSlug}/cinemas/${cinemaId}`, {
+        headers: { Authorization: `Bearer ${orgAToken}` },
+      });
+      expect(deleteResponse.status()).toBe(204);
+    }
+
+    const orgAUiCinemasResponse = await request.get(`/api/org/${orgA.orgSlug}/cinemas`, {
+      headers: { Authorization: `Bearer ${orgAToken}` },
+    });
+    expect(orgAUiCinemasResponse.ok()).toBe(true);
+    const orgAUiCinemasBody = await orgAUiCinemasResponse.json() as CinemasResponse;
+    const orgAUiCinemaIds = orgAUiCinemasBody.data.map((item) => item.id);
+
+    await page.goto('/');
+    await page.evaluate(([token, slug]) => {
+      localStorage.setItem('token', token);
+      localStorage.setItem(
+        'user',
+        JSON.stringify({
+          id: 1,
+          username: 'impersonated-admin',
+          role_id: 1,
+          role_name: 'admin',
+          is_system_role: false,
+          permissions: ['cinemas:read', 'cinemas:create'],
+          org_slug: slug,
+        })
+      );
+    }, [orgAToken, orgA.orgSlug]);
+
+    const responsePromise = page.waitForResponse((response) => {
+      return response.url().includes(`/api/org/${orgA.orgSlug}/cinemas`) && response.request().method() === 'GET';
+    });
+
+    await page.goto(`/org/${orgA.orgSlug}/`);
+
+    const cinemaList = page.getByTestId('cinema-list');
+    await expect(cinemaList).toBeVisible();
+
+    const cinemaItems = page.getByTestId('cinema-list-item');
+    await expect(cinemaItems).toHaveCount(2);
+
+    const orgAFirstCinemaText = await cinemaItems.first().textContent();
+    expect(orgAFirstCinemaText).toContain(orgA.orgSlug);
+
+    const orgBLeak = page.locator(`[data-testid="cinema-list-item"]:has-text("${orgB.orgSlug}")`);
+    await expect(orgBLeak).toHaveCount(0);
+
+    const cinemasResponse = await responsePromise;
+    expect(cinemasResponse.ok()).toBe(true);
+
+    const cinemasPayload = await cinemasResponse.json() as {
+      success: boolean;
+      data: Array<{ id: string; name: string }>;
+    };
+    expect(cinemasPayload.success).toBe(true);
+    const names = cinemasPayload.data.map((item) => item.name);
+    expect(names.length).toBe(2);
+    expect(names.every((name) => name.includes(orgA.orgSlug))).toBe(true);
+    expect(names.some((name) => name.includes(orgB.orgSlug))).toBe(false);
+    const ids = cinemasPayload.data.map((item) => item.id);
+    expect([...ids].sort()).toEqual([...orgAUiCinemaIds].sort());
+    expect(ids).not.toContain(orgBFirstCinemaId);
+
+    const orgBCinemasResponse = await request.get(`/api/org/${orgB.orgSlug}/cinemas`, {
+      headers: { Authorization: `Bearer ${orgAToken}` },
+    });
+
+    expect(orgBCinemasResponse.status()).toBe(403);
+    const orgBCinemasPayload = await orgBCinemasResponse.json() as { error?: string };
+    expect(orgBCinemasPayload.error).toBe('Cross-tenant access denied');
+
+    const orgBDetailResponse = await request.get(`/api/org/${orgB.orgSlug}/cinemas/${orgBFirstCinemaId}`, {
+      headers: { Authorization: `Bearer ${orgAToken}` },
+    });
+    expect(orgBDetailResponse.status()).toBe(403);
+    const orgBDetailPayload = await orgBDetailResponse.json() as { error?: string };
+    expect(orgBDetailPayload.error).toBe('Cross-tenant access denied');
+
+    await page.goto(`/org/${orgB.orgSlug}/cinema/${orgBFirstCinemaId}`);
+    await expect(page.getByTestId('403-error-message')).toBeVisible();
+    await expect(page.getByTestId('403-error-message')).toContainText(/cross-tenant access denied/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated Playwright scenario for org cinema isolation and cross-tenant denial checks
- add stable client selectors and forbidden-state rendering behavior needed by the scenario
- update testing runbook and BMAD story/sprint tracking for story 1.3

## Validation
- `npm run test:run -- src/components/CinemasQuickLinks.test.tsx src/pages/CinemaPage.test.tsx`
- `npx playwright test e2e/multi-tenant-cinema-isolation.spec.ts --project=chromium --list --no-deps`

Closes #887