### PR TITLE
test(client): complete tenant schedule isolation coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,8 +821,8 @@ For AI coding agents, see [AGENTS.md](./AGENTS.md) for mandatory workflow and TD
 - See [`docs/guides/development/testing.md`](./docs/guides/development/testing.md) for usage and safety rules.
 
 **SaaS fixture API (test runtime):**
-- In `NODE_ENV=test`, SaaS exposes `POST /test/seed-org` and `DELETE /test/cleanup-org/:id` for deterministic multi-tenant test setup.
-- Outside test runtime these endpoints are intentionally unavailable (`404`).
+- In `NODE_ENV=test`, or when the backend runs with `E2E_ENABLE_ORG_FIXTURE=true`, SaaS exposes `POST /test/seed-org` and `DELETE /test/cleanup-org/:id` for deterministic multi-tenant test setup.
+- Outside those explicit fixture runtimes these endpoints are intentionally unavailable (`404`).
 - See [`docs/guides/development/testing.md`](./docs/guides/development/testing.md) for payload examples and troubleshooting.
 
 **Quick contribution checklist:**

--- a/_bmad-output/implementation-artifacts/1-5-e2e-multi-tenant-schedule-isolation-test.md
+++ b/_bmad-output/implementation-artifacts/1-5-e2e-multi-tenant-schedule-isolation-test.md
@@ -1,6 +1,6 @@
 # Story 1.5: E2E Multi-Tenant Schedule Isolation Test
 
-Status: in-progress
+Status: review
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -50,22 +50,22 @@ so that users cannot view screening schedules from other organizations.
   - [x] Do not invent a new `/api/schedules?cinema_id=...` contract unless the smallest correct fix genuinely requires one; prefer locking tests to the real schedule-fetch path already used by the tenant UI
   - [x] If acceptance-criteria wording and real route topology diverge, codify the chosen tenant-scoped contract in route tests before relying on it in Playwright
 
-- [ ] Implement tenant-authenticated schedule-page assertions for org A (AC: 1)
+- [x] Implement tenant-authenticated schedule-page assertions for org A (AC: 1)
   - [x] Log in with org A admin credentials returned by the fixture seed, not legacy global credentials
   - [x] Navigate to the real tenant route shape for a cinema schedule page under org A
   - [x] Add `data-testid="schedule-calendar"` to the actual schedule/showtime container if it does not already exist
-  - [ ] Assert org A schedule content is visible and org B schedule content is absent in the rendered calendar view
+  - [x] Assert org A schedule content is visible and org B schedule content is absent in the rendered calendar view
 
-- [ ] Validate API-level denial for cross-tenant schedule access (AC: 2)
+- [x] Validate API-level denial for cross-tenant schedule access (AC: 2)
   - [x] Trigger the tenant-scoped schedule fetch for an org B cinema while authenticated as org A
   - [x] Assert the request receives `403` rather than a silent success or incidental `404`
   - [x] Assert no org B schedule payload is returned on the denied request
   - [x] Assert the denial is API-driven, not only a client-side guard or hidden navigation path
 
-- [ ] Validate network payload isolation for the schedule page (AC: 3)
+- [x] Validate network payload isolation for the schedule page (AC: 3)
   - [x] Capture the actual schedule API response used by the org A cinema page session
-  - [ ] Add a negative assertion that known org B cinema identifiers and showtime data are absent from the org A payload
-  - [ ] If the current payload does not expose explicit tenant identity fields, add the minimal stable response metadata or alternate negative assertions needed to prove org-A-only scope without broad API redesign
+  - [x] Add a negative assertion that known org B cinema identifiers and showtime data are absent from the org A payload
+  - [x] If the current payload does not expose explicit tenant identity fields, add the minimal stable response metadata or alternate negative assertions needed to prove org-A-only scope without broad API redesign
   - [x] Keep assertions deterministic and not dependent on incidental ordering of showtime entries
 
 - [x] Close UX and contract gaps required by this story (AC: 1, 2, 3)
@@ -73,9 +73,9 @@ so that users cannot view screening schedules from other organizations.
   - [x] Add or extend SaaS route tests in `packages/saas/src/routes/org.test.ts` to lock the chosen `403` contract for cross-tenant schedule access
   - [x] Preserve existing cinema-isolation behavior from Story 1.3 and avoid broad rewrites of shared films/cinemas route structure
 
-- [ ] Keep fixture cleanup and parallel safety intact (AC: 4)
+- [x] Keep fixture cleanup and parallel safety intact (AC: 4)
   - [x] Reuse `e2e/fixtures/org-fixture.ts`, `e2e/fixtures/org-cleanup.ts`, and `e2e/global-teardown.ts`
-  - [ ] Do not add ad-hoc SQL cleanup or manual tenant deletion inside the spec
+  - [x] Do not add ad-hoc SQL cleanup or manual tenant deletion inside the spec
   - [x] Reuse the shared runtime and cleanup assertions already established in Stories 1.3 and 1.4 where applicable
 
 - [x] Update tests and docs for the new E2E contract (AC: 1, 2, 3, 4)
@@ -175,10 +175,12 @@ github-copilot/gpt-5.4
 ### Debug Log References
 
 - CS execution for story 1.5 based on sprint auto-discovery after marking story 1.4 done
-- `npx vitest run src/routes/cinemas.test.ts src/routes/cinemas.security.test.ts` (server)
-- `npx vitest run src/pages/CinemaPage.test.tsx` (client)
-- `npx vitest run src/routes/org.test.ts` (packages/saas)
-- `E2E_ENABLE_ORG_FIXTURE=true npx playwright test e2e/multi-tenant-schedule-isolation.spec.ts --project=chromium --no-deps` (fixture runtime blocked locally: `/test/seed-org` returned `404`)
+- `npx vitest run src/routes/cinemas.test.ts src/routes/cinemas.security.test.ts src/app.test.ts` (server)
+- `npx vitest run src/api/client.test.ts src/pages/CinemaPage.test.tsx src/contexts/TenantProvider.test.tsx` (client)
+- `npx vitest run src/routes/test-fixtures.test.ts src/routes/org.test.ts src/plugin.test.ts src/services/org-service.test.ts` (packages/saas)
+- `npx vitest run e2e/fixtures/org-cleanup.test.ts` (fixture cleanup utilities)
+- `PLAYWRIGHT_BASE_URL=http://localhost:5174 E2E_ENABLE_ORG_FIXTURE=true npx playwright test e2e/multi-tenant-schedule-isolation.spec.ts --project=chromium --no-deps`
+- `PLAYWRIGHT_BASE_URL=http://localhost:5174 E2E_ENABLE_ORG_FIXTURE=true npx playwright test e2e/multi-tenant-schedule-isolation.spec.ts --project=chromium --no-deps --workers=4 --repeat-each=4`
 
 ### Completion Notes List
 
@@ -188,7 +190,11 @@ github-copilot/gpt-5.4
 - Added `data-testid="schedule-calendar"` coverage to `CinemaPage` and locked the selector with a focused client test.
 - Hardened the shared cinema detail route so org-scoped `GET /api/org/:slug/cinemas/:id` uses the same tenant auth, permission, and org-boundary enforcement as the list route.
 - Extended server and SaaS route tests to lock `403` behavior for cross-tenant cinema schedule access while keeping the current shared route topology intact.
-- Verified targeted client, server, and SaaS tests locally; dedicated Playwright verification is currently blocked by a local runtime configuration issue where `/test/seed-org` is not exposed.
+- Added fixture runtime opt-in, tenant-aware client cinema routing, hashed fixture IDs, and current-week seeded showtimes so the schedule page hits the correct tenant-scoped data.
+- Moved the shared API error handler to final app fallback registration so plugin org-route `403` errors return JSON instead of Express HTML error pages.
+- Updated tenant bootstrap to preserve cross-tenant `403` failures and render a dedicated forbidden state instead of collapsing them into `404 Organization not found`.
+- Hardened org creation bootstrap onto a dedicated pool client and parallelized fixture cleanup deletes so 4-worker schedule isolation runs stay deterministic.
+- Verified the story end-to-end in both single-worker and 4-worker Playwright runs against the real local SaaS dev stack.
 
 ### File List
 
@@ -197,12 +203,30 @@ github-copilot/gpt-5.4
 - `e2e/multi-tenant-schedule-isolation.spec.ts`
 - `client/src/pages/CinemaPage.tsx`
 - `client/src/pages/CinemaPage.test.tsx`
+- `client/src/api/client.ts`
+- `client/src/api/client.test.ts`
+- `client/src/contexts/TenantProvider.tsx`
+- `client/src/contexts/TenantProvider.test.tsx`
+- `server/src/app.ts`
+- `server/src/app.test.ts`
 - `server/src/routes/cinemas.ts`
 - `server/src/routes/cinemas.test.ts`
 - `server/src/routes/cinemas.security.test.ts`
+- `e2e/fixtures/org-cleanup.ts`
+- `e2e/fixtures/org-cleanup.test.ts`
+- `packages/saas/src/plugin.ts`
+- `packages/saas/src/plugin.test.ts`
+- `packages/saas/src/routes/test-fixtures.ts`
+- `packages/saas/src/routes/test-fixtures.test.ts`
+- `packages/saas/src/services/org-service.ts`
+- `packages/saas/src/services/org-service.test.ts`
+- `docs/guides/development/testing.md`
+- `docker-compose.dev.yml`
+- `README.md`
 - `packages/saas/src/routes/org.test.ts`
 
 ## Change Log
 
 - 2026-04-20: Created implementation-ready story file for multi-tenant schedule isolation with explicit route-topology guardrails, fixture reuse guidance, and concrete test/file targets.
 - 2026-04-20: Started dev-story implementation for schedule isolation by adding the dedicated Playwright spec, `schedule-calendar` instrumentation, and org-scoped cinema detail tenant-boundary enforcement; targeted tests pass, while full E2E execution is currently blocked locally because `/test/seed-org` returns `404`.
+- 2026-04-20: Completed Story 1.5 implementation and verification, including fixture runtime enablement, tenant-aware client schedule routing, hashed fixture IDs, JSON error handling for plugin routes, tenant forbidden-state rendering, concurrency-safe org bootstrap, and green Playwright validation in both single-worker and 4-worker runs.

--- a/_bmad-output/implementation-artifacts/1-5-e2e-multi-tenant-schedule-isolation-test.md
+++ b/_bmad-output/implementation-artifacts/1-5-e2e-multi-tenant-schedule-isolation-test.md
@@ -1,0 +1,208 @@
+# Story 1.5: E2E Multi-Tenant Schedule Isolation Test
+
+Status: in-progress
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a QA engineer,
+I want E2E tests that validate schedule data isolation between organizations,
+so that users cannot view screening schedules from other organizations.
+
+## Acceptance Criteria
+
+1. **Given** organization A has schedules for Cinema A1  
+   **And** organization B has schedules for Cinema B1  
+   **When** user from org A views the schedule calendar page  
+   **Then** only schedules from Cinema A1 are displayed in `data-testid="schedule-calendar"`  
+   **And** schedules from Cinema B1 are NOT visible
+
+2. **Given** user from org A is authenticated  
+   **When** they request the tenant-scoped schedule API for Cinema B1  
+   **Then** the API returns `403 Forbidden`  
+   **And** no schedule data from Cinema B1 is returned
+
+3. **Given** user from org A is authenticated  
+   **When** they inspect the schedule API response used by the page  
+   **Then** all schedule entries are scoped to org A  
+   **And** no schedules from org B are present in the response
+
+4. **Performance & Cleanup**  
+   **Given** this test runs with Playwright `workers: 4`  
+   **When** the test executes  
+   **Then** the test completes in `<2 minutes` (single worker)  
+   **And** parallel execution with 4 workers completes in `<5 minutes` total  
+   **And** test cleanup removes all seeded schedules and cinemas within `500ms`  
+   **And** no orphan schedule data remains after test completion
+
+## Tasks / Subtasks
+
+- [x] Add RED E2E spec for schedule isolation between two tenant orgs (AC: 1, 2, 3)
+  - [x] Create `e2e/multi-tenant-schedule-isolation.spec.ts` as a dedicated spec; do not overload `e2e/multi-tenant-cinema-isolation.spec.ts`
+  - [x] Use the shared org fixture layer: `import { test, expect, assertFixtureRuntimeWithinLimit } from './fixtures/org-fixture'`
+  - [x] Seed two orgs with `seedTestOrg()` and capture the org-specific cinema identifiers needed for positive and negative assertions
+  - [x] Keep the scenario deterministic by deriving cinema IDs and known fixture-backed showtime labels from the seeded org payloads or the test fixture data already inserted in `packages/saas/src/routes/test-fixtures.ts`
+
+- [x] Reconcile the real schedule UI/API topology before implementing assertions (AC: 1, 2, 3)
+  - [x] Confirm the user-facing schedule view under test is the tenant cinema schedule page (`/org/:slug/cinema/:id`) rendered by `client/src/pages/CinemaPage.tsx`, not the admin scrape-schedule management page in `client/src/pages/admin/SchedulesPage.tsx`
+  - [x] Confirm the real client request path used to fetch showtimes is `getCinemaSchedule()` in `client/src/api/client.ts`, which currently targets `/cinemas/:id`, and that under SaaS this resolves to `/api/org/:slug/cinemas/:id`
+  - [x] Do not invent a new `/api/schedules?cinema_id=...` contract unless the smallest correct fix genuinely requires one; prefer locking tests to the real schedule-fetch path already used by the tenant UI
+  - [x] If acceptance-criteria wording and real route topology diverge, codify the chosen tenant-scoped contract in route tests before relying on it in Playwright
+
+- [ ] Implement tenant-authenticated schedule-page assertions for org A (AC: 1)
+  - [x] Log in with org A admin credentials returned by the fixture seed, not legacy global credentials
+  - [x] Navigate to the real tenant route shape for a cinema schedule page under org A
+  - [x] Add `data-testid="schedule-calendar"` to the actual schedule/showtime container if it does not already exist
+  - [ ] Assert org A schedule content is visible and org B schedule content is absent in the rendered calendar view
+
+- [ ] Validate API-level denial for cross-tenant schedule access (AC: 2)
+  - [x] Trigger the tenant-scoped schedule fetch for an org B cinema while authenticated as org A
+  - [x] Assert the request receives `403` rather than a silent success or incidental `404`
+  - [x] Assert no org B schedule payload is returned on the denied request
+  - [x] Assert the denial is API-driven, not only a client-side guard or hidden navigation path
+
+- [ ] Validate network payload isolation for the schedule page (AC: 3)
+  - [x] Capture the actual schedule API response used by the org A cinema page session
+  - [ ] Add a negative assertion that known org B cinema identifiers and showtime data are absent from the org A payload
+  - [ ] If the current payload does not expose explicit tenant identity fields, add the minimal stable response metadata or alternate negative assertions needed to prove org-A-only scope without broad API redesign
+  - [x] Keep assertions deterministic and not dependent on incidental ordering of showtime entries
+
+- [x] Close UX and contract gaps required by this story (AC: 1, 2, 3)
+  - [x] Add or update client tests for any new `schedule-calendar` selector or explicit forbidden-state hooks on the schedule page
+  - [x] Add or extend SaaS route tests in `packages/saas/src/routes/org.test.ts` to lock the chosen `403` contract for cross-tenant schedule access
+  - [x] Preserve existing cinema-isolation behavior from Story 1.3 and avoid broad rewrites of shared films/cinemas route structure
+
+- [ ] Keep fixture cleanup and parallel safety intact (AC: 4)
+  - [x] Reuse `e2e/fixtures/org-fixture.ts`, `e2e/fixtures/org-cleanup.ts`, and `e2e/global-teardown.ts`
+  - [ ] Do not add ad-hoc SQL cleanup or manual tenant deletion inside the spec
+  - [x] Reuse the shared runtime and cleanup assertions already established in Stories 1.3 and 1.4 where applicable
+
+- [x] Update tests and docs for the new E2E contract (AC: 1, 2, 3, 4)
+  - [x] Verify whether `docs/guides/development/testing.md` needs updates for the dedicated schedule-isolation spec or current fixture-mode execution guidance
+  - [x] Keep the story scoped to schedule isolation only; do not pull in unrelated admin scheduling, scraper queue, or generic routing refactors
+
+## Dev Notes
+
+### Scope and Guardrails
+
+- This story is about end-user screening/showtime isolation between tenant organizations, not about admin scrape-schedule CRUD.
+- Keep implementation minimal: prefer a dedicated Playwright spec, targeted selector instrumentation, and the smallest backend contract clarification needed to make schedule isolation deterministic.
+- Story 1.3 already covered cinema isolation and Story 1.4 covered user isolation; reuse their fixture, anti-flake, and API-contract patterns rather than inventing new infrastructure.
+
+### Reinvention Prevention
+
+- Reuse existing fixture and cleanup utilities already delivered in Epic 0:
+  - `e2e/fixtures/org-fixture.ts`
+  - `e2e/fixtures/org-cleanup.ts`
+  - `e2e/global-teardown.ts`
+- Reuse current Playwright project settings in `playwright.config.ts`; do not add a separate Playwright config.
+- Reuse the existing SaaS tenant route shell in `client/src/App.tsx` and the existing cinema schedule page in `client/src/pages/CinemaPage.tsx`.
+- Do not use `client/src/pages/admin/SchedulesPage.tsx` as the page under test. That page manages scrape schedules (`/api/scraper/schedules`) and is not the user-facing cinema showtime view required by this story.
+
+### Previous Story Intelligence (from 1.3 and 1.4)
+
+- Story 1.3 established the pattern for fixture-backed tenant login: use seeded org-admin credentials, not hardcoded global credentials. [Source: `_bmad-output/implementation-artifacts/1-3-e2e-multi-tenant-cinema-isolation-test.md:54-69`]
+- Story 1.3 also added measurable fixture runtime and cleanup assertions in `e2e/fixtures/org-fixture.ts`; reuse those thresholds instead of duplicating cleanup logic. [Source: `e2e/fixtures/org-fixture.ts:5-39`]
+- Story 1.3 showed that explicit forbidden-state contracts matter: avoid relying on incidental `not found` behavior when the requirement is `403 Forbidden`. [Source: `_bmad-output/implementation-artifacts/1-3-e2e-multi-tenant-cinema-isolation-test.md:60-75`]
+- Story 1.4 showed that shared client APIs may still point at standalone-style paths and must be reconciled with SaaS org route topology before writing E2E expectations. [Source: `_bmad-output/implementation-artifacts/1-4-e2e-multi-tenant-user-management-isolation-test.md:74-88`]
+
+### Architecture Compliance Notes
+
+- Monorepo ESM and strict TypeScript rules remain mandatory; avoid `any` in tenant-isolation or auth-sensitive code paths. [Source: `_bmad-output/project-context.md:49-87`]
+- The tenant route shell lives under `/org/:slug/*`, including `/org/:slug/cinema/:id` for user-facing cinema schedules. [Source: `client/src/App.tsx:175-205`]
+- The current user-facing schedule page is `client/src/pages/CinemaPage.tsx`, which fetches showtimes with `getCinemaSchedule()` and currently has no `schedule-calendar` selector. [Source: `client/src/pages/CinemaPage.tsx:23-35`, `client/src/pages/CinemaPage.tsx:147-269`, `client/src/api/client.ts:123-133`]
+- The current admin `SchedulesPage` is for scrape cron jobs and talks to `/api/scraper/schedules`; it is out of scope for this story. [Source: `client/src/pages/admin/SchedulesPage.tsx:21-53`, `client/src/api/client.ts:208-260`]
+- Under SaaS, tenant org routes mount `cinemasRouter` and `filmsRouter` beneath `/api/org/:slug/*`; there is no separate showtime API route in the current architecture. [Source: `packages/saas/src/routes/org.ts:99-111`]
+- The current cinema detail API is `GET /api/cinemas/:id` in the shared router; implementation must verify and lock the tenant-safe behavior actually used under `/api/org/:slug/cinemas/:id`. [Source: `server/src/routes/cinemas.ts:146-165`]
+- Fixture seeding already inserts tenant-scoped showtimes into each org schema through `packages/saas/src/routes/test-fixtures.ts`; reuse that seeded data instead of introducing bespoke schedule seed logic. [Source: `packages/saas/src/routes/test-fixtures.ts:120-150`]
+
+### LLM-Dev Implementation Strategy
+
+1. RED: add failing schedule-isolation E2E coverage against the real tenant cinema schedule page and actual tenant-scoped fetch path.
+2. GREEN: add only the missing selector hooks and the smallest backend contract fix needed to produce a stable `403` denial for cross-tenant schedule access.
+3. HARDEN: add negative payload assertions proving org B showtimes are absent from org A schedule responses.
+4. VERIFY: run the dedicated Playwright spec, then the impacted client and SaaS route/unit tests.
+5. DOCS: update testing guidance only if the dedicated spec changes the documented fixture-backed workflow.
+
+### Suggested Test Matrix
+
+- Happy path: org A login -> `/org/:slug/cinema/:id` for an org A cinema -> only org A showtimes visible.
+- Negative path: org A session -> request org B cinema schedule via the tenant-scoped API -> `403`.
+- Network assertion: org A schedule payload contains no org B cinema IDs, names, or showtime entries.
+- Parallel/cleanup sanity: repeated runs with workers=4 do not leak or orphan tenant fixture data.
+
+### Concrete File Targets
+
+- `e2e/multi-tenant-schedule-isolation.spec.ts` (new dedicated spec)
+- `client/src/pages/CinemaPage.tsx` (likely `schedule-calendar` selector and possibly explicit forbidden-state UX wiring)
+- `client/src/pages/CinemaPage.test.tsx` (lock new selector and/or forbidden-state behavior if client UI changes)
+- `packages/saas/src/routes/org.test.ts` (route-level regression coverage for schedule access isolation)
+- `docs/guides/development/testing.md` (only if the dedicated spec needs documented execution changes)
+
+### Pitfalls to Avoid
+
+- Do not target `client/src/pages/admin/SchedulesPage.tsx`; it is a different feature area.
+- Do not invent `/api/schedules` without first verifying whether a minimal adaptation of the current `/api/org/:slug/cinemas/:id` contract is sufficient.
+- Do not hardcode global admin credentials; use seeded org-admin credentials from the fixture.
+- Do not rely only on visible UI state; capture and verify the real network/API denial.
+- Do not accept `404` as good enough if the story still requires `403 Forbidden` for cross-tenant schedule access.
+- Do not bypass fixture cleanup with direct SQL or tenant-schema deletes inside tests.
+
+### References
+
+- Story source: `_bmad-output/planning-artifacts/epics.md:581-612`
+- Sprint tracker row: `_bmad-output/implementation-artifacts/sprint-status.yaml:65`
+- Planning notes for story 1.5: `_bmad-output/planning-artifacts/notes-epics-stories.md:96-102`
+- Project context rules: `_bmad-output/project-context.md:17-239`
+- Previous story context (cinema isolation): `_bmad-output/implementation-artifacts/1-3-e2e-multi-tenant-cinema-isolation-test.md:46-173`
+- Previous story context (user isolation): `_bmad-output/implementation-artifacts/1-4-e2e-multi-tenant-user-management-isolation-test.md:41-179`
+- Tenant route shell: `client/src/App.tsx:175-205`
+- User-facing cinema schedule page: `client/src/pages/CinemaPage.tsx:23-269`
+- Shared client cinema schedule API: `client/src/api/client.ts:123-133`
+- Admin scrape schedule page (out of scope): `client/src/pages/admin/SchedulesPage.tsx:8-248`
+- SaaS route mounting for cinemas/films/scraper: `packages/saas/src/routes/org.ts:99-111`
+- Shared cinema detail route: `server/src/routes/cinemas.ts:146-165`
+- Fixture-backed showtime seeding: `packages/saas/src/routes/test-fixtures.ts:120-150`
+- Test handoff selector guidance: `_bmad-output/test-artifacts/test-design/allo-scrapper-handoff.md:96-114`
+
+## Dev Agent Record
+
+### Agent Model Used
+
+github-copilot/gpt-5.4
+
+### Debug Log References
+
+- CS execution for story 1.5 based on sprint auto-discovery after marking story 1.4 done
+- `npx vitest run src/routes/cinemas.test.ts src/routes/cinemas.security.test.ts` (server)
+- `npx vitest run src/pages/CinemaPage.test.tsx` (client)
+- `npx vitest run src/routes/org.test.ts` (packages/saas)
+- `E2E_ENABLE_ORG_FIXTURE=true npx playwright test e2e/multi-tenant-schedule-isolation.spec.ts --project=chromium --no-deps` (fixture runtime blocked locally: `/test/seed-org` returned `404`)
+
+### Completion Notes List
+
+- Story file created with explicit guardrails separating user-facing showtime isolation from admin scrape-schedule management.
+- Added route-topology reconciliation tasks to prevent implementation against a nonexistent `/api/schedules` endpoint when the current tenant UI fetches schedules via `/api/org/:slug/cinemas/:id`.
+- Added dedicated Playwright coverage in `e2e/multi-tenant-schedule-isolation.spec.ts` for tenant schedule-page isolation, cross-tenant denial, and payload-level leakage checks.
+- Added `data-testid="schedule-calendar"` coverage to `CinemaPage` and locked the selector with a focused client test.
+- Hardened the shared cinema detail route so org-scoped `GET /api/org/:slug/cinemas/:id` uses the same tenant auth, permission, and org-boundary enforcement as the list route.
+- Extended server and SaaS route tests to lock `403` behavior for cross-tenant cinema schedule access while keeping the current shared route topology intact.
+- Verified targeted client, server, and SaaS tests locally; dedicated Playwright verification is currently blocked by a local runtime configuration issue where `/test/seed-org` is not exposed.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/1-5-e2e-multi-tenant-schedule-isolation-test.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `e2e/multi-tenant-schedule-isolation.spec.ts`
+- `client/src/pages/CinemaPage.tsx`
+- `client/src/pages/CinemaPage.test.tsx`
+- `server/src/routes/cinemas.ts`
+- `server/src/routes/cinemas.test.ts`
+- `server/src/routes/cinemas.security.test.ts`
+- `packages/saas/src/routes/org.test.ts`
+
+## Change Log
+
+- 2026-04-20: Created implementation-ready story file for multi-tenant schedule isolation with explicit route-topology guardrails, fixture reuse guidance, and concrete test/file targets.
+- 2026-04-20: Started dev-story implementation for schedule isolation by adding the dedicated Playwright spec, `schedule-calendar` instrumentation, and org-scoped cinema detail tenant-boundary enforcement; targeted tests pass, while full E2E execution is currently blocked locally because `/test/seed-org` returns `404`.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-04-15
-last_updated: 2026-04-20T17:56:00Z
+last_updated: 2026-04-20T18:24:00Z
 project: allo-scrapper
 project_key: NOKEY
 tracking_system: file-system
@@ -62,7 +62,7 @@ development_status:
   1-2-add-org-id-to-all-observability-traces: done
   1-3-e2e-multi-tenant-cinema-isolation-test: done
   1-4-e2e-multi-tenant-user-management-isolation-test: done
-  1-5-e2e-multi-tenant-schedule-isolation-test: in-progress
+  1-5-e2e-multi-tenant-schedule-isolation-test: review
   1-6-api-level-tenant-isolation-enforcement-tests: backlog
   epic-1-retrospective: optional
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-04-15
-last_updated: 2026-04-20T15:28:16Z
+last_updated: 2026-04-20T17:56:00Z
 project: allo-scrapper
 project_key: NOKEY
 tracking_system: file-system
@@ -61,8 +61,8 @@ development_status:
   1-1-implement-org-id-validation-middleware: done
   1-2-add-org-id-to-all-observability-traces: done
   1-3-e2e-multi-tenant-cinema-isolation-test: done
-  1-4-e2e-multi-tenant-user-management-isolation-test: review
-  1-5-e2e-multi-tenant-schedule-isolation-test: backlog
+  1-4-e2e-multi-tenant-user-management-isolation-test: done
+  1-5-e2e-multi-tenant-schedule-isolation-test: in-progress
   1-6-api-level-tenant-isolation-enforcement-tests: backlog
   epic-1-retrospective: optional
 

--- a/client/src/api/client.test.ts
+++ b/client/src/api/client.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGet, mockPost, mockPut, mockDelete } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPost: vi.fn(),
+  mockPut: vi.fn(),
+  mockDelete: vi.fn(),
+}));
+
+vi.mock('axios', () => ({
+  default: {
+    create: vi.fn(() => ({
+      get: mockGet,
+      post: mockPost,
+      put: mockPut,
+      delete: mockDelete,
+      interceptors: {
+        request: { use: vi.fn() },
+        response: { use: vi.fn() },
+      },
+    })),
+  },
+}));
+
+import { getCinemas, getCinemaSchedule } from './client';
+
+describe('Cinema API Client', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it('uses the shared cinemas endpoint outside tenant routes', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: { success: true, data: [] },
+    });
+
+    await getCinemas();
+
+    expect(mockGet).toHaveBeenCalledWith('/cinemas');
+  });
+
+  it('uses the tenant-scoped cinemas endpoint on org routes', async () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        pathname: '/org/acme/cinema/C1234',
+      },
+    });
+
+    mockGet.mockResolvedValueOnce({
+      data: { success: true, data: [] },
+    });
+
+    await getCinemas();
+
+    expect(mockGet).toHaveBeenCalledWith('/org/acme/cinemas');
+  });
+
+  it('uses the tenant-scoped cinema detail endpoint on org routes', async () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        pathname: '/org/acme/cinema/C1234',
+      },
+    });
+
+    mockGet.mockResolvedValueOnce({
+      data: { success: true, data: { showtimes: [], weekStart: '2026-04-15' } },
+    });
+
+    await getCinemaSchedule('C1234');
+
+    expect(mockGet).toHaveBeenCalledWith('/org/acme/cinemas/C1234');
+  });
+});

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -23,6 +23,15 @@ const apiClient = axios.create({
   },
 });
 
+function getCinemasBasePath(): string {
+  const match = window.location.pathname.match(/^\/org\/([^/]+)/);
+  if (!match?.[1]) {
+    return '/cinemas';
+  }
+
+  return `/org/${encodeURIComponent(match[1])}/cinemas`;
+}
+
 // Add a request interceptor to include the JWT token
 apiClient.interceptors.request.use(
   (config) => {
@@ -113,7 +122,7 @@ export async function searchFilms(query: string): Promise<Film[]> {
 // ============================================================================
 
 export async function getCinemas(): Promise<Cinema[]> {
-  const response = await apiClient.get<ApiResponse<Cinema[]>>('/cinemas');
+  const response = await apiClient.get<ApiResponse<Cinema[]>>(getCinemasBasePath());
   if (!response.data.success || !response.data.data) {
     throw new Error(response.data.error || 'Failed to fetch cinemas');
   }
@@ -124,7 +133,7 @@ export async function getCinemaSchedule(
   cinemaId: string
 ): Promise<{ showtimes: ShowtimeWithFilm[]; weekStart: string }> {
   const response = await apiClient.get<ApiResponse<{ showtimes: ShowtimeWithFilm[]; weekStart: string }>>(
-    `/cinemas/${cinemaId}`
+    `${getCinemasBasePath()}/${cinemaId}`
   );
   if (!response.data.success || !response.data.data) {
     throw new Error(response.data.error || 'Failed to fetch cinema schedule');

--- a/client/src/contexts/TenantProvider.test.tsx
+++ b/client/src/contexts/TenantProvider.test.tsx
@@ -72,4 +72,22 @@ describe('TenantProvider', () => {
       expect(screen.getByText('Organization not found.')).toBeInTheDocument();
     });
   });
+
+  it('renders 403 screen when ping fails with org access denied', async () => {
+    const error = Object.assign(new Error('Access denied: organization mismatch'), {
+      response: {
+        status: 403,
+        data: { error: 'Access denied: organization mismatch' },
+      },
+    });
+    vi.mocked(pingOrg).mockRejectedValue(error);
+
+    renderWithSlug('other-org', <ContextInspector />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('403-error-message')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('403-error-message')).toHaveTextContent(/organization mismatch/i);
+  });
 });

--- a/client/src/contexts/TenantProvider.tsx
+++ b/client/src/contexts/TenantProvider.tsx
@@ -30,6 +30,17 @@ function NotFoundScreen() {
   );
 }
 
+function ForbiddenScreen({ message }: { message: string }) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="text-center">
+        <h1 className="text-4xl font-bold text-red-800 mb-4">403</h1>
+        <p className="text-red-600" data-testid="403-error-message">{message}</p>
+      </div>
+    </div>
+  );
+}
+
 /**
  * TenantProvider
  *
@@ -42,6 +53,7 @@ export const TenantProvider: React.FC<TenantProviderProps> = ({ children }) => {
   const [org, setOrg] = useState<{ id: number; slug: string; name: string; status: string } | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
+  const [forbiddenMessage, setForbiddenMessage] = useState<string | null>(null);
 
   useEffect(() => {
     if (!slug) {
@@ -56,12 +68,29 @@ export const TenantProvider: React.FC<TenantProviderProps> = ({ children }) => {
       .then((result) => {
         if (!cancelled) {
           setOrg(result.org);
+          setNotFound(false);
+          setForbiddenMessage(null);
           setIsLoading(false);
         }
       })
-      .catch(() => {
+      .catch((error: unknown) => {
         if (!cancelled) {
-          setNotFound(true);
+          const responseStatus = typeof error === 'object' && error !== null && 'response' in error
+            ? (error as { response?: { status?: number; data?: { error?: string } } }).response?.status
+            : undefined;
+          const responseMessage = typeof error === 'object' && error !== null && 'response' in error
+            ? (error as { response?: { status?: number; data?: { error?: string } } }).response?.data?.error
+            : undefined;
+          const message = error instanceof Error ? error.message : 'Organization not found';
+
+          if (responseStatus === 403 || /organization mismatch|cross-tenant access denied/i.test(responseMessage ?? message)) {
+            setForbiddenMessage(responseMessage ?? message);
+            setNotFound(false);
+          } else {
+            setNotFound(true);
+            setForbiddenMessage(null);
+          }
+
           setIsLoading(false);
         }
       });
@@ -77,6 +106,10 @@ export const TenantProvider: React.FC<TenantProviderProps> = ({ children }) => {
 
   if (notFound) {
     return <NotFoundScreen />;
+  }
+
+  if (forbiddenMessage) {
+    return <ForbiddenScreen message={forbiddenMessage} />;
   }
 
   return (

--- a/client/src/pages/CinemaPage.test.tsx
+++ b/client/src/pages/CinemaPage.test.tsx
@@ -72,6 +72,18 @@ describe('CinemaPage - renders cinema details', () => {
     expect(screen.getByRole('heading', { name: 'UGC Test' })).toBeInTheDocument();
   });
 
+  it('renders the schedule calendar container for showtime content', async () => {
+    renderWithClient(
+      <MemoryRouter initialEntries={['/cinema/C0153']}>
+        <Routes>
+          <Route path="/cinema/:id" element={<CinemaPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByTestId('schedule-calendar')).toBeInTheDocument();
+  });
+
   it('does NOT render a scrape button (scraping moved to admin)', async () => {
     renderWithClient(
       <MemoryRouter initialEntries={['/cinema/C0153']}>

--- a/client/src/pages/CinemaPage.tsx
+++ b/client/src/pages/CinemaPage.tsx
@@ -21,15 +21,15 @@ interface FilmGroup {
 }
 
 export default function CinemaPage() {
-  const { id } = useParams<{ id: string }>();
+  const { id, slug } = useParams<{ id: string; slug?: string }>();
 
   const { data: cinemasData, isLoading: cinemasLoading, error: cinemasError } = useQuery({
-    queryKey: ['cinemas'],
+    queryKey: ['cinemas', slug ?? null],
     queryFn: getCinemas
   });
 
   const { data: scheduleData, isLoading: scheduleLoading, error: scheduleError } = useQuery({
-    queryKey: ['cinema-schedule', id],
+    queryKey: ['cinema-schedule', slug ?? null, id],
     queryFn: () => getCinemaSchedule(id!),
     enabled: !!id
   });

--- a/client/src/pages/CinemaPage.tsx
+++ b/client/src/pages/CinemaPage.tsx
@@ -188,7 +188,7 @@ export default function CinemaPage() {
       </div>
 
       {/* Films List for Selected Date */}
-      <div className="min-h-[300px]">
+      <div className="min-h-[300px]" data-testid="schedule-calendar">
         {filmGroups.length > 0 ? (
           <div className="space-y-6">
             {filmGroups.map(({ film, showtimes }) => (

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -1,5 +1,6 @@
 import { useState, useContext, useCallback, useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
 import { getWeeklyFilms, getFilmsByDate, getCinemas, addCinema } from '../api/client';
 import FilmCard from '../components/FilmCard';
 import DaySelector from '../components/DaySelector';
@@ -10,12 +11,14 @@ import CinemasQuickLinks from '../components/CinemasQuickLinks';
 
 export default function HomePage() {
   const queryClient = useQueryClient();
+  const routeParams = useParams<{ slug?: string }>();
+  const slug = routeParams?.slug;
   const [selectedDate, setSelectedDate] = useState<string>('');
   const [afterTime, setAfterTime] = useState<string | null>(null);
   const { isAuthenticated, hasPermission } = useContext(AuthContext);
 
   const { data: cinemas = [], isLoading: isLoadingCinemas } = useQuery({
-    queryKey: ['cinemas'],
+    queryKey: ['cinemas', slug ?? null],
     queryFn: getCinemas,
   });
 
@@ -69,7 +72,7 @@ export default function HomePage() {
   const addCinemaMutation = useMutation({
     mutationFn: addCinema,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['cinemas'] });
+      queryClient.invalidateQueries({ queryKey: ['cinemas', slug ?? null] });
       queryClient.invalidateQueries({ queryKey: ['films', selectedDate] });
     },
     onError: (err: Error) => {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -66,6 +66,7 @@ services:
       JWT_SECRET: ${JWT_SECRET}
       JWT_EXPIRES_IN: ${JWT_EXPIRES_IN:-24h}
       SAAS_ENABLED: ${SAAS_ENABLED:-false}
+      E2E_ENABLE_ORG_FIXTURE: ${E2E_ENABLE_ORG_FIXTURE:-false}
     depends_on:
       db:
         condition: service_healthy

--- a/docs/guides/development/testing.md
+++ b/docs/guides/development/testing.md
@@ -284,7 +284,7 @@ Troubleshooting:
 
 ### Multi-Tenant Fixture API (SaaS test runtime)
 
-When running SaaS tests in `NODE_ENV=test`, the plugin exposes fixture endpoints for deterministic org setup/teardown:
+When running SaaS tests in `NODE_ENV=test`, or when the backend is started with `E2E_ENABLE_ORG_FIXTURE=true`, the plugin exposes fixture endpoints for deterministic org setup/teardown:
 
 - `POST /test/seed-org`
 - `DELETE /test/cleanup-org/:id`
@@ -308,7 +308,8 @@ Behavior and safety:
 - Parallel test runs should use unique slugs per worker/test to avoid collisions.
 
 Troubleshooting:
-- If `/test/*` returns `404` in local dev, verify you are running with `NODE_ENV=test`.
+- If `/test/*` returns `404` in local dev, verify the backend is running with `E2E_ENABLE_ORG_FIXTURE=true` or `NODE_ENV=test`.
+- When using the Vite dev server locally, point Playwright at the UI origin, for example: `PLAYWRIGHT_BASE_URL=http://localhost:5174`.
 - If cleanup fails, inspect logs for `org_id`, status, and SQL error context.
 - Repeated cleanup calls for already-deleted orgs are treated as safe/expected skips by fixture tooling.
 

--- a/e2e/fixtures/org-cleanup.ts
+++ b/e2e/fixtures/org-cleanup.ts
@@ -122,7 +122,7 @@ export async function cleanupTestOrgs(testId: string, workerId: string, options:
   let skipped = 0;
   const deduped = matching.length - uniqueOrgIds.length;
 
-  for (const orgId of uniqueOrgIds) {
+  await Promise.all(uniqueOrgIds.map(async (orgId) => {
     const orgStart = Date.now();
     try {
       const result = await options.deleteOrg(orgId);
@@ -141,7 +141,7 @@ export async function cleanupTestOrgs(testId: string, workerId: string, options:
       failed += 1;
       logger.error('e2e cleanup delete exception', { org_id: orgId, test_id: testId, worker_id: workerId, error: error instanceof Error ? error.message : String(error) });
     }
-  }
+  }));
 
   const remaining = registry.records.filter((record) => record.testId !== testId);
   await writeRegistry(registryFilePath, { records: remaining });
@@ -175,10 +175,10 @@ export async function cleanupAllTrackedOrgs(options: CleanupOptions): Promise<Cl
     const uniqueOrgIds = [...new Set(eligibleRecords.map((record) => record.orgId))];
     deduped += eligibleRecords.length - uniqueOrgIds.length;
 
-    for (const orgId of uniqueOrgIds) {
+    await Promise.all(uniqueOrgIds.map(async (orgId) => {
       if (globallySeenOrgIds.has(orgId)) {
         deduped += 1;
-        continue;
+        return;
       }
       globallySeenOrgIds.add(orgId);
 
@@ -200,7 +200,7 @@ export async function cleanupAllTrackedOrgs(options: CleanupOptions): Promise<Cl
         failed += 1;
         logger.error('e2e global cleanup delete exception', { org_id: orgId, error: error instanceof Error ? error.message : String(error) });
       }
-    }
+    }));
 
     await rm(filePath, { force: true });
   }

--- a/e2e/multi-tenant-schedule-isolation.spec.ts
+++ b/e2e/multi-tenant-schedule-isolation.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect, assertFixtureRuntimeWithinLimit } from './fixtures/org-fixture';
+
+const useOrgFixture = process.env['E2E_ENABLE_ORG_FIXTURE'] === 'true';
+
+interface LoginResponse {
+  success: boolean;
+  data: {
+    token: string;
+    user: {
+      org_slug?: string;
+    };
+  };
+}
+
+interface CinemasResponse {
+  success: boolean;
+  data: Array<{ id: string; name: string }>;
+}
+
+test.describe('Multi-tenant schedule isolation', () => {
+  test.skip(!useOrgFixture, 'Requires fixture-backed SaaS runtime (E2E_ENABLE_ORG_FIXTURE=true)');
+
+  test('org A only sees org A schedules and gets forbidden for org B schedule route', async ({ page, request, seedTestOrg }) => {
+    const startedAt = Date.now();
+    const orgA = await seedTestOrg();
+    const orgB = await seedTestOrg();
+
+    const orgALogin = await request.post('/api/auth/login', {
+      data: {
+        username: orgA.admin.username,
+        password: orgA.admin.password,
+      },
+    });
+    expect(orgALogin.ok()).toBe(true);
+    const orgALoginBody = await orgALogin.json() as LoginResponse;
+    const orgAToken = orgALoginBody.data.token;
+    expect(orgALoginBody.data.user.org_slug).toBe(orgA.orgSlug);
+
+    const orgBLogin = await request.post('/api/auth/login', {
+      data: {
+        username: orgB.admin.username,
+        password: orgB.admin.password,
+      },
+    });
+    expect(orgBLogin.ok()).toBe(true);
+    const orgBLoginBody = await orgBLogin.json() as LoginResponse;
+    const orgBToken = orgBLoginBody.data.token;
+    expect(orgBLoginBody.data.user.org_slug).toBe(orgB.orgSlug);
+
+    const orgACinemasResponse = await request.get(`/api/org/${orgA.orgSlug}/cinemas`, {
+      headers: { Authorization: `Bearer ${orgAToken}` },
+    });
+    expect(orgACinemasResponse.ok()).toBe(true);
+    const orgACinemasBody = await orgACinemasResponse.json() as CinemasResponse;
+    const orgAFirstCinemaId = orgACinemasBody.data[0]?.id;
+    expect(orgAFirstCinemaId).toBeTruthy();
+
+    const orgBCinemasResponse = await request.get(`/api/org/${orgB.orgSlug}/cinemas`, {
+      headers: { Authorization: `Bearer ${orgBToken}` },
+    });
+    expect(orgBCinemasResponse.ok()).toBe(true);
+    const orgBCinemasBody = await orgBCinemasResponse.json() as CinemasResponse;
+    const orgBFirstCinemaId = orgBCinemasBody.data[0]?.id;
+    expect(orgBFirstCinemaId).toBeTruthy();
+
+    await page.goto('/');
+    await page.evaluate(([token, slug]) => {
+      localStorage.setItem('token', token);
+      localStorage.setItem(
+        'user',
+        JSON.stringify({
+          id: 1,
+          username: 'impersonated-admin',
+          role_id: 1,
+          role_name: 'admin',
+          is_system_role: false,
+          permissions: ['cinemas:read'],
+          org_slug: slug,
+        })
+      );
+    }, [orgAToken, orgA.orgSlug]);
+
+    const scheduleResponsePromise = page.waitForResponse((response) => {
+      return response.url().includes(`/api/org/${orgA.orgSlug}/cinemas/${orgAFirstCinemaId}`)
+        && response.request().method() === 'GET';
+    });
+
+    await page.goto(`/org/${orgA.orgSlug}/cinema/${orgAFirstCinemaId}`);
+
+    const scheduleCalendar = page.getByTestId('schedule-calendar');
+    await expect(scheduleCalendar).toBeVisible();
+    await expect(scheduleCalendar).toContainText(orgA.orgSlug);
+    await expect(scheduleCalendar).not.toContainText(orgB.orgSlug);
+
+    const scheduleResponse = await scheduleResponsePromise;
+    expect(scheduleResponse.ok()).toBe(true);
+    const schedulePayload = await scheduleResponse.json() as {
+      success: boolean;
+      data: {
+        showtimes: Array<{
+          cinema_id: string;
+          film: { title: string };
+        }>;
+      };
+    };
+
+    expect(schedulePayload.success).toBe(true);
+    expect(schedulePayload.data.showtimes.length).toBeGreaterThan(0);
+    expect(schedulePayload.data.showtimes.every((showtime) => showtime.cinema_id === orgAFirstCinemaId)).toBe(true);
+    expect(schedulePayload.data.showtimes.some((showtime) => showtime.cinema_id === orgBFirstCinemaId)).toBe(false);
+    expect(schedulePayload.data.showtimes.some((showtime) => showtime.film.title.includes(orgA.orgSlug))).toBe(true);
+    expect(schedulePayload.data.showtimes.some((showtime) => showtime.film.title.includes(orgB.orgSlug))).toBe(false);
+
+    const orgBDetailResponse = await request.get(`/api/org/${orgB.orgSlug}/cinemas/${orgBFirstCinemaId}`, {
+      headers: { Authorization: `Bearer ${orgAToken}` },
+    });
+    expect(orgBDetailResponse.status()).toBe(403);
+    const orgBDetailPayload = await orgBDetailResponse.json() as { error?: string };
+    expect(orgBDetailPayload.error).toBe('Access denied: organization mismatch');
+
+    await page.goto(`/org/${orgB.orgSlug}/cinema/${orgBFirstCinemaId}`);
+    await expect(page.getByTestId('403-error-message')).toBeVisible();
+    await expect(page.getByTestId('403-error-message')).toContainText(/access denied: organization mismatch|cross-tenant access denied/i);
+
+    assertFixtureRuntimeWithinLimit(startedAt);
+  });
+});

--- a/e2e/multi-tenant-schedule-isolation.spec.ts
+++ b/e2e/multi-tenant-schedule-isolation.spec.ts
@@ -52,16 +52,19 @@ test.describe('Multi-tenant schedule isolation', () => {
     });
     expect(orgACinemasResponse.ok()).toBe(true);
     const orgACinemasBody = await orgACinemasResponse.json() as CinemasResponse;
-    const orgAFirstCinemaId = orgACinemasBody.data[0]?.id;
-    expect(orgAFirstCinemaId).toBeTruthy();
+    const orgAFirstCinema = orgACinemasBody.data.find((cinema) => cinema.name === `Fixture Cinema 1 (${orgA.orgSlug})`);
+    expect(orgAFirstCinema).toBeDefined();
 
     const orgBCinemasResponse = await request.get(`/api/org/${orgB.orgSlug}/cinemas`, {
       headers: { Authorization: `Bearer ${orgBToken}` },
     });
     expect(orgBCinemasResponse.ok()).toBe(true);
     const orgBCinemasBody = await orgBCinemasResponse.json() as CinemasResponse;
-    const orgBFirstCinemaId = orgBCinemasBody.data[0]?.id;
-    expect(orgBFirstCinemaId).toBeTruthy();
+    const orgBFirstCinema = orgBCinemasBody.data.find((cinema) => cinema.name === `Fixture Cinema 1 (${orgB.orgSlug})`);
+    expect(orgBFirstCinema).toBeDefined();
+
+    const orgAFirstCinemaId = orgAFirstCinema!.id;
+    const orgBFirstCinemaId = orgBFirstCinema!.id;
 
     await page.goto('/');
     await page.evaluate(([token, slug]) => {
@@ -118,9 +121,12 @@ test.describe('Multi-tenant schedule isolation', () => {
     const orgBDetailPayload = await orgBDetailResponse.json() as { error?: string };
     expect(orgBDetailPayload.error).toBe('Access denied: organization mismatch');
 
-    await page.goto(`/org/${orgB.orgSlug}/cinema/${orgBFirstCinemaId}`);
-    await expect(page.getByTestId('403-error-message')).toBeVisible();
-    await expect(page.getByTestId('403-error-message')).toContainText(/access denied: organization mismatch|cross-tenant access denied/i);
+    await page.evaluate((path) => {
+      window.history.pushState({}, '', path);
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    }, `/org/${orgB.orgSlug}/cinema/${orgBFirstCinemaId}`);
+    await expect(page.getByRole('heading', { name: '403' })).toBeVisible();
+    await expect(page.getByText(/access denied: organization mismatch|cross-tenant access denied/i)).toBeVisible();
 
     assertFixtureRuntimeWithinLimit(startedAt);
   });

--- a/packages/saas/src/plugin.test.ts
+++ b/packages/saas/src/plugin.test.ts
@@ -4,7 +4,7 @@
  * Verifies that register() wires SaaS migrations by calling runMigrations
  * with the SaaS migration directory.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import express from 'express';
 import type { Express } from 'express';
 import request from 'supertest';
@@ -29,6 +29,11 @@ describe('saasPlugin', () => {
   beforeEach(() => {
     app = express();
     vi.clearAllMocks();
+    vi.stubEnv('JWT_SECRET', 'local-dev-jwt-fixture-key-1234567890abcd');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('has the correct plugin name', async () => {
@@ -76,6 +81,20 @@ describe('saasPlugin', () => {
 
     const res = await request(app).post('/test/seed-org').send({});
     expect(res.status).not.toBe(404);
+  });
+
+  it('keeps /test fixture routes disabled in production even when E2E fixture mode is enabled', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('E2E_ENABLE_ORG_FIXTURE', 'true');
+
+    const { saasPlugin } = await import('./plugin.js');
+    const db = { query: vi.fn() };
+    const pool = { connect: vi.fn() };
+
+    await saasPlugin.register(app, { db, pool });
+
+    const res = await request(app).post('/test/seed-org').send({});
+    expect(res.status).toBe(404);
   });
 
 

--- a/packages/saas/src/plugin.test.ts
+++ b/packages/saas/src/plugin.test.ts
@@ -7,13 +7,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import express from 'express';
 import type { Express } from 'express';
+import request from 'supertest';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // We spy on runMigrations imported dynamically inside plugin.ts.
 // Since plugin.ts uses a dynamic import to avoid cross-rootDir compile-time
 // dependency, we mock the module path it resolves to at runtime.
 // In the test environment (packages/saas), the server module path is resolved
 // via the workspace alias configured in tsconfig / vitest.
-vi.mock('../../../server/src/db/migrations.js', () => ({
+vi.mock('allo-scrapper-server/dist/db/migrations.js', () => ({
   runMigrations: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -43,7 +49,7 @@ describe('saasPlugin', () => {
     const { saasPlugin, getSaasMigrationDir } = await import('./plugin.js');
 
     // Import the mock to inspect calls
-    const migrationsModule = await import('../../../server/src/db/migrations.js');
+    const migrationsModule = await import('allo-scrapper-server/dist/db/migrations.js');
     const runMigrationsMock = vi.mocked(migrationsModule.runMigrations);
 
     const db = { query: vi.fn() };
@@ -58,12 +64,24 @@ describe('saasPlugin', () => {
     );
   });
 
+  it('mounts /test fixture routes when E2E fixture mode is enabled outside NODE_ENV=test', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('E2E_ENABLE_ORG_FIXTURE', 'true');
+
+    const { saasPlugin } = await import('./plugin.js');
+    const db = { query: vi.fn() };
+    const pool = { connect: vi.fn() };
+
+    await saasPlugin.register(app, { db, pool });
+
+    const res = await request(app).post('/test/seed-org').send({});
+    expect(res.status).not.toBe(404);
+  });
+
 
   it('includes saas_008_create_default_ics_org.sql in migrations directory', async () => {
     const fs = await import('fs/promises');
-    const { getSaasMigrationDir } = await import('./plugin.js');
-
-    const files = await fs.readdir(getSaasMigrationDir());
+    const files = await fs.readdir(path.join(__dirname, '../migrations'));
     const migrationFiles = files.filter((f) => f.endsWith('.sql')).sort();
 
     expect(migrationFiles).toContain('saas_008_create_default_ics_org.sql');
@@ -71,9 +89,7 @@ describe('saasPlugin', () => {
 
   it('includes saas_009_fix_org_settings_fk_cascade.sql in migrations directory', async () => {
     const fs = await import('fs/promises');
-    const { getSaasMigrationDir } = await import('./plugin.js');
-
-    const files = await fs.readdir(getSaasMigrationDir());
+    const files = await fs.readdir(path.join(__dirname, '../migrations'));
     const migrationFiles = files.filter((f) => f.endsWith('.sql')).sort();
 
     expect(migrationFiles).toContain('saas_009_fix_org_settings_fk_cascade.sql');
@@ -81,9 +97,7 @@ describe('saasPlugin', () => {
 
   it('includes saas_010_add_fk_indexes.sql in migrations directory', async () => {
     const fs = await import('fs/promises');
-    const { getSaasMigrationDir } = await import('./plugin.js');
-
-    const files = await fs.readdir(getSaasMigrationDir());
+    const files = await fs.readdir(path.join(__dirname, '../migrations'));
     const migrationFiles = files.filter((f) => f.endsWith('.sql')).sort();
 
     expect(migrationFiles).toContain('saas_010_add_fk_indexes.sql');

--- a/packages/saas/src/plugin.ts
+++ b/packages/saas/src/plugin.ts
@@ -32,7 +32,8 @@ interface AppPlugin {
 }
 
 function isFixtureRuntimeEnabled(): boolean {
-  return process.env['NODE_ENV'] === 'test' || process.env['E2E_ENABLE_ORG_FIXTURE'] === 'true';
+  return process.env['NODE_ENV'] === 'test'
+    || (process.env['NODE_ENV'] === 'development' && process.env['E2E_ENABLE_ORG_FIXTURE'] === 'true');
 }
 
 export const saasPlugin: AppPlugin = {

--- a/packages/saas/src/plugin.ts
+++ b/packages/saas/src/plugin.ts
@@ -6,6 +6,7 @@
  * register() is called once at startup by applyPlugins().
  */
 import { fileURLToPath } from 'url';
+import { existsSync } from 'fs';
 import path from 'path';
 import type { Express } from 'express';
 import { createRegisterRouter } from './routes/register.js';
@@ -28,6 +29,10 @@ const __dirname = path.dirname(__filename);
 interface AppPlugin {
   name: string;
   register(app: Express, options: { pool: unknown; db: unknown }): void | Promise<void>;
+}
+
+function isFixtureRuntimeEnabled(): boolean {
+  return process.env['NODE_ENV'] === 'test' || process.env['E2E_ENABLE_ORG_FIXTURE'] === 'true';
 }
 
 export const saasPlugin: AppPlugin = {
@@ -59,7 +64,7 @@ export const saasPlugin: AppPlugin = {
     // Test fixture routes: mounted in test runtime only.
     // In non-test runtimes, explicitly deny /test/* to avoid SPA fallback (production)
     // returning index.html with 200.
-    if (process.env['NODE_ENV'] === 'test') {
+    if (isFixtureRuntimeEnabled()) {
       app.use('/test', createTestFixturesRouter());
     } else {
       app.use('/test', createTestFixturesNotFoundRouter());
@@ -88,7 +93,15 @@ export const saasPlugin: AppPlugin = {
  */
 export function getSaasMigrationDir(): string {
   const isProduction = process.env['NODE_ENV'] === 'production';
-  return isProduction
-    ? path.join('/app', 'packages', 'saas', 'migrations')
-    : path.join(__dirname, '../../../../migrations');
+  if (isProduction) {
+    return path.join('/app', 'packages', 'saas', 'migrations');
+  }
+
+  const candidates = [
+    path.join(__dirname, '../migrations'),
+    path.join(__dirname, '../../../../migrations'),
+  ];
+
+  const resolved = candidates.find((candidate) => existsSync(candidate));
+  return resolved ?? candidates[0];
 }

--- a/packages/saas/src/routes/org.test.ts
+++ b/packages/saas/src/routes/org.test.ts
@@ -252,6 +252,26 @@ describe('GET /api/org/:slug/cinemas', () => {
     expect(dbClient.query).toHaveBeenCalled();
     expect(db.query).not.toHaveBeenCalled();
   });
+
+  it('returns 403 when org A token requests org B cinema schedule details', async () => {
+    const jwtUser = {
+      id: 1, username: 'admin-a', role_name: 'admin',
+      is_system_role: true, permissions: ['cinemas:read'], org_slug: 'org-a',
+    };
+    const { app, token } = buildApp('org-b', 'active', [], jwtUser);
+    const { createOrgRouter } = await import('./org.js');
+    app.use('/api/org/:slug', createOrgRouter());
+
+    const res = await request(app)
+      .get('/api/org/org-b/cinemas/CB01')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(403);
+    const errorText = [res.body?.error, res.body?.message, res.text]
+      .filter((value): value is string => typeof value === 'string')
+      .join(' ');
+    expect(errorText).toMatch(/organization mismatch/i);
+  });
 });
 
 describe('POST /api/org/:slug/cinemas — quota guard', () => {

--- a/packages/saas/src/routes/register.test.ts
+++ b/packages/saas/src/routes/register.test.ts
@@ -7,7 +7,7 @@ import express from 'express';
 import request from 'supertest';
 
 const SLUG_VALID = 'my-cinema';
-const JWT_SECRET = 'test-secret-minimum-32-chars-required-for-tests-abc';
+const JWT_SECRET = 'local-dev-jwt-fixture-key-1234567890abcd';
 
 function buildApp(dbOverride?: object, poolOverride?: object) {
   const app = express();
@@ -98,18 +98,19 @@ describe('POST /api/saas/orgs (register)', () => {
     };
     const db = {
       query: vi.fn()
-        .mockResolvedValueOnce({ rows: [{ count: '0' }], rowCount: 1 })  // isSlugAvailable (route)
-        .mockResolvedValueOnce({ rows: [{ count: '0' }], rowCount: 1 })  // isSlugAvailable (createOrg)
-        .mockResolvedValueOnce({ rows: [], rowCount: 0 })                 // BEGIN
-        .mockResolvedValueOnce({ rows: [org], rowCount: 1 })              // insertOrg
-        .mockResolvedValue({ rows: [], rowCount: 0 }),                    // rest (CREATE SCHEMA, bootstrap, COMMIT)
+        .mockResolvedValueOnce({ rows: [{ count: '0' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [{ count: '0' }], rowCount: 1 }),
     };
+    const poolQuery = vi.fn()
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({ rows: [org], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({ rows: [{ id: 1, username: 'admin@acme.com', role_id: 1, role_name: 'admin' }], rowCount: 1 });
     const pool = {
       connect: vi.fn().mockResolvedValue({
-        query: vi.fn().mockResolvedValue({
-          rows: [{ id: 1, username: 'admin@acme.com', role_id: 1, role_name: 'admin' }],
-          rowCount: 1,
-        }),
+        query: poolQuery,
         release: vi.fn(),
       }),
     };

--- a/packages/saas/src/routes/register.ts
+++ b/packages/saas/src/routes/register.ts
@@ -74,7 +74,7 @@ export function createRegisterRouter(): Router {
       name: orgName.trim(),
       slug,
       plan_id: 1, // Free plan by default
-    });
+    }, pool);
 
     // Create admin user in the org's private schema and mint JWT
     const authService = new SaasAuthService(pool);

--- a/packages/saas/src/routes/test-fixtures.test.ts
+++ b/packages/saas/src/routes/test-fixtures.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 import type { DB, Pool } from '../db/types.js';
@@ -63,6 +63,12 @@ describe('test fixture routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubEnv('NODE_ENV', 'test');
+    vi.unstubAllEnvs();
+    vi.stubEnv('NODE_ENV', 'test');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('POST /test/seed-org returns org metadata and seeded counts', async () => {
@@ -182,6 +188,46 @@ describe('test fixture routes', () => {
     expect(res.status).toBe(404);
   });
 
+  it('POST /test/seed-org returns org metadata when fixture mode is explicitly enabled outside test mode', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('E2E_ENABLE_ORG_FIXTURE', 'true');
+
+    const mockDb = {
+      query: vi.fn(),
+    } as unknown as DB;
+
+    const mockClient = createMockPoolClient();
+
+    const mockPool = {
+      connect: vi.fn().mockResolvedValue(mockClient),
+    } as unknown as Pool;
+
+    createOrgMock.mockResolvedValue({
+      org: {
+        id: 42,
+        slug: 'e2e-fixture-dev',
+        schema_name: 'org_e2e_fixture_dev',
+      },
+    });
+
+    createAdminUserMock.mockResolvedValue({
+      id: 8,
+      username: 'admin-dev@fixture.local',
+    });
+
+    const app = buildApp(mockDb, mockPool);
+    const { createTestFixturesRouter } = await import('./test-fixtures.js');
+    app.use('/test', createTestFixturesRouter());
+
+    const res = await request(app)
+      .post('/test/seed-org')
+      .send({ slug: 'e2e-fixture-dev', name: 'Fixture Dev' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.org_slug).toBe('e2e-fixture-dev');
+  });
+
   it('DELETE /test/cleanup-org/:id removes schema and org row', async () => {
     const mockDb = {
       query: vi.fn().mockResolvedValueOnce({
@@ -241,6 +287,33 @@ describe('test fixture routes', () => {
     const res = await request(app).delete('/test/cleanup-org/41');
 
     expect(res.status).toBe(404);
+  });
+
+  it('DELETE /test/cleanup-org/:id works when fixture mode is explicitly enabled outside test mode', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('E2E_ENABLE_ORG_FIXTURE', 'true');
+
+    const mockDb = {
+      query: vi.fn().mockResolvedValueOnce({
+        rows: [{ id: 41, slug: 'e2e-fixture-a', schema_name: 'org_e2e_fixture_a' }],
+        rowCount: 1,
+      }),
+    } as unknown as DB;
+
+    const mockClient = createMockPoolClient();
+
+    const mockPool = {
+      connect: vi.fn().mockResolvedValue(mockClient),
+    } as unknown as Pool;
+
+    const app = buildApp(mockDb, mockPool);
+    const { createTestFixturesRouter } = await import('./test-fixtures.js');
+    app.use('/test', createTestFixturesRouter());
+
+    const res = await request(app).delete('/test/cleanup-org/41');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
   });
 
   it('DELETE /test/cleanup-org/:id refuses non-fixture organizations', async () => {

--- a/packages/saas/src/routes/test-fixtures.ts
+++ b/packages/saas/src/routes/test-fixtures.ts
@@ -17,7 +17,8 @@ type SeedRequestBody = {
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{1,28}[a-z0-9]$/;
 
 function isFixtureRuntimeEnabled(): boolean {
-  return process.env['NODE_ENV'] === 'test' || process.env['E2E_ENABLE_ORG_FIXTURE'] === 'true';
+  return process.env['NODE_ENV'] === 'test'
+    || (process.env['NODE_ENV'] === 'development' && process.env['E2E_ENABLE_ORG_FIXTURE'] === 'true');
 }
 
 function buildDefaultSlug(): string {

--- a/packages/saas/src/routes/test-fixtures.ts
+++ b/packages/saas/src/routes/test-fixtures.ts
@@ -1,10 +1,11 @@
 import { Router, type Request, type Response } from 'express';
 import bcrypt from 'bcryptjs';
-import { randomBytes } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import { createOrg } from '../services/org-service.js';
 import { SaasAuthService } from '../services/saas-auth-service.js';
 import type { DB, Pool } from '../db/types.js';
 import { logger } from '../utils/logger.js';
+import { getWeekDates, getWeekStart } from 'allo-scrapper-server/dist/utils/date.js';
 
 type SeedRequestBody = {
   slug?: string;
@@ -15,8 +16,8 @@ type SeedRequestBody = {
 
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{1,28}[a-z0-9]$/;
 
-function isTestRuntime(): boolean {
-  return process.env['NODE_ENV'] === 'test';
+function isFixtureRuntimeEnabled(): boolean {
+  return process.env['NODE_ENV'] === 'test' || process.env['E2E_ENABLE_ORG_FIXTURE'] === 'true';
 }
 
 function buildDefaultSlug(): string {
@@ -47,6 +48,23 @@ function normalizeSeedInput(body: SeedRequestBody): {
 
 function quoteIdentifier(identifier: string): string {
   return `"${identifier.replace(/"/g, '""')}"`;
+}
+
+function buildFixtureSlugHash(slug: string, length: number): string {
+  return createHash('sha1').update(slug).digest('hex').slice(0, length);
+}
+
+function buildFixtureCinemaId(slug: string, index: number): string {
+  return `C${buildFixtureSlugHash(slug, 7)}${index}`;
+}
+
+function buildFixtureFilmId(slug: string, index: number): number {
+  const base = 100000 + (Number.parseInt(buildFixtureSlugHash(slug, 6), 16) % 700000);
+  return base + index - 1;
+}
+
+function buildFixtureShowtimeId(slug: string, index: number): string {
+  return `S${buildFixtureSlugHash(slug, 6)}${index.toString().padStart(3, '0')}`;
 }
 
 async function seedTenantData(
@@ -88,7 +106,7 @@ async function seedTenantData(
     );
 
     const cinemas = [1, 2, 3].map((index) => ({
-      id: `C${slug.replace(/-/g, '').slice(0, 8).padEnd(8, '0')}${index}`.slice(0, 9),
+      id: buildFixtureCinemaId(slug, index),
       name: `Fixture Cinema ${index} (${slug})`,
       url: `https://example.test/cinema/${slug}/${index}`,
     }));
@@ -103,9 +121,9 @@ async function seedTenantData(
     }
 
     const films = [
-      { id: 100001, title: `Fixture Film A (${slug})` },
-      { id: 100002, title: `Fixture Film B (${slug})` },
-      { id: 100003, title: `Fixture Film C (${slug})` },
+      { id: buildFixtureFilmId(slug, 1), title: `Fixture Film A (${slug})` },
+      { id: buildFixtureFilmId(slug, 2), title: `Fixture Film B (${slug})` },
+      { id: buildFixtureFilmId(slug, 3), title: `Fixture Film C (${slug})` },
     ];
 
     for (const film of films) {
@@ -117,7 +135,8 @@ async function seedTenantData(
       );
     }
 
-    const weekStart = '2026-01-14';
+    const weekStart = getWeekStart();
+    const weekDates = getWeekDates(weekStart, 5);
     const showtimeSlots = [
       '10:00', '11:30', '13:00', '14:30', '16:00',
       '17:30', '19:00', '20:30', '21:00', '22:15',
@@ -127,8 +146,8 @@ async function seedTenantData(
       const film = films[i % films.length];
       const cinema = cinemas[i % cinemas.length];
       const time = showtimeSlots[i];
-      const id = `S${slug.replace(/-/g, '').slice(0, 6)}${(i + 1).toString().padStart(3, '0')}`;
-      const date = `2026-01-${(15 + (i % 5)).toString().padStart(2, '0')}`;
+      const id = buildFixtureShowtimeId(slug, i + 1);
+      const date = weekDates[i % weekDates.length] as string;
 
       await client.query(
         `INSERT INTO showtimes (id, film_id, cinema_id, date, time, datetime_iso, week_start)
@@ -165,7 +184,7 @@ export function createTestFixturesRouter(): Router {
   const router = Router();
 
   router.post('/seed-org', async (req: Request, res: Response) => {
-    if (!isTestRuntime()) {
+    if (!isFixtureRuntimeEnabled()) {
       return res.status(404).json({ success: false, error: 'Not found' });
     }
 
@@ -180,7 +199,7 @@ export function createTestFixturesRouter(): Router {
         name: input.name,
         slug: input.slug,
         plan_id: 1,
-      });
+      }, pool);
 
       const authService = new SaasAuthService(pool);
       const admin = await authService.createAdminUser(org, input.adminEmail, input.adminPassword);
@@ -216,7 +235,7 @@ export function createTestFixturesRouter(): Router {
   });
 
   router.delete('/cleanup-org/:id', async (req: Request, res: Response) => {
-    if (!isTestRuntime()) {
+    if (!isFixtureRuntimeEnabled()) {
       return res.status(404).json({ success: false, error: 'Not found' });
     }
 

--- a/packages/saas/src/services/org-service.test.ts
+++ b/packages/saas/src/services/org-service.test.ts
@@ -2,7 +2,7 @@
  * RED tests for org-service.ts
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { DB } from '../db/types.js';
+import type { DB, Pool } from '../db/types.js';
 
 // We'll import after the module exists — stubbed inline for RED phase
 // import { createOrg } from './org-service.js';
@@ -11,6 +11,15 @@ function makeDb(overrides: Partial<DB> = {}): DB {
   return {
     query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
     ...overrides,
+  };
+}
+
+function makePool(db: DB): Pool & { connect: ReturnType<typeof vi.fn> } {
+  return {
+    connect: vi.fn().mockResolvedValue({
+      query: db.query,
+      release: vi.fn(),
+    }),
   };
 }
 
@@ -111,5 +120,34 @@ describe('createOrg', () => {
     );
     expect(calls.some((sql) => sql === 'BEGIN')).toBe(true);
     expect(calls.some((sql) => sql === 'COMMIT')).toBe(true);
+  });
+
+  it('uses a dedicated pool client when one is provided', async () => {
+    const org = {
+      id: 3,
+      name: 'Gamma',
+      slug: 'gamma',
+      schema_name: 'org_gamma',
+      status: 'trial',
+    };
+    const queryMock = vi.fn()
+      .mockResolvedValueOnce({ rows: [{ count: '0' }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({ rows: [org], rowCount: 1 })
+      .mockResolvedValue({ rows: [], rowCount: 0 });
+    const db = makeDb({ query: queryMock });
+    const release = vi.fn();
+    const pool = {
+      connect: vi.fn().mockResolvedValue({
+        query: queryMock,
+        release,
+      }),
+    } as unknown as Pool;
+
+    const { createOrg } = await import('./org-service.js');
+    await createOrg(db, { name: 'Gamma', slug: 'gamma' }, pool);
+
+    expect((pool.connect as unknown as ReturnType<typeof vi.fn>)).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledOnce();
   });
 });

--- a/packages/saas/src/services/org-service.ts
+++ b/packages/saas/src/services/org-service.ts
@@ -11,7 +11,7 @@ import path from 'path';
 import fs from 'fs/promises';
 import { fileURLToPath } from 'url';
 import { insertOrg, isSlugAvailable, slugToSchemaName } from '../db/org-queries.js';
-import type { DB, Organization, InsertOrgInput } from '../db/types.js';
+import type { DB, Organization, InsertOrgInput, Pool } from '../db/types.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -56,28 +56,34 @@ export interface CreateOrgResult {
 
 export async function createOrg(
   db: DB,
-  input: InsertOrgInput
+  input: InsertOrgInput,
+  pool?: Pool,
 ): Promise<CreateOrgResult> {
   const slugAvailable = await isSlugAvailable(db, input.slug);
   if (!slugAvailable) {
     throw new Error(`Slug "${input.slug}" is already taken`);
   }
 
-  await db.query('BEGIN');
+  const client = pool ? await pool.connect() : null;
+  const executor = client ?? db;
+
+  await executor.query('BEGIN');
   try {
-    const org = await insertOrg(db, input);
+    const org = await insertOrg(executor, input);
     const schemaName = slugToSchemaName(input.slug);
 
     // Create the PostgreSQL schema for this org
-    await db.query(`CREATE SCHEMA IF NOT EXISTS ${schemaName}`);
+    await executor.query(`CREATE SCHEMA IF NOT EXISTS ${schemaName}`);
 
     // Bootstrap all org-level tables
-    await bootstrapOrgSchema(db, schemaName);
+    await bootstrapOrgSchema(executor, schemaName);
 
-    await db.query('COMMIT');
+    await executor.query('COMMIT');
     return { org, schemaCreated: true };
   } catch (err) {
-    await db.query('ROLLBACK');
+    await executor.query('ROLLBACK');
     throw err;
+  } finally {
+    client?.release();
   }
 }

--- a/server/src/app.test.ts
+++ b/server/src/app.test.ts
@@ -4,6 +4,7 @@ import type { Express } from 'express';
 import type { DB } from './db/client.js';
 import type { Pool } from 'pg';
 import { createApp, applyPlugins, registerFallbackHandlers, type AppPlugin } from './app.js';
+import { AuthError } from './utils/errors.js';
 
 // Mock dependencies
 vi.mock('./services/theme-generator.js');
@@ -407,5 +408,36 @@ describe('AppPlugin / applyPlugins', () => {
     } finally {
       process.env.NODE_ENV = originalNodeEnv;
     }
+  });
+
+  it('serializes plugin route errors with the shared JSON error handler', async () => {
+    const appWithPlugin = createApp();
+    const pool = {} as Pool;
+    const db = {} as DB;
+
+    appWithPlugin.set('db', db);
+    appWithPlugin.set('pool', pool);
+
+    const failingPlugin: AppPlugin = {
+      name: 'failing-plugin',
+      register: async (registeredApp) => {
+        registeredApp.get('/api/plugin-error', (_req, _res, next) => {
+          next(new AuthError('Plugin denied', 403));
+        });
+      },
+    };
+
+    await applyPlugins(appWithPlugin, [failingPlugin], { pool, db });
+    registerFallbackHandlers(appWithPlugin);
+
+    const res = await request(appWithPlugin)
+      .get('/api/plugin-error')
+      .expect(403);
+
+    expect(res.headers['content-type']).toContain('application/json');
+    expect(res.body).toEqual({
+      success: false,
+      error: 'Plugin denied',
+    });
   });
 });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -244,9 +244,6 @@ export function createApp() {
     }
   });
 
-  // Error handler (registered early, but will catch errors from all routes including plugins)
-  app.use(errorHandler);
-
   return app;
 }
 
@@ -255,6 +252,10 @@ export function createApp() {
  * MUST be called after applyPlugins() to avoid catching plugin routes.
  */
 export function registerFallbackHandlers(app: Express): void {
+  // Error handler must be registered after plugins so plugin-route errors keep the
+  // shared JSON API contract instead of falling through to Express' HTML handler.
+  app.use(errorHandler);
+
   // 404 handler for API routes (must be AFTER plugin routes, BEFORE SPA fallback)
   app.use(/^\/api(?:\/(.*))?$/, (_req, res) => {
     res.status(404).json({

--- a/server/src/routes/cinemas.security.test.ts
+++ b/server/src/routes/cinemas.security.test.ts
@@ -136,6 +136,9 @@ describe('Routes - Cinemas - Security', () => {
       const names = getMiddlewareNames('/:id', 'get');
       expect(names).not.toContain('requireAuth');
       expect(names).not.toContain('requirePermission');
+      expect(names).toContain('requireAuthForOrgRequests');
+      expect(names).toContain('requireCinemaReadPermissionForOrgRequests');
+      expect(names).toContain('enforceOrgBoundary');
     });
   });
 });

--- a/server/src/routes/cinemas.test.ts
+++ b/server/src/routes/cinemas.test.ts
@@ -226,5 +226,19 @@ describe('Routes - Cinemas', () => {
       expect(response.status).toBe(200);
       expect(response.body.data.showtimes).toHaveLength(1);
     });
+
+    it('should reject cross-tenant org-scoped cinema schedule access', async () => {
+      const app = await setupApp({
+        mountPath: '/api/org/:slug/cinemas',
+        injectOrgContext: true,
+        authenticatedOrgId: 1,
+      });
+
+      const response = await request(app).get('/api/org/acme/cinemas/C0099?org_id=2');
+
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe('Cross-tenant access denied');
+      expect(mockGetCinemaShowtimes).not.toHaveBeenCalled();
+    });
   });
 });

--- a/server/src/routes/cinemas.ts
+++ b/server/src/routes/cinemas.ts
@@ -144,7 +144,7 @@ router.delete('/:id', protectedLimiter, requireAuth, requirePermission('cinemas:
 });
 
 // GET /api/cinemas/:id - Get cinema schedule
-router.get('/:id', publicLimiter, async (req, res, next) => {
+router.get('/:id', publicLimiter, requireAuthForOrgRequests, requireCinemaReadPermissionForOrgRequests, enforceOrgBoundary, async (req, res, next) => {
   try {
     const db = getDbFromRequest(req);
     const cinemaService = new CinemaService(db);


### PR DESCRIPTION
## Summary
- add dedicated Playwright coverage for tenant-scoped cinema schedule isolation on `/org/:slug/cinema/:id`
- harden client and SaaS runtime paths so schedule requests, forbidden states, fixture seeding, and React Query cache keys stay tenant-safe
- keep fixture-only routes disabled in production even if `E2E_ENABLE_ORG_FIXTURE=true`, and align route tests with the pool-backed org creation flow

## Validation
- `npm run test:run --workspace=allo-scrapper-server -- src/app.test.ts src/routes/cinemas.test.ts src/routes/cinemas.security.test.ts`
- `npm run test:run --workspace=client`
- `npm run test:run --workspace=@allo-scrapper/saas`
- `PLAYWRIGHT_BASE_URL=http://localhost:5174 E2E_ENABLE_ORG_FIXTURE=true npx playwright test e2e/multi-tenant-schedule-isolation.spec.ts --project=chromium --no-deps`
- `PLAYWRIGHT_BASE_URL=http://localhost:5174 E2E_ENABLE_ORG_FIXTURE=true npx playwright test e2e/multi-tenant-schedule-isolation.spec.ts --project=chromium --no-deps --workers=4 --repeat-each=4`

Closes #897