### PR TITLE
feat(client): compact date/search bar to single line

### DIFF
--- a/client/src/components/DaySelector.test.tsx
+++ b/client/src/components/DaySelector.test.tsx
@@ -3,12 +3,198 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import DaySelector from './DaySelector';
 
+
 const WEEK_START = '2026-03-25';
 // Fixed "today" in the week: 2026-03-30 (Monday)
 const FIXED_NOW = new Date('2026-03-30T14:00:00');
 const FIXED_TODAY = '2026-03-30';
 
-describe('DaySelector — bouton Maintenant', () => {
+describe('DaySelector — toggle compact (Maintenant ⇄ Tous les jours)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-03-30T14:00:00'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders a single toggle button instead of two separate buttons', () => {
+    render(
+      <DaySelector
+        weekStart="2026-03-25"
+        selectedDate={null}
+        onSelectDate={vi.fn()}
+        isNowActive={false}
+      />
+    );
+
+    // Must NOT have both a "Maintenant" button AND a "Tous les jours" button as separate elements
+    // Instead should have one toggle button with testid "day-selector-mode-toggle"
+    expect(screen.getByTestId('day-selector-mode-toggle')).toBeInTheDocument();
+    expect(screen.queryByTestId('day-selector-all')).not.toBeInTheDocument();
+  });
+
+  it('toggle shows "Tous les jours" label when isNowActive is false and selectedDate is null', () => {
+    render(
+      <DaySelector
+        weekStart="2026-03-25"
+        selectedDate={null}
+        onSelectDate={vi.fn()}
+        isNowActive={false}
+      />
+    );
+
+    const toggle = screen.getByTestId('day-selector-mode-toggle');
+    expect(toggle).toHaveTextContent(/tous les jours/i);
+  });
+
+  it('toggle shows "Maintenant" label when isNowActive is true', () => {
+    render(
+      <DaySelector
+        weekStart="2026-03-25"
+        selectedDate="2026-03-30"
+        onSelectDate={vi.fn()}
+        isNowActive={true}
+      />
+    );
+
+    const toggle = screen.getByTestId('day-selector-mode-toggle');
+    expect(toggle).toHaveTextContent(/maintenant/i);
+    expect(toggle).toHaveAttribute('data-now-active', 'true');
+  });
+
+  it('clicking toggle when in "Tous les jours" mode calls onNow', () => {
+    const onNow = vi.fn();
+
+    render(
+      <DaySelector
+        weekStart="2026-03-25"
+        selectedDate={null}
+        onSelectDate={vi.fn()}
+        onNow={onNow}
+        isNowActive={false}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('day-selector-mode-toggle'));
+    expect(onNow).toHaveBeenCalledOnce();
+    expect(onNow).toHaveBeenCalledWith('2026-03-30', '14:00');
+  });
+
+  it('clicking toggle when in "Maintenant" mode calls onSelectDate(null)', () => {
+    const onSelectDate = vi.fn();
+
+    render(
+      <DaySelector
+        weekStart="2026-03-25"
+        selectedDate="2026-03-30"
+        onSelectDate={onSelectDate}
+        isNowActive={true}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('day-selector-mode-toggle'));
+    expect(onSelectDate).toHaveBeenCalledWith(null);
+  });
+
+  it('toggle is disabled when today is outside the week', () => {
+    vi.setSystemTime(new Date('2030-01-01T10:00:00'));
+
+    render(
+      <DaySelector
+        weekStart="2026-03-25"
+        selectedDate={null}
+        onSelectDate={vi.fn()}
+        isNowActive={false}
+      />
+    );
+
+    expect(screen.getByTestId('day-selector-mode-toggle')).toBeDisabled();
+  });
+
+  it('toggle has aria-pressed attribute reflecting isNowActive state', () => {
+    const { rerender } = render(
+      <DaySelector
+        weekStart="2026-03-25"
+        selectedDate={null}
+        onSelectDate={vi.fn()}
+        isNowActive={false}
+      />
+    );
+
+    expect(screen.getByTestId('day-selector-mode-toggle')).toHaveAttribute('aria-pressed', 'false');
+
+    rerender(
+      <DaySelector
+        weekStart="2026-03-25"
+        selectedDate="2026-03-30"
+        onSelectDate={vi.fn()}
+        isNowActive={true}
+      />
+    );
+
+    expect(screen.getByTestId('day-selector-mode-toggle')).toHaveAttribute('aria-pressed', 'true');
+  });
+});
+
+describe('DaySelector — format jour compact (une ligne)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-03-30T14:00:00'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('day buttons do NOT have flex-col class (no vertical stack)', () => {
+    render(
+      <DaySelector
+        weekStart="2026-03-25"
+        selectedDate={null}
+        onSelectDate={vi.fn()}
+      />
+    );
+
+    const dayButton = screen.getByTestId('day-selector-2026-03-25');
+    expect(dayButton).not.toHaveClass('flex-col');
+  });
+
+  it('day buttons render weekday and day number inline on one line', () => {
+    render(
+      <DaySelector
+        weekStart="2026-03-25"
+        selectedDate={null}
+        onSelectDate={vi.fn()}
+      />
+    );
+
+    // The first day (2026-03-25 = mercredi) should show weekday + day number
+    const dayButton = screen.getByTestId('day-selector-2026-03-25');
+    expect(dayButton).toHaveTextContent(/mer/i); // weekday
+    expect(dayButton).toHaveTextContent(/25/);   // day number
+    // Month should NOT be rendered as separate element
+    expect(dayButton.querySelectorAll('span').length).toBeLessThanOrEqual(2);
+  });
+
+  it('renders 7 day buttons', () => {
+    render(
+      <DaySelector
+        weekStart="2026-03-25"
+        selectedDate={null}
+        onSelectDate={vi.fn()}
+      />
+    );
+
+    for (let i = 25; i <= 31; i++) {
+      const dateStr = `2026-03-${String(i).padStart(2, '0')}`;
+      expect(screen.getByTestId(`day-selector-${dateStr}`)).toBeInTheDocument();
+    }
+  });
+});
+
+describe('DaySelector — bouton Maintenant (legacy compatibility)', () => {
   beforeEach(() => {
     vi.useFakeTimers({ toFake: ['Date'] });
     vi.setSystemTime(FIXED_NOW);

--- a/client/src/components/DaySelector.test.tsx
+++ b/client/src/components/DaySelector.test.tsx
@@ -194,7 +194,7 @@ describe('DaySelector — format jour compact (une ligne)', () => {
   });
 });
 
-describe('DaySelector — bouton Maintenant (legacy compatibility)', () => {
+describe('DaySelector — toggle (legacy compatibility)', () => {
   beforeEach(() => {
     vi.useFakeTimers({ toFake: ['Date'] });
     vi.setSystemTime(FIXED_NOW);
@@ -204,7 +204,7 @@ describe('DaySelector — bouton Maintenant (legacy compatibility)', () => {
     vi.useRealTimers();
   });
 
-  it('renders the Maintenant button as the first button', () => {
+  it('renders the toggle as the first button', () => {
     render(
       <DaySelector
         weekStart={WEEK_START}
@@ -214,10 +214,10 @@ describe('DaySelector — bouton Maintenant (legacy compatibility)', () => {
     );
 
     const buttons = screen.getAllByRole('button');
-    expect(buttons[0]).toHaveTextContent(/maintenant/i);
+    expect(buttons[0]).toBe(screen.getByTestId('day-selector-mode-toggle'));
   });
 
-  it('Maintenant button is enabled when today is within the week', () => {
+  it('toggle is enabled when today is within the week', () => {
     render(
       <DaySelector
         weekStart={WEEK_START}
@@ -226,11 +226,10 @@ describe('DaySelector — bouton Maintenant (legacy compatibility)', () => {
       />
     );
 
-    expect(screen.getByRole('button', { name: /maintenant/i })).not.toBeDisabled();
+    expect(screen.getByTestId('day-selector-mode-toggle')).not.toBeDisabled();
   });
 
-  it('Maintenant button is disabled when today is outside the week', () => {
-    // Week starting in the past, today is way ahead
+  it('toggle is disabled when today is outside the week', () => {
     vi.setSystemTime(new Date('2030-01-01T10:00:00'));
 
     render(
@@ -241,10 +240,10 @@ describe('DaySelector — bouton Maintenant (legacy compatibility)', () => {
       />
     );
 
-    expect(screen.getByRole('button', { name: /maintenant/i })).toBeDisabled();
+    expect(screen.getByTestId('day-selector-mode-toggle')).toBeDisabled();
   });
 
-  it('calls onNow with today date and current HH:MM when clicked', () => {
+  it('calls onNow with today date and current HH:MM when clicked in "Tous les jours" mode', () => {
     const handleNow = vi.fn();
 
     render(
@@ -256,13 +255,13 @@ describe('DaySelector — bouton Maintenant (legacy compatibility)', () => {
       />
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /maintenant/i }));
+    fireEvent.click(screen.getByTestId('day-selector-mode-toggle'));
 
     expect(handleNow).toHaveBeenCalledOnce();
     expect(handleNow).toHaveBeenCalledWith(FIXED_TODAY, '14:00');
   });
 
-  it('shows Maintenant button as active when isNowActive is true', () => {
+  it('shows toggle as active (data-now-active) when isNowActive is true', () => {
     render(
       <DaySelector
         weekStart={WEEK_START}
@@ -272,10 +271,10 @@ describe('DaySelector — bouton Maintenant (legacy compatibility)', () => {
       />
     );
 
-    expect(screen.getByRole('button', { name: /maintenant/i })).toHaveAttribute('data-now-active', 'true');
+    expect(screen.getByTestId('day-selector-mode-toggle')).toHaveAttribute('data-now-active', 'true');
   });
 
-  it('shows Maintenant button as inactive when isNowActive is false', () => {
+  it('toggle has no data-now-active when isNowActive is false', () => {
     render(
       <DaySelector
         weekStart={WEEK_START}
@@ -285,6 +284,6 @@ describe('DaySelector — bouton Maintenant (legacy compatibility)', () => {
       />
     );
 
-    expect(screen.getByRole('button', { name: /maintenant/i })).not.toHaveAttribute('data-now-active', 'true');
+    expect(screen.getByTestId('day-selector-mode-toggle')).not.toHaveAttribute('data-now-active', 'true');
   });
 });

--- a/client/src/components/DaySelector.tsx
+++ b/client/src/components/DaySelector.tsx
@@ -12,20 +12,19 @@ interface DaySelectorProps {
 // re-initialization during loops or frequent re-renders
 const fmtWeekday = new Intl.DateTimeFormat('fr-FR', { weekday: 'short' });
 const fmtDay     = new Intl.DateTimeFormat('fr-FR', { day: 'numeric' });
-const fmtMonth   = new Intl.DateTimeFormat('fr-FR', { month: 'short' });
 
-// fr-FR abbreviates weekdays/months with a trailing period (e.g. "lun.", "mars.")
+// fr-FR abbreviates weekdays with a trailing period (e.g. "lun.", "mar.")
 const stripDot = (s: string) => s.replace(/\.$/, '');
 
 function DaySelector({ weekStart, selectedDate, onSelectDate, onNow, isNowActive = false }: DaySelectorProps) {
   const days = useMemo(() => {
     if (!weekStart) return [];
-    
+
     const start = new Date(weekStart);
     if (isNaN(start.getTime())) return [];
 
     const result = [];
-    
+
     for (let i = 0; i < 7; i++) {
       const date = new Date(start);
       date.setDate(start.getDate() + i);
@@ -33,72 +32,73 @@ function DaySelector({ weekStart, selectedDate, onSelectDate, onNow, isNowActive
         date: date.toISOString().split('T')[0],
         weekday: stripDot(fmtWeekday.format(date)),
         day:     fmtDay.format(date),
-        month:   stripDot(fmtMonth.format(date)),
       });
     }
-    
+
     return result;
   }, [weekStart]);
 
   const today = new Date().toISOString().split('T')[0];
   const todayInWeek = days.some(d => d.date === today);
 
-  const handleNowClick = () => {
-    if (!todayInWeek) return;
-    const now = new Date();
-    const hh = String(now.getHours()).padStart(2, '0');
-    const mm = String(now.getMinutes()).padStart(2, '0');
-    onNow?.(today, `${hh}:${mm}`);
+  const handleToggleClick = () => {
+    if (isNowActive) {
+      // bascule vers "Tous les jours"
+      onSelectDate(null);
+    } else {
+      // bascule vers "Maintenant"
+      if (!todayInWeek) return;
+      const now = new Date();
+      const hh = String(now.getHours()).padStart(2, '0');
+      const mm = String(now.getMinutes()).padStart(2, '0');
+      onNow?.(today, `${hh}:${mm}`);
+    }
   };
 
   return (
-    <div className="bg-white rounded-xl border border-gray-100 p-3 shadow-sm overflow-x-auto">
-      <div className="flex gap-2 min-w-max items-stretch">
-        {/* Maintenant button — always first */}
+    <div className="bg-white rounded-lg border border-gray-100 px-2 py-1.5 shadow-sm overflow-x-auto">
+      <div className="flex gap-1.5 min-w-max items-center">
+        {/* Toggle bi-état: Maintenant ⇄ Tous les jours */}
         <button
-          onClick={handleNowClick}
-          disabled={!todayInWeek}
+          onClick={handleToggleClick}
+          disabled={!isNowActive && !todayInWeek}
           data-now-active={isNowActive || undefined}
-          className={`px-3 py-2 text-sm rounded-lg transition font-semibold active:scale-95 flex flex-col items-center justify-center min-w-[68px] ${
+          data-testid="day-selector-mode-toggle"
+          aria-pressed={isNowActive}
+          aria-label={
+            isNowActive
+              ? 'Désactiver le filtre Maintenant et voir tous les jours'
+              : 'Filtrer pour voir uniquement les séances à venir aujourd\'hui'
+          }
+          className={`px-3 py-1.5 text-xs rounded-lg transition font-semibold active:scale-95 flex items-center gap-1.5 whitespace-nowrap ${
             isNowActive
               ? 'bg-teal-500 text-white cursor-pointer'
-              : 'bg-gray-50 text-gray-700 hover:bg-gray-100 cursor-pointer'
-          } ${!todayInWeek ? 'opacity-50 cursor-not-allowed' : ''}`}
+              : selectedDate === null
+                ? 'bg-primary text-black cursor-pointer'
+                : 'bg-gray-50 text-gray-700 hover:bg-gray-100 cursor-pointer'
+          } ${!isNowActive && !todayInWeek ? 'opacity-50 cursor-not-allowed' : ''}`}
         >
-          <span className="text-base leading-none">⏱</span>
-          <span className="text-[11px] font-bold mt-0.5">Maintenant</span>
+          <span>{isNowActive ? '⏱' : '📅'}</span>
+          <span>{isNowActive ? 'Maintenant' : 'Tous les jours'}</span>
         </button>
 
-        <button
-          onClick={() => onSelectDate(null)}
-          className={`px-3 py-2 text-sm rounded-lg transition font-semibold cursor-pointer active:scale-95 flex flex-col items-center justify-center min-w-[68px] ${
-            selectedDate === null && !isNowActive
-              ? 'bg-primary text-black'
-              : 'bg-gray-50 text-gray-700 hover:bg-gray-100'
-          }`}
-          data-testid="day-selector-all"
-        >
-          <span className="text-[11px] font-bold leading-tight text-center">Tous les jours</span>
-        </button>
+        {/* Séparateur visuel */}
+        <div className="w-px h-5 bg-gray-200 flex-shrink-0" />
 
+        {/* Jours de la semaine — format compact "Lun 21" sur une ligne */}
         {days.map((day) => (
           <button
             key={day.date}
             onClick={() => onSelectDate(day.date)}
-            className={`px-2 py-2 rounded-lg transition cursor-pointer active:scale-95 flex flex-col items-center justify-center min-w-[52px] ${
+            className={`px-3 py-1.5 text-xs rounded-lg transition cursor-pointer active:scale-95 flex items-center gap-1 whitespace-nowrap ${
               selectedDate === day.date && !isNowActive
-                ? 'bg-primary text-black'
+                ? 'bg-primary text-black font-bold'
                 : 'bg-gray-50 text-gray-700 hover:bg-gray-100'
             }`}
             data-testid={`day-selector-${day.date}`}
           >
-            <span className={`text-[10px] uppercase font-bold ${selectedDate === day.date && !isNowActive ? 'text-black' : 'text-gray-400'}`}>
-              {day.weekday}
-            </span>
-            <span className="text-base font-bold leading-none my-0.5">{day.day}</span>
-            <span className={`text-[10px] ${selectedDate === day.date && !isNowActive ? 'text-black' : 'text-gray-400'}`}>
-              {day.month}
-            </span>
+            <span className="uppercase font-bold">{day.weekday}</span>
+            <span className="font-bold">{day.day}</span>
           </button>
         ))}
       </div>

--- a/client/src/pages/HomePage.test.tsx
+++ b/client/src/pages/HomePage.test.tsx
@@ -174,15 +174,15 @@ describe('HomePage — bouton Maintenant', () => {
 
   it('renders the Maintenant button in the DaySelector', async () => {
     renderHomePage();
-    await waitFor(() => expect(screen.queryByRole('button', { name: /maintenant/i })).toBeInTheDocument());
-    expect(screen.getByRole('button', { name: /maintenant/i })).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByTestId('day-selector-mode-toggle')).toBeInTheDocument());
+    expect(screen.getByTestId('day-selector-mode-toggle')).toBeInTheDocument();
   });
 
   it('fetches today\'s films when Maintenant is clicked', async () => {
     renderHomePage();
-    await waitFor(() => expect(screen.getByRole('button', { name: /maintenant/i })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('day-selector-mode-toggle')).toBeInTheDocument());
 
-    fireEvent.click(screen.getByRole('button', { name: /maintenant/i }));
+    fireEvent.click(screen.getByTestId('day-selector-mode-toggle'));
 
     await waitFor(() => {
       expect(clientApi.getFilmsByDate).toHaveBeenCalledWith(FIXED_TODAY);
@@ -191,9 +191,9 @@ describe('HomePage — bouton Maintenant', () => {
 
   it('hides films with only past showtimes after Maintenant click', async () => {
     renderHomePage();
-    await waitFor(() => expect(screen.getByRole('button', { name: /maintenant/i })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('day-selector-mode-toggle')).toBeInTheDocument());
 
-    fireEvent.click(screen.getByRole('button', { name: /maintenant/i }));
+    fireEvent.click(screen.getByTestId('day-selector-mode-toggle'));
 
     await waitFor(() => {
       expect(screen.getByText('Film Futur')).toBeInTheDocument();

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -125,7 +125,7 @@ export default function HomePage() {
 
       {/* Sticky Header Section - Compact */}
       <div
-        className="sticky z-40 bg-gray-50/95 backdrop-blur-sm pt-3 pb-3 mb-4 shadow-sm -mx-4 px-4"
+        className="sticky z-40 bg-gray-50/95 backdrop-blur-sm pt-2 pb-2 mb-3 shadow-sm -mx-4 px-4"
         style={{ top: 'var(--layout-header-offset, 64px)' }}
         data-testid="sticky-search-date-container"
       >


### PR DESCRIPTION
## Summary

- Replace separate \`Maintenant\` + \`Tous les jours\` buttons with a single bi-state toggle
- Toggle switches between modes on click: \`📅 Tous les jours\` ⇄ \`⏱ Maintenant\`
- Day buttons flattened from vertical 3-line stack (weekday/day/month) to inline compact format \`Lun 21\`
- Reduce wrapper and sticky container padding to achieve single-line bar height (~40-48px vs ~90-100px)
- Accessibility: \`aria-pressed\` + \`aria-label\` on toggle button
- Tests updated to use \`data-testid\` instead of accessible name queries

Closes #889