### PR TITLE
⚡ Bolt: Optimize getScrapeReports by running queries concurrently

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-04-08 - Use Promise.all() to run concurrent independent queries
 **Learning:** Found sequential independent database queries in `getScraperStatus` (`server/src/services/system-info.ts`) which unnecessarily block one another, thereby creating a response time bottleneck.
 **Action:** When working on backend queries and system services, always verify that independent queries execute concurrently (using `Promise.all()`) instead of sequentially to optimize application latency.
+## 2024-05-24 - Refactor Sequential Database Queries with Promise.all
+**Learning:** In the database layer (e.g. Postgres queries), sequential `COUNT(*)` and paginated `SELECT` queries introduce unnecessary network roundtrip latency overhead, forming a bottleneck.
+**Action:** When refactoring sequential database queries to run concurrently via `Promise.all()`, never mutate the shared `params` array directly. Always clone the array (e.g. `const dataParams = [...params, limit, offset]`) for the query requiring additional parameters, to prevent race conditions and unintended parameter corruption across concurrent calls.

--- a/server/src/db/report-queries.ts
+++ b/server/src/db/report-queries.ts
@@ -127,22 +127,25 @@ export async function getScrapeReports(
 
   const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
-  // Get total count
-  const countResult = await db.query<{ count: string }>(
-    `SELECT COUNT(*) as count FROM scrape_reports ${whereClause}`,
-    params
-  );
-  const total = parseInt(countResult.rows[0].count);
+  // ⚡ PERFORMANCE: Run total count and paginated results queries concurrently.
+  // We use Promise.all to avoid a sequential bottleneck, significantly reducing DB roundtrip time.
+  const dataParams = [...params, limit, offset];
 
-  // Get paginated results
-  params.push(limit, offset);
-  const result = await db.query<ScrapeReport>(
-    `SELECT * FROM scrape_reports 
-     ${whereClause}
-     ORDER BY started_at DESC 
-     LIMIT $${paramIndex++} OFFSET $${paramIndex++}`,
-    params
-  );
+  const [countResult, result] = await Promise.all([
+    db.query<{ count: string }>(
+      `SELECT COUNT(*) as count FROM scrape_reports ${whereClause}`,
+      params
+    ),
+    db.query<ScrapeReport>(
+      `SELECT * FROM scrape_reports
+       ${whereClause}
+       ORDER BY started_at DESC
+       LIMIT $${paramIndex++} OFFSET $${paramIndex++}`,
+      dataParams
+    )
+  ]);
+
+  const total = parseInt(countResult.rows[0].count);
 
   return {
     reports: result.rows,


### PR DESCRIPTION
💡 **What**: Refactored `getScrapeReports` in `server/src/db/report-queries.ts` to execute its sequential `COUNT(*)` and paginated `SELECT` queries concurrently using `Promise.all()`. Cloned the params array (`dataParams`) for the paginated query to prevent mutation and race conditions during concurrent execution.

🎯 **Why**: Running independent database queries sequentially introduces unnecessary network round-trip overhead. Executing them concurrently reduces the total latency bottleneck of the API endpoint.

📊 **Impact**: Expected to significantly reduce database query time and overall response latency for the `GET /api/reports` endpoint, particularly when filtering or sorting large datasets, by turning two sequential trips into one concurrent operation.

🔬 **Measurement**: Verify by running `npm run test -w server -- --run src/routes/reports.test.ts` and `npm run test -w server -- --run src/db/report-queries.test.ts` locally to ensure identical behavior with faster execution. Mentally verify via code review that independent database requests operate asynchronously.

---
*PR created automatically by Jules for task [8991678562919920815](https://jules.google.com/task/8991678562919920815) started by @PhBassin*