### PR TITLE
feat(scraper): add dead-letter queue support

### DIFF
--- a/_bmad-output/implementation-artifacts/2-1-implement-dead-letter-queue-for-failed-scraper-jobs.md
+++ b/_bmad-output/implementation-artifacts/2-1-implement-dead-letter-queue-for-failed-scraper-jobs.md
@@ -1,0 +1,186 @@
+# Story 2.1: Implement Dead-Letter Queue for Failed Scraper Jobs
+
+Status: review
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a DevOps engineer,
+I want failed scraper jobs to move to a dead-letter queue after 3 retry attempts,
+so that failed jobs do not block the queue and can be inspected or retried safely.
+
+## Acceptance Criteria
+
+1. **Given** a scraper job fails 3 times with exponential backoff (`1s`, `2s`, `4s`)  
+   **When** the 3rd retry fails  
+   **Then** the job is moved to the dead-letter queue (DLQ)  
+   **And** the DLQ entry includes metadata: `job_id`, `failure_reason`, `retry_count`, `timestamp`, `cinema_id`, `org_id`  
+   **And** the job is removed from the active queue
+
+2. **Given** a job is in the DLQ  
+   **When** I query `GET /api/scraper/dlq`  
+   **Then** the API returns all DLQ jobs with metadata  
+   **And** jobs are sorted by timestamp (most recent first)  
+   **And** the response includes pagination (max 50 jobs per page)
+
+3. **Given** a job is in the DLQ  
+   **When** an admin retries it through the backend contract  
+   **Then** the job is re-queued to the active queue  
+   **And** the retry counter is reset to `0`  
+   **And** the job executes with fresh attempts
+
+## Tasks / Subtasks
+
+- [ ] Add RED tests for DLQ persistence and queue behavior before implementation (AC: 1, 2, 3)
+  - [ ] Add or extend unit/integration tests in `server/src/services/redis-client.test.ts` and/or a new focused DLQ service test to fail when failed jobs are not persisted separately from `scrape:jobs`
+  - [ ] Add or extend route tests in `server/src/routes/scraper.test.ts` for `GET /api/scraper/dlq` response shape, ordering, pagination, and permission behavior
+  - [ ] Add or extend scraper worker tests in `scraper/src/redis/client.test.ts` and/or `scraper/src/index.test.ts` to fail when 3 terminal failures do not end in DLQ movement
+  - [ ] Keep the RED coverage focused on DLQ movement and inspection only; do not pull Story 2.2's retry-delay math into this story beyond contract assumptions
+
+- [ ] Implement a single DLQ persistence path for failed scraper jobs (AC: 1)
+  - [ ] Add a dedicated DLQ storage mechanism using the existing Redis architecture and naming conventions; do not invent a second queueing system outside Redis for this story
+  - [ ] Ensure a job that reaches terminal failure is removed from `scrape:jobs` processing flow and written to DLQ with required metadata
+  - [ ] Keep job metadata typed and compatible with existing `ScrapeJob` shape plus the minimum DLQ envelope needed for diagnostics
+  - [ ] Preserve tenant observability context (`org_id`, `org_slug`, `user_id`, `endpoint`) when available so failed jobs remain traceable
+
+- [ ] Add API read access for DLQ inspection (AC: 2)
+  - [ ] Implement `GET /api/scraper/dlq` in the existing scraper route area, using current auth/permission patterns rather than introducing a parallel admin router
+  - [ ] Return a paginated response capped at 50 items per page and sorted newest-first
+  - [ ] Keep response metadata explicit and deterministic so later Story 2.6 can build on it without breaking contract
+  - [ ] If a stricter admin-only endpoint is deferred to Story 2.6, document the chosen scope in completion notes and keep this story's route contract minimal and test-backed
+
+- [ ] Add retry-from-DLQ backend contract without UI scope creep (AC: 3)
+  - [ ] Implement the backend requeue path needed to retry a DLQ job and reset its retry counter
+  - [ ] Do not build admin UI, filters, live updates, or table rendering in this story
+  - [ ] Reuse existing job publication helpers where possible so retrying a DLQ item does not fork queue semantics
+  - [ ] Ensure invalid or missing DLQ entries return deterministic not-found behavior instead of silent no-ops
+
+- [ ] Keep story boundaries aligned with Epic 2 sequencing (AC: 1, 2, 3)
+  - [ ] Do not fully implement the retry backoff engine in this story beyond the DLQ handoff contract; Story 2.2 owns the backoff calculation details
+  - [ ] Do not implement the 100+ job load test matrix; Story 2.3 owns that
+  - [ ] Do not implement Redis reconnection orchestration; Story 2.4 owns that
+  - [ ] Do not add DLQ UI components; Story 2.6 is explicitly API-only for MVP and any UI is future work
+
+- [ ] Preserve existing logging, error handling, and deployment patterns (AC: 1, 2, 3)
+  - [ ] Use structured logger output for DLQ enqueue/retry/failure transitions
+  - [ ] Keep ESM, strict typing, and existing route/service separation intact
+  - [ ] Follow the project migration rules if DLQ storage requires schema changes: idempotent migration, verification step, and inventory update
+
+- [ ] Update documentation only where the new backend contract becomes externally relevant (AC: 2, 3)
+  - [ ] Update `README.md` or API docs if the DLQ endpoints become part of the contributor/operator workflow
+  - [ ] Update testing guidance only if there is a new Redis/Testcontainers command or DLQ-specific test flow contributors must know
+
+## Dev Notes
+
+### Scope and Guardrails
+
+- This story is the first reliability slice of Epic 2. Keep scope centered on DLQ storage, inspection, and backend retry contract.
+- The story must not absorb Story 2.2, 2.3, 2.4, or 2.6 responsibilities.
+- Stay API-first. The planning notes explicitly keep DLQ UI out of MVP scope.
+- Prefer the smallest correct extension of the current Redis queue design rather than introducing new infra or database-first orchestration.
+
+### Reinvention Prevention
+
+- Reuse the existing queue infrastructure before adding anything new:
+  - `server/src/services/redis-client.ts`
+  - `server/src/routes/scraper.ts`
+  - `server/src/services/scraper-service.ts`
+  - `scraper/src/redis/client.ts`
+  - `scraper/src/index.ts`
+- Reuse the existing `ScrapeJob` contract and trace-context shape where possible.
+- Reuse Redis/Testcontainers patterns already established in Story 0.3 rather than creating a separate integration harness.
+
+### Previous Story Intelligence (from Epic 0 and Epic 1)
+
+- Story 0.3 established the expectation that Redis-backed integration paths should be validated against real containers in CI/local where appropriate, with concise failure logging for first-pass debugging. [Source: `_bmad-output/implementation-artifacts/0-3-setup-redis-testcontainers-in-ci.md:82-108`]
+- Story 0.2 showed the value of deterministic payloads, structured diagnostics, and explicit cleanup boundaries when building test-supporting backend contracts. The same discipline should apply to DLQ entries and retry flows. [Source: `_bmad-output/implementation-artifacts/0-2-implement-multi-tenant-test-fixture-api.md:81-89`, `_bmad-output/implementation-artifacts/0-2-implement-multi-tenant-test-fixture-api.md:118-156`]
+- Epic 1 reinforced a pattern that is relevant here too: boundary behavior should be locked through explicit denial-path and invariant tests rather than by assuming the architecture will behave correctly. [Source: `_bmad-output/implementation-artifacts/epic-1-retro-2026-04-21.md:49-67`]
+
+### Architecture Compliance Notes
+
+- Backend job publication currently flows through `server/src/services/redis-client.ts`, which writes serialized `ScrapeJob` payloads into Redis list `scrape:jobs`. [Source: `server/src/services/redis-client.ts:65-83`]
+- The scraper worker currently consumes `scrape:jobs` through `RedisJobConsumer` and executes jobs in `scraper/src/index.ts`. This is the correct seam to extend for terminal-failure -> DLQ behavior. [Source: `scraper/src/redis/client.ts:73-147`, `scraper/src/index.ts:58-152`]
+- Current scraper routes already centralize scrape-related API contracts in `server/src/routes/scraper.ts`; keep DLQ inspection/retry in this existing route surface unless a later story explicitly moves it. [Source: `server/src/routes/scraper.ts:42-220`]
+- Existing logging and observability patterns already include tenant trace context on scraper jobs; preserve that context in DLQ metadata instead of introducing a second tracing scheme. [Source: `server/src/services/redis-client.ts:9-14`, `scraper/src/index.ts:63-70`]
+- If DLQ persistence requires a database migration, follow project migration rules strictly: idempotent SQL, verification step, and update `server/src/db/system-queries.test.ts`. [Source: `_bmad-output/project-context.md:204-207`]
+
+### Suggested Test Matrix
+
+- Terminal failure path: a job that exhausts 3 attempts ends in DLQ and is no longer active in the primary queue.
+- DLQ metadata path: persisted entry includes `job_id`, `failure_reason`, `retry_count`, `timestamp`, `cinema_id`, and `org_id` when applicable.
+- API read path: `GET /api/scraper/dlq?page=1` returns newest-first results with max 50 items.
+- Retry path: retrying a DLQ job re-publishes it to `scrape:jobs` with reset retry count and removes or marks the DLQ entry appropriately.
+- Failure path: unknown DLQ job id returns deterministic not-found response.
+- Integration path: Redis-backed tests use the established Testcontainers flow rather than a mocked-only happy path.
+
+### LLM-Dev Implementation Strategy
+
+1. RED: write failing tests around DLQ persistence, listing, and retry behavior.
+2. GREEN: add the smallest DLQ persistence/read/retry implementation that satisfies those tests.
+3. HARDEN: preserve structured metadata, deterministic ordering, and clear error contracts.
+4. VERIFY: run targeted server and scraper suites, plus Redis-backed integration tests if changed.
+5. DOCS: update API/testing docs only if the contract becomes operator-facing.
+
+### Concrete File Targets
+
+- `_bmad-output/implementation-artifacts/2-1-implement-dead-letter-queue-for-failed-scraper-jobs.md`
+- `server/src/services/redis-client.ts`
+- `server/src/services/redis-client.test.ts`
+- `server/src/routes/scraper.ts`
+- `server/src/routes/scraper.test.ts`
+- `server/src/services/scraper-service.ts` (only if orchestration needs a minimal hook)
+- `scraper/src/redis/client.ts`
+- `scraper/src/redis/client.test.ts`
+- `scraper/src/index.ts`
+- `migrations/*.sql` and `server/src/db/system-queries.test.ts` only if persistent DB-backed DLQ storage is introduced
+- `README.md` and/or `docs/reference/api/scraper.md` only if the endpoint contract should be documented now
+
+### Pitfalls to Avoid
+
+- Do not implement DLQ UI in this story.
+- Do not fully absorb exponential backoff policy logic from Story 2.2 into this story.
+- Do not create a second parallel job contract for retried jobs if the existing `ScrapeJob` contract can be extended minimally.
+- Do not lose tenant trace context when a job moves from active queue to DLQ.
+- Do not add non-idempotent migrations or forget migration inventory updates if schema changes are introduced.
+
+### References
+
+- Story source: `_bmad-output/planning-artifacts/epics.md:661-685`
+- Planning notes for Epic 2 / Story 2.1: `_bmad-output/planning-artifacts/notes-epics-stories.md:112-124`
+- Sprint tracker row: `_bmad-output/implementation-artifacts/sprint-status.yaml:73-80`
+- Epic 1 retrospective: `_bmad-output/implementation-artifacts/epic-1-retro-2026-04-21.md`
+- Redis Testcontainers guidance: `_bmad-output/implementation-artifacts/0-3-setup-redis-testcontainers-in-ci.md:82-108`
+- Fixture/API contract discipline: `_bmad-output/implementation-artifacts/0-2-implement-multi-tenant-test-fixture-api.md:118-156`
+- Queue publisher: `server/src/services/redis-client.ts:65-83`
+- Scraper API route surface: `server/src/routes/scraper.ts:42-220`
+- Redis job consumer: `scraper/src/redis/client.ts:73-147`
+- Job execution flow: `scraper/src/index.ts:58-152`
+- Workflow rules and migration gotchas: `_bmad-output/project-context.md:167-207`
+
+## Dev Agent Record
+
+### Agent Model Used
+
+github-copilot/gpt-5.4
+
+### Debug Log References
+
+- CS execution for story 2.1 based on sprint tracker, Epic 2 planning artifacts, Epic 0 Redis/Testcontainers groundwork, and Epic 1 retrospective learnings
+- `git log -5 --oneline`
+
+### Completion Notes List
+
+- Story file created for the first Epic 2 reliability slice, scoped to DLQ persistence, inspection, and backend retry behavior.
+- Separated this story explicitly from Story 2.2 backoff logic, Story 2.3 load testing, Story 2.4 reconnection handling, and Story 2.6 API/UI expansion.
+- Anchored the story in the existing Redis queue seams (`scrape:jobs`, `RedisJobConsumer`, `server/src/routes/scraper.ts`) to reduce implementation drift.
+- Carried forward the Epic 1 retrospective lesson that boundary and failure contracts should be tested explicitly, not assumed.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/2-1-implement-dead-letter-queue-for-failed-scraper-jobs.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+
+## Change Log
+
+- 2026-04-21: Created implementation-ready story file for Epic 2 Story 2.1 with guardrails around Redis-backed DLQ storage, API-first scope, explicit separation from later retry/load/reconnection stories, and references to the existing queue architecture.

--- a/_bmad-output/implementation-artifacts/epic-1-retro-2026-04-21.md
+++ b/_bmad-output/implementation-artifacts/epic-1-retro-2026-04-21.md
@@ -1,0 +1,133 @@
+# Epic 1 Retrospective: Multi-Tenant Security & Isolation Hardening
+
+Date: 2026-04-21
+Epic: 1
+Status: complete
+Retrospective Type: full
+
+## Epic Review
+
+Epic 1 achieved its main objective: multi-tenant isolation is now validated across request boundaries, observability, end-to-end tenant workflows, and integration-level DB client scoping.
+
+Completed stories:
+
+- `1-1-implement-org-id-validation-middleware`
+- `1-2-add-org-id-to-all-observability-traces`
+- `1-3-e2e-multi-tenant-cinema-isolation-test`
+- `1-4-e2e-multi-tenant-user-management-isolation-test`
+- `1-5-e2e-multi-tenant-schedule-isolation-test`
+- `1-6-api-level-tenant-isolation-enforcement-tests`
+
+## What Went Well
+
+- Epic 0 foundations were reused effectively: fixture API, auto-cleanup, and parallel test support reduced repeated setup work.
+- The team consistently preferred extending existing seams over adding new abstractions.
+- Stable security contracts were preserved across the epic, especially `403 Cross-tenant access denied`.
+- Observability and tenant isolation were treated together instead of as separate concerns.
+- Code review added real hardening value by catching incomplete coverage and forcing explicit denial-path assertions.
+
+## Challenges
+
+- Several acceptance criteria and story descriptions were initially more abstract than the actual brownfield architecture.
+- The largest mismatch was Story 1.6, where the original wording implied universal `WHERE org_id = ...` filtering even though the real SaaS isolation model is schema-based.
+- E2E reliability depended on local/runtime fixture availability, which created friction when the fixture endpoints were not enabled in the current environment.
+- BMAD end-state tracking after PR merge required a follow-up sync PR, which indicates process friction between implementation completion and artifact completion.
+
+## Key Discoveries
+
+### Architecture Discovery
+
+The real tenant isolation model for SaaS org routes is:
+
+- `resolveTenant()` resolves the org and sets PostgreSQL `search_path`
+- `req.dbClient` carries the tenant-scoped DB client
+- `getDbFromRequest()` ensures shared routers reuse the scoped client
+- `requireOrgAuth` and `enforceOrgBoundary` reject cross-tenant access before downstream logic returns data
+
+This means tenant-schema tables such as `cinemas` and `showtimes` are not primarily isolated via shared-table `org_id` filtering.
+
+### Testing Discovery
+
+The highest-value regression seams were not broad feature rewrites, but boundary tests proving:
+
+- cross-tenant denials return stable `403` responses
+- denied requests stop before downstream query execution
+- org-scoped routes use the tenant client rather than the global DB client
+- traces/logs preserve tenant context in operational flows
+
+### Process Discovery
+
+For brownfield security stories, implementation quality improved when story files explicitly described the existing architecture instead of idealized abstractions.
+
+## Lessons Learned
+
+1. Multi-tenant stories must document the real isolation mechanism at the start of the story.
+2. Test stories should lock architectural seams, not only user-visible outputs.
+3. Review findings should be expected as part of completion, especially for security and isolation work.
+4. BMAD artifact closure should happen as part of the merge workflow, not as an afterthought.
+
+## Repeated Patterns Across Stories
+
+- Reuse of existing infrastructure consistently produced better outcomes than introducing new helpers.
+- Tenant boundary behavior needed both positive-path and denied-path coverage.
+- Route topology mismatches between expectation and actual implementation were a recurring source of confusion.
+- Structured logging and deterministic error contracts reduced ambiguity in both tests and reviews.
+
+## Technical Debt and Follow-Up Risks
+
+- `epics.md` still contains the original misleading wording for Story 1.6 and should be corrected later to match the real architecture.
+- The post-merge BMAD sync path is still manual enough to create unnecessary follow-up work.
+- The E2E fixture-mode dependency remains a source of environment-specific friction when local stacks are not started in the expected mode.
+
+## Action Items
+
+### Process
+
+1. Update future brownfield security stories to explicitly describe the current architecture before implementation begins.
+Owner: story creation workflow / project lead
+Success criteria: new stories mention concrete route, middleware, and DB scoping seams where relevant.
+
+2. Treat BMAD end-state sync as part of the merge checklist.
+Owner: project lead
+Success criteria: story status, sprint status, and epic status are updated without requiring a follow-up recovery step.
+
+### Documentation
+
+3. Correct the Story 1.6 wording in `epics.md` so it reflects schema-based SaaS isolation rather than generic ORM filtering.
+Owner: project lead / documentation pass
+Success criteria: the planning artifact no longer implies a nonexistent universal `WHERE org_id` mechanism.
+
+### Testing
+
+4. Keep denial-path assertions mandatory for future tenant-isolation stories.
+Owner: developer / reviewer
+Success criteria: tests prove both the response contract and the absence of downstream query execution on forbidden paths.
+
+## Epic 2 Preparation
+
+Epic 2 is the next logical focus: Scraper Job Queue Reliability & Failure Handling.
+
+Preparation notes:
+
+- Keep scope API-first for DLQ behavior; do not drift into admin UI work.
+- Start with tests that lock retry, DLQ movement, and queue invariants.
+- Reuse the stability mindset from Epic 1: prove boundaries and failure handling explicitly.
+- Treat Redis/Testcontainers support from Epic 0 as a dependency to leverage, not rebuild.
+
+## Readiness Assessment For Epic 2
+
+Epic 2 can start.
+
+Reasons:
+
+- Epic 0 prerequisites are done.
+- Epic 1 no longer has open implementation work.
+- The next epic has a clear first story (`2-1`) with bounded scope.
+
+Known caution:
+
+- The team should keep resisting architecture drift and should define failure contracts early, the same way tenant-security contracts were stabilized in Epic 1.
+
+## Summary
+
+Epic 1 was successful and materially improved the security posture of the SaaS tenant model. The most important learning is that brownfield delivery quality depends on describing the architecture that exists, not the architecture we assume exists. The next epic is ready to begin, with process and documentation improvements identified from this retro.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-04-15
-last_updated: 2026-04-21T16:50:00Z
+last_updated: 2026-04-21T17:15:00Z
 project: allo-scrapper
 project_key: NOKEY
 tracking_system: file-system
@@ -46,7 +46,7 @@ development_status:
   # EPIC 0: Test Infrastructure Setup (Technical Blocker)
   # ⚡ MUST complete before Epic 1 begins
   # ─────────────────────────────────────────────────────────────
-  epic-0: in-progress
+  epic-0: done
   0-1-enable-playwright-parallel-execution: done
   0-2-implement-multi-tenant-test-fixture-api: done
   0-3-setup-redis-testcontainers-in-ci: done
@@ -57,21 +57,21 @@ development_status:
   # EPIC 1: Multi-Tenant Security & Isolation Hardening
   # 🔴 BLOCKER — requires Epic 0 complete
   # ─────────────────────────────────────────────────────────────
-  epic-1: in-progress
+  epic-1: done
   1-1-implement-org-id-validation-middleware: done
   1-2-add-org-id-to-all-observability-traces: done
   1-3-e2e-multi-tenant-cinema-isolation-test: done
   1-4-e2e-multi-tenant-user-management-isolation-test: done
   1-5-e2e-multi-tenant-schedule-isolation-test: done
   1-6-api-level-tenant-isolation-enforcement-tests: done
-  epic-1-retrospective: optional
+  epic-1-retrospective: done
 
   # ─────────────────────────────────────────────────────────────
   # EPIC 2: Scraper Job Queue Reliability & Failure Handling
   # 🔴 HIGH — requires Epic 0 (Stories 0.2, 0.3) complete
   # ─────────────────────────────────────────────────────────────
-  epic-2: backlog
-  2-1-implement-dead-letter-queue-for-failed-scraper-jobs: backlog
+  epic-2: in-progress
+  2-1-implement-dead-letter-queue-for-failed-scraper-jobs: review
   2-2-add-exponential-backoff-retry-logic-for-redis-failures: backlog
   2-3-redis-job-queue-load-testing-100-concurrent-jobs: backlog
   2-4-redis-reconnection-handling-during-job-processing: backlog

--- a/_bmad-output/planning-artifacts/epics.md
+++ b/_bmad-output/planning-artifacts/epics.md
@@ -614,26 +614,26 @@ So that users cannot view screening schedules from other organizations.
 ### Story 1.6: API-Level Tenant Isolation Enforcement Tests
 
 As a QA engineer,
-I want integration tests that validate org_id filtering at the database query level,
-So that SQL queries automatically filter by org_id without manual WHERE clauses.
+I want integration tests that validate tenant isolation at the API and database-client injection level,
+So that org-scoped requests always execute in the correct tenant context and cannot leak cross-tenant data.
 
 **Acceptance Criteria:**
 
-**Given** a database query for cinemas is executed  
-**When** the query is built via ORM/query builder  
-**Then** the query includes `WHERE org_id = :authenticated_org_id`  
-**And** the WHERE clause is automatically added by middleware  
-**And** developers cannot accidentally omit org_id filtering
+**Given** a database query for cinemas is executed through an org-scoped SaaS route  
+**When** the request is handled via the shared router/query stack  
+**Then** the request uses the tenant-scoped database client attached by middleware  
+**And** the effective query scope is bound to the authenticated tenant context  
+**And** developers cannot accidentally bypass tenant scoping by falling back to the global DB client on org routes
 
 **Given** a user with org_id=A makes a request  
 **When** the request handler queries the database  
 **Then** all queries are scoped to org_id=A  
-**And** a database query log shows the org_id filter  
+**And** cross-tenant access attempts are rejected with a stable `403` contract before data is returned  
 **And** no cross-tenant data is returned
 
-**Given** a database migration creates a new org-scoped table  
+**Given** a database change introduces a shared `public` table that stores multi-tenant rows in this area  
 **When** the table is queried via the API  
-**Then** the query automatically filters by org_id  
+**Then** the implementation includes explicit tenant filtering by authenticated org context  
 **And** the migration includes a NOT NULL constraint on org_id column  
 **And** the migration includes an index on org_id for performance
 

--- a/docs/reference/api/scraper.md
+++ b/docs/reference/api/scraper.md
@@ -397,6 +397,134 @@ curl http://localhost:3000/api/reports/124 \
 
 ---
 
+### List Dead-Letter Queue Jobs
+
+```http
+GET /api/scraper/dlq?page=1&pageSize=50
+```
+
+**Authentication:** Required (Bearer token)
+
+**Permission:** `scraper:trigger` or system admin
+
+**Description:** Returns scraper jobs that reached terminal failure and were moved to the Redis-backed dead-letter queue after exhausting retry attempts.
+
+**Query Parameters:**
+- `page` (integer, optional): 1-based page number. Defaults to `1`.
+- `pageSize` (integer, optional): Maximum jobs per page. Capped at `50`. Defaults to `50`.
+
+**Response (200 - success):**
+```json
+{
+  "success": true,
+  "data": {
+    "jobs": [
+      {
+        "job_id": "report-123",
+        "failure_reason": "HTTP 503",
+        "retry_count": 3,
+        "timestamp": "2026-04-21T19:00:00.000Z",
+        "cinema_id": "C0042",
+        "org_id": "7",
+        "org_slug": "acme",
+        "user_id": "12",
+        "endpoint": "/api/scraper/trigger",
+        "job": {
+          "type": "scrape",
+          "triggerType": "manual",
+          "reportId": 123,
+          "retryCount": 3,
+          "options": {
+            "cinemaId": "C0042"
+          },
+          "traceContext": {
+            "org_id": "7",
+            "org_slug": "acme",
+            "user_id": "12",
+            "endpoint": "/api/scraper/trigger"
+          }
+        }
+      }
+    ],
+    "total": 1,
+    "page": 1,
+    "pageSize": 50
+  }
+}
+```
+
+**Behavior:**
+- Jobs are returned newest first.
+- `pageSize` is clamped to `50`.
+- Non-system users only see DLQ entries for their own `org_id`.
+- The response includes the original job payload so operators can inspect the failed request context.
+
+**Response (403 - forbidden):**
+```json
+{
+  "success": false,
+  "error": "Permission denied"
+}
+```
+
+**Example:**
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:3000/api/scraper/dlq?page=1&pageSize=50"
+```
+
+---
+
+### Retry Dead-Letter Queue Job
+
+```http
+POST /api/scraper/dlq/:jobId/retry
+```
+
+**Authentication:** Required (Bearer token)
+
+**Permission:** `scraper:trigger` or system admin
+
+**Description:** Requeues a dead-lettered job back onto `scrape:jobs` and resets its retry counter to `0`.
+
+**Response (200 - success):**
+```json
+{
+  "success": true,
+  "data": {
+    "job_id": "report-123",
+    "failure_reason": "HTTP 503",
+    "retry_count": 0,
+    "timestamp": "2026-04-21T19:00:00.000Z",
+    "cinema_id": "C0042",
+    "org_id": "7",
+    "job": {
+      "type": "scrape",
+      "triggerType": "manual",
+      "reportId": 123,
+      "retryCount": 0
+    }
+  }
+}
+```
+
+**Response (404 - not found):**
+```json
+{
+  "success": false,
+  "error": "DLQ job not found"
+}
+```
+
+**Example:**
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  http://localhost:3000/api/scraper/dlq/report-123/retry
+```
+
+---
+
 ## Scrape Schedules
 
 Schedule recurring scrapes using cron expressions.

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -4,6 +4,114 @@ const { combine, timestamp, json, colorize, simple } = winston.format;
 
 const isProduction = process.env.NODE_ENV === 'production';
 
+export type ScrapeTraceContext = Record<string, string>;
+
+export interface BaseScrapeJob {
+  reportId: number;
+  retryCount?: number;
+  traceContext?: ScrapeTraceContext;
+}
+
+export interface ScrapeJobScrape extends BaseScrapeJob {
+  type: 'scrape';
+  triggerType: 'manual' | 'cron';
+  options?: {
+    mode?: 'weekly' | 'from_today' | 'from_today_limited';
+    days?: number;
+    cinemaId?: string;
+    filmId?: number;
+    resumeMode?: boolean;
+    pendingAttempts?: Array<{ cinema_id: string; date: string }>;
+  };
+}
+
+export interface ScrapeJobAddCinema extends BaseScrapeJob {
+  type: 'add_cinema';
+  triggerType: 'manual';
+  url: string;
+}
+
+export type ScrapeJob = ScrapeJobScrape | ScrapeJobAddCinema;
+
+export interface ScheduleChangeEvent {
+  action: 'created' | 'updated' | 'deleted';
+  scheduleId: number;
+  schedule?: {
+    id: number;
+    name: string;
+    cron_expression: string;
+    enabled: boolean;
+    target_cinemas?: string[] | null;
+  };
+}
+
+export interface DlqJobEntry {
+  job_id: string;
+  failure_reason: string;
+  retry_count: number;
+  timestamp: string;
+  cinema_id?: string;
+  org_id?: string;
+  org_slug?: string;
+  user_id?: string;
+  endpoint?: string;
+  job: ScrapeJob;
+}
+
+export const SCRAPE_JOBS_KEY = 'scrape:jobs';
+export const SCRAPE_DLQ_KEY = 'scrape:jobs:dlq';
+export const MAX_SCRAPE_JOB_RETRY_ATTEMPTS = 3;
+
+export function getDlqJobId(job: ScrapeJob): string {
+  return `report-${job.reportId}`;
+}
+
+export function getJobCinemaId(job: ScrapeJob): string | undefined {
+  if (job.type !== 'scrape') return undefined;
+  return job.options?.cinemaId;
+}
+
+export function createDlqJobEntry({
+  job,
+  failureReason,
+  retryCount,
+  timestamp = new Date().toISOString(),
+}: {
+  job: ScrapeJob;
+  failureReason: string;
+  retryCount: number;
+  timestamp?: string;
+}): DlqJobEntry {
+  return {
+    job_id: getDlqJobId(job),
+    failure_reason: failureReason,
+    retry_count: retryCount,
+    timestamp,
+    cinema_id: getJobCinemaId(job),
+    org_id: job.traceContext?.org_id,
+    org_slug: job.traceContext?.org_slug,
+    user_id: job.traceContext?.user_id,
+    endpoint: job.traceContext?.endpoint,
+    job,
+  };
+}
+
+export function resetDlqJobForRetry(entry: DlqJobEntry): DlqJobEntry {
+  return {
+    ...entry,
+    retry_count: 0,
+    job: {
+      ...entry.job,
+      retryCount: 0,
+    },
+  };
+}
+
+export function matchesDlqOrg(entry: DlqJobEntry, orgId?: number): boolean {
+  if (orgId === undefined) return true;
+  return entry.org_id === String(orgId);
+}
+
 /**
  * Creates a structured JSON logger.
  * - In production (NODE_ENV=production): outputs JSON (for Loki ingestion)

--- a/scraper/src/index.ts
+++ b/scraper/src/index.ts
@@ -4,9 +4,10 @@ dotenv.config();
 import { logger } from './utils/logger.js';
 import { registry, scrapeJobsTotal, scrapeDurationSeconds, filmsScrapedTotal, showtimesScrapedTotal } from './utils/metrics.js';
 import { initTracing } from './utils/tracer.js';
+import type { ScrapeJobAddCinema, ScrapeJobScrape } from '@allo-scrapper/logger';
 
 import { runScraper, addCinemaAndScrape } from './scraper/index.js';
-import { getRedisPublisher, getRedisConsumer, getRedisSubscriber, disconnectRedis, type ScrapeJob, type ScrapeJobScrape, type ScrapeJobAddCinema, type ScheduleChangeEvent } from './redis/client.js';
+import { getRedisPublisher, getRedisConsumer, getRedisSubscriber, disconnectRedis, type ScrapeJob, type ScheduleChangeEvent } from './redis/client.js';
 import { db } from './db/client.js';
 import { createScrapeReport, updateScrapeReport } from './db/report-queries.js';
 import { getEnabledSchedules, updateScheduleRunStatus } from './db/schedule-queries.js';

--- a/scraper/src/index.ts
+++ b/scraper/src/index.ts
@@ -55,8 +55,13 @@ const RUN_MODE: RunMode = (process.env.RUN_MODE as RunMode) ?? 'oneshot';
 // Job executor
 // ---------------------------------------------------------------------------
 
-export async function executeJob(job: ScrapeJob): Promise<void> {
+interface ExecuteJobOptions {
+  rethrowOnFailure?: boolean;
+}
+
+export async function executeJob(job: ScrapeJob, options: ExecuteJobOptions = {}): Promise<void> {
   const publisher = getRedisPublisher();
+  const { rethrowOnFailure = false } = options;
   // Support legacy jobs that predate the discriminated union (no 'type' field)
   const jobType = ('type' in job) ? job.type : 'scrape';
 
@@ -98,6 +103,10 @@ export async function executeJob(job: ScrapeJob): Promise<void> {
         completed_at: new Date().toISOString(),
         errors: [{ cinema_name: 'System', error: errorMessage }],
       }).catch(() => {});
+
+      if (rethrowOnFailure) {
+        throw err;
+      }
     }
     return;
   }
@@ -149,6 +158,10 @@ export async function executeJob(job: ScrapeJob): Promise<void> {
       completed_at: new Date().toISOString(),
       errors: [{ cinema_name: 'System', error: errorMessage }],
     }).catch(() => {});
+
+    if (rethrowOnFailure) {
+      throw err;
+    }
   }
 }
 
@@ -214,7 +227,7 @@ async function runConsumer(): Promise<void> {
   });
 
   await consumer.start(async (job) => {
-    await executeJob(job);
+    await executeJob(job, { rethrowOnFailure: true });
   });
 }
 

--- a/scraper/src/redis/client.test.ts
+++ b/scraper/src/redis/client.test.ts
@@ -6,6 +6,7 @@ const quitMock = vi.fn();
 const blpopMock = vi.fn();
 const publishMock = vi.fn();
 const lpopMock = vi.fn();
+const zaddMock = vi.fn();
 
 vi.mock('ioredis', () => {
   class MockRedis {
@@ -15,6 +16,7 @@ vi.mock('ioredis', () => {
     blpop = blpopMock;
     lpop = lpopMock;
     publish = publishMock;
+    zadd = zaddMock;
   }
 
   return {
@@ -117,5 +119,48 @@ describe('scraper redis client trace context', () => {
         traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
       }),
     }));
+  });
+
+  it('moves jobs to the scraper DLQ after terminal failures', async () => {
+    const { RedisJobConsumer } = await import('./client.js');
+
+    const dlqCandidate = {
+      type: 'scrape',
+      triggerType: 'manual',
+      reportId: 93,
+      retryCount: 2,
+      options: { cinemaId: 'C0042' },
+      traceContext: {
+        org_id: '42',
+        org_slug: 'acme',
+      },
+    };
+
+    blpopMock
+      .mockResolvedValueOnce(['scrape:jobs', JSON.stringify(dlqCandidate)])
+      .mockResolvedValueOnce(null);
+
+    const consumer = new RedisJobConsumer('redis://localhost:6379');
+
+    await consumer.start(async () => {
+      consumer.stop();
+      throw new Error('terminal failure');
+    });
+
+    expect(zaddMock).toHaveBeenCalledWith(
+      'scrape:jobs:dlq',
+      expect.any(Number),
+      expect.stringContaining('"retry_count":3')
+    );
+    expect(zaddMock).toHaveBeenCalledWith(
+      'scrape:jobs:dlq',
+      expect.any(Number),
+      expect.stringContaining('"failure_reason":"terminal failure"')
+    );
+    expect(zaddMock).toHaveBeenCalledWith(
+      'scrape:jobs:dlq',
+      expect.any(Number),
+      expect.stringContaining('"org_id":"42"')
+    );
   });
 });

--- a/scraper/src/redis/client.ts
+++ b/scraper/src/redis/client.ts
@@ -1,4 +1,13 @@
 import Redis from 'ioredis';
+import {
+  createDlqJobEntry,
+  MAX_SCRAPE_JOB_RETRY_ATTEMPTS,
+  SCRAPE_DLQ_KEY,
+  SCRAPE_JOBS_KEY,
+  type DlqJobEntry,
+  type ScrapeJob,
+  type ScheduleChangeEvent,
+} from '@allo-scrapper/logger';
 import type { ProgressEvent, ScrapeSummary } from '../types/scraper.js';
 import { logger } from '../utils/logger.js';
 
@@ -6,48 +15,7 @@ import { logger } from '../utils/logger.js';
 // Types
 // ---------------------------------------------------------------------------
 
-export interface ScheduleChangeEvent {
-  action: 'created' | 'updated' | 'deleted';
-  scheduleId: number;
-  schedule?: {
-    id: number;
-    name: string;
-    cron_expression: string;
-    enabled: boolean;
-    target_cinemas?: string[] | null;
-  };
-}
-
-interface BaseScrapeJob {
-  reportId: number;
-  /** OpenTelemetry trace context propagated from the HTTP request */
-  traceContext?: Record<string, string>;
-}
-
-export interface ScrapeJobScrape extends BaseScrapeJob {
-  type: 'scrape';
-  triggerType: 'manual' | 'cron';
-  options?: {
-    mode?: 'weekly' | 'from_today' | 'from_today_limited';
-    days?: number;
-    cinemaId?: string;
-    filmId?: number;
-  };
-}
-
-export interface ScrapeJobAddCinema extends BaseScrapeJob {
-  type: 'add_cinema';
-  triggerType: 'manual';
-  /** The Allociné cinema URL to add and scrape */
-  url: string;
-}
-
-/**
- * Discriminated union of all job types the scraper can process.
- * Use `job.type` (or check for presence of the field for legacy jobs) to
- * narrow to a concrete job variant.
- */
-export type ScrapeJob = ScrapeJobScrape | ScrapeJobAddCinema;
+export type { DlqJobEntry, ScheduleChangeEvent, ScrapeJob };
 
 // ---------------------------------------------------------------------------
 // RedisProgressPublisher – implements ProgressPublisher interface
@@ -123,6 +91,36 @@ export class RedisJobConsumer {
           await handler(job);
         } catch (err) {
           logger.error('[RedisJobConsumer] Job handler failed', { err });
+
+          const nextRetryCount = (job.retryCount ?? 0) + 1;
+          if (nextRetryCount >= MAX_SCRAPE_JOB_RETRY_ATTEMPTS) {
+            const failureReason = err instanceof Error ? err.message : String(err);
+            const entry: DlqJobEntry = createDlqJobEntry({
+              job: {
+                ...job,
+                retryCount: nextRetryCount,
+              },
+              failureReason,
+              retryCount: nextRetryCount,
+            });
+
+            await this.client.zadd(SCRAPE_DLQ_KEY, Date.parse(entry.timestamp), JSON.stringify(entry));
+            logger.warn('[RedisJobConsumer] Job moved to DLQ', {
+              reportId: job.reportId,
+              retry_count: nextRetryCount,
+              org_id: job.traceContext?.org_id,
+            });
+          } else {
+            await this.client.rpush(SCRAPE_JOBS_KEY, JSON.stringify({
+              ...job,
+              retryCount: nextRetryCount,
+            }));
+            logger.warn('[RedisJobConsumer] Requeued failed job', {
+              reportId: job.reportId,
+              retry_count: nextRetryCount,
+              org_id: job.traceContext?.org_id,
+            });
+          }
         }
       } catch (err: any) {
         // If connection closed cleanly during shutdown, stop

--- a/scraper/tests/unit/index.test.ts
+++ b/scraper/tests/unit/index.test.ts
@@ -152,4 +152,23 @@ describe('executeJob dispatcher', () => {
       expect.objectContaining({ status: 'failed' })
     );
   });
+
+  it('should rethrow scraper failures when consumer mode requests propagation', async () => {
+    const failure = new Error('redis downstream failure');
+    mockRunScraper.mockRejectedValue(failure);
+
+    const { executeJob } = await import('../../src/index.js');
+
+    await expect(executeJob({
+      type: 'scrape',
+      triggerType: 'manual',
+      reportId: 46,
+    }, { rethrowOnFailure: true })).rejects.toThrow('redis downstream failure');
+
+    expect(mockUpdateScrapeReport).toHaveBeenCalledWith(
+      expect.anything(),
+      46,
+      expect.objectContaining({ status: 'failed' })
+    );
+  });
 });

--- a/server/src/routes/scraper.test.ts
+++ b/server/src/routes/scraper.test.ts
@@ -11,6 +11,8 @@ const mockPublishScheduleChange = vi.fn();
 const mockGetScrapeReport = vi.fn();
 const mockGetPendingScrapeAttempts = vi.fn();
 const mockLoggerInfo = vi.fn();
+const mockListDlqJobs = vi.fn();
+const mockRetryDlqJob = vi.fn();
 
 let currentMockUser = { role_name: 'admin', is_system_role: true, permissions: [], id: 1, username: 'admin' };
 let failAuth = false;
@@ -63,6 +65,8 @@ vi.mock('../middleware/permission.js', () => ({
 vi.mock('../services/redis-client.js', () => ({
   getRedisClient: () => ({
     publishScheduleChange: mockPublishScheduleChange,
+    listDlqJobs: mockListDlqJobs,
+    retryDlqJob: mockRetryDlqJob,
   }),
 }));
 
@@ -111,6 +115,8 @@ describe('Routes - Scraper', () => {
     mockTriggerResume.mockResolvedValue({ reportId: 43, queueDepth: 1 });
     mockGetStatus.mockResolvedValue({ isRunning: false, latestReport: null });
     mockPublishScheduleChange.mockResolvedValue(undefined);
+    mockListDlqJobs.mockResolvedValue({ jobs: [], total: 0, page: 1, pageSize: 50 });
+    mockRetryDlqJob.mockResolvedValue(null);
     mockGetScrapeReport.mockResolvedValue({ id: 123, status: 'failed' });
     mockGetPendingScrapeAttempts.mockResolvedValue([
       { cinema_id: 'C0042', date: '2026-03-26' },
@@ -245,6 +251,93 @@ describe('Routes - Scraper', () => {
           method: 'GET',
         })
       );
+    });
+  });
+
+  describe('GET /api/scraper/dlq', () => {
+    it('should return paginated DLQ jobs newest first', async () => {
+      mockListDlqJobs.mockResolvedValue({
+        jobs: [
+          { job_id: 'job-2', timestamp: '2026-04-21T19:00:00.000Z' },
+          { job_id: 'job-1', timestamp: '2026-04-21T18:00:00.000Z' },
+        ],
+        total: 2,
+        page: 1,
+        pageSize: 50,
+      });
+
+      const app = await setupApp({ role_name: 'user', is_system_role: false, permissions: ['scraper:trigger'] });
+      const response = await request(app).get('/api/scraper/dlq?page=1&pageSize=99');
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.jobs).toHaveLength(2);
+      expect(response.body.data.jobs[0].job_id).toBe('job-2');
+      expect(mockListDlqJobs).toHaveBeenCalledWith(50, 1, undefined);
+    });
+
+    it('should return 403 when user lacks scraper trigger permission', async () => {
+      const app = await setupApp({ role_name: 'user', is_system_role: false, permissions: [] });
+      const response = await request(app).get('/api/scraper/dlq');
+
+      expect(response.status).toBe(403);
+      expect(mockListDlqJobs).not.toHaveBeenCalled();
+    });
+
+    it('should scope DLQ listing to the caller org for non-system users', async () => {
+      const app = await setupApp({ role_name: 'user', is_system_role: false, permissions: ['scraper:trigger'], org_id: 7 });
+      const response = await request(app).get('/api/scraper/dlq');
+
+      expect(response.status).toBe(200);
+      expect(mockListDlqJobs).toHaveBeenCalledWith(50, 1, 7);
+    });
+  });
+
+  describe('POST /api/scraper/dlq/:jobId/retry', () => {
+    it('should requeue a DLQ job and return success payload', async () => {
+      mockRetryDlqJob.mockResolvedValue({
+        job_id: 'job-2',
+        retry_count: 0,
+      });
+
+      const app = await setupApp({ role_name: 'user', is_system_role: false, permissions: ['scraper:trigger'], org_id: 7 });
+      const response = await request(app).post('/api/scraper/dlq/job-2/retry');
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.job_id).toBe('job-2');
+      expect(response.body.data.retry_count).toBe(0);
+      expect(mockRetryDlqJob).toHaveBeenCalledWith('job-2', 7);
+    });
+
+    it('should return 404 when DLQ job does not exist', async () => {
+      mockRetryDlqJob.mockResolvedValue(null);
+
+      const app = await setupApp({ role_name: 'user', is_system_role: false, permissions: ['scraper:trigger'] });
+      const response = await request(app).post('/api/scraper/dlq/missing-job/retry');
+
+      expect(response.status).toBe(404);
+      expect(response.body.error).toContain('DLQ job not found');
+    });
+
+    it('should return the retried job payload with reset nested retryCount', async () => {
+      mockRetryDlqJob.mockResolvedValue({
+        job_id: 'job-3',
+        retry_count: 0,
+        job: {
+          type: 'scrape',
+          triggerType: 'manual',
+          reportId: 3,
+          retryCount: 0,
+        },
+      });
+
+      const app = await setupApp({ role_name: 'user', is_system_role: false, permissions: ['scraper:trigger'], org_id: 7 });
+      const response = await request(app).post('/api/scraper/dlq/job-3/retry');
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.retry_count).toBe(0);
+      expect(response.body.data.job.retryCount).toBe(0);
     });
   });
 

--- a/server/src/routes/scraper.ts
+++ b/server/src/routes/scraper.ts
@@ -37,6 +37,15 @@ function getValidTraceparentHeader(req: AuthRequest): string | undefined {
   return raw;
 }
 
+function canManageScraper(req: AuthRequest): boolean {
+  if (req.user?.role_name === 'admin' && req.user?.is_system_role) {
+    return true;
+  }
+
+  const userPermissions = new Set(req.user?.permissions || []);
+  return userPermissions.has('scraper:trigger');
+}
+
 router.use(validateInputSize({ maxArrayLength: 100, maxTotalSize: 50 * 1024 }));
 
 // POST /api/scraper/trigger - Start a manual scrape (delegates to Redis microservice)
@@ -189,6 +198,60 @@ router.get('/status', scraperLimiter, requireAuth, async (req: AuthRequest, res,
     const response: ApiResponse = {
       success: true,
       data: statusData,
+    };
+
+    res.json(response);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/scraper/dlq - List dead-lettered scraper jobs
+router.get('/dlq', scraperLimiter, requireAuth, async (req: AuthRequest, res, next) => {
+  try {
+    if (!canManageScraper(req)) {
+      return next(new AuthError('Permission denied', 403));
+    }
+
+    const page = parseStrictInt(req.query.page);
+    const pageSize = parseStrictInt(req.query.pageSize);
+    const normalizedPage = Number.isNaN(page) ? 1 : Math.max(1, page);
+    const normalizedPageSize = Number.isNaN(pageSize) ? 50 : Math.min(Math.max(1, pageSize), 50);
+    const result = await getRedisClient().listDlqJobs(
+      normalizedPageSize,
+      normalizedPage,
+      req.user?.is_system_role ? undefined : req.user?.org_id,
+    );
+
+    const response: ApiResponse = {
+      success: true,
+      data: result,
+    };
+
+    res.json(response);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/scraper/dlq/:jobId/retry - Requeue a dead-lettered job
+router.post('/dlq/:jobId/retry', scraperLimiter, requireAuth, async (req: AuthRequest, res, next) => {
+  try {
+    if (!canManageScraper(req)) {
+      return next(new AuthError('Permission denied', 403));
+    }
+
+    const retried = await getRedisClient().retryDlqJob(
+      req.params.jobId,
+      req.user?.is_system_role ? undefined : req.user?.org_id,
+    );
+    if (!retried) {
+      return next(new NotFoundError('DLQ job not found'));
+    }
+
+    const response: ApiResponse = {
+      success: true,
+      data: retried,
     };
 
     res.json(response);

--- a/server/src/routes/scraper.ts
+++ b/server/src/routes/scraper.ts
@@ -37,6 +37,10 @@ function getValidTraceparentHeader(req: AuthRequest): string | undefined {
   return raw;
 }
 
+function getSingleRouteParam(value: string | string[] | undefined): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
 function canManageScraper(req: AuthRequest): boolean {
   if (req.user?.role_name === 'admin' && req.user?.is_system_role) {
     return true;
@@ -241,8 +245,13 @@ router.post('/dlq/:jobId/retry', scraperLimiter, requireAuth, async (req: AuthRe
       return next(new AuthError('Permission denied', 403));
     }
 
+    const jobId = getSingleRouteParam(req.params.jobId);
+    if (!jobId) {
+      return next(new ValidationError('Invalid DLQ job ID'));
+    }
+
     const retried = await getRedisClient().retryDlqJob(
-      req.params.jobId,
+      jobId,
       req.user?.is_system_role ? undefined : req.user?.org_id,
     );
     if (!retried) {

--- a/server/src/services/redis-client.test.ts
+++ b/server/src/services/redis-client.test.ts
@@ -6,6 +6,10 @@ import { logger } from '../utils/logger.js';
 const mockRedisInstance = {
   rpush: vi.fn().mockResolvedValue(1),
   llen: vi.fn().mockResolvedValue(0),
+  zadd: vi.fn().mockResolvedValue(1),
+  zrevrange: vi.fn().mockResolvedValue([]),
+  zcard: vi.fn().mockResolvedValue(0),
+  zrem: vi.fn().mockResolvedValue(1),
   publish: vi.fn().mockResolvedValue(1),
   subscribe: vi.fn().mockResolvedValue(undefined),
   on: vi.fn(),
@@ -43,6 +47,140 @@ describe('RedisClient', () => {
   it('should get queue depth', async () => {
     await client.getQueueDepth();
     expect(mockRedisInstance.llen).toHaveBeenCalledWith('scrape:jobs');
+  });
+
+  it('should persist terminally failed jobs in the scraper DLQ', async () => {
+    const timestamp = '2026-04-21T18:00:00.000Z';
+
+    await client.moveJobToDlq({
+      job: {
+        type: 'scrape',
+        triggerType: 'manual',
+        reportId: 1,
+        options: { cinemaId: 'C1234' },
+        traceContext: { org_id: '77', org_slug: 'acme' },
+      },
+      failureReason: 'boom',
+      retryCount: 3,
+      timestamp,
+    });
+
+    expect(mockRedisInstance.zadd).toHaveBeenCalledWith(
+      'scrape:jobs:dlq',
+      expect.any(Number),
+      expect.stringContaining('"job_id":"report-1"')
+    );
+    expect(mockRedisInstance.zadd).toHaveBeenCalledWith(
+      'scrape:jobs:dlq',
+      expect.any(Number),
+      expect.stringContaining('"failure_reason":"boom"')
+    );
+    expect(mockRedisInstance.zadd).toHaveBeenCalledWith(
+      'scrape:jobs:dlq',
+      expect.any(Number),
+      expect.stringContaining('"cinema_id":"C1234"')
+    );
+    expect(mockRedisInstance.zadd).toHaveBeenCalledWith(
+      'scrape:jobs:dlq',
+      expect.any(Number),
+      expect.stringContaining('"org_id":"77"')
+    );
+  });
+
+  it('should list DLQ jobs newest first with pagination metadata', async () => {
+    mockRedisInstance.zrevrange.mockResolvedValueOnce([
+      JSON.stringify({ job_id: 'job-2', timestamp: '2026-04-21T19:00:00.000Z' }),
+      JSON.stringify({ job_id: 'job-1', timestamp: '2026-04-21T18:00:00.000Z' }),
+    ]);
+    mockRedisInstance.zcard.mockResolvedValueOnce(2);
+
+    const result = await client.listDlqJobs(2, 1);
+
+    expect(mockRedisInstance.zrevrange).toHaveBeenCalledWith('scrape:jobs:dlq', 0, -1);
+    expect(result).toEqual({
+      jobs: [
+        { job_id: 'job-2', timestamp: '2026-04-21T19:00:00.000Z' },
+        { job_id: 'job-1', timestamp: '2026-04-21T18:00:00.000Z' },
+      ],
+      total: 2,
+      page: 1,
+      pageSize: 2,
+    });
+  });
+
+  it('should requeue a DLQ job and remove it from DLQ', async () => {
+    const dlqEntry = {
+      job_id: 'report-2',
+      retry_count: 3,
+      job: {
+        type: 'scrape',
+        triggerType: 'manual',
+        reportId: 2,
+      },
+    };
+
+    mockRedisInstance.zrevrange.mockResolvedValueOnce([JSON.stringify(dlqEntry)]);
+
+    await client.retryDlqJob('report-2');
+
+    expect(mockRedisInstance.rpush).toHaveBeenCalledWith(
+      'scrape:jobs',
+      expect.stringContaining('"retryCount":0')
+    );
+    expect(mockRedisInstance.zrem).toHaveBeenCalledWith('scrape:jobs:dlq', JSON.stringify(dlqEntry));
+    expect(mockRedisInstance.rpush).toHaveBeenCalledWith(
+      'scrape:jobs',
+      expect.stringContaining('"retryCount":0')
+    );
+  });
+
+  it('should return null when retrying a missing DLQ job', async () => {
+    mockRedisInstance.zrevrange.mockResolvedValueOnce([]);
+
+    const result = await client.retryDlqJob('missing-job');
+
+    expect(result).toBeNull();
+    expect(mockRedisInstance.rpush).not.toHaveBeenCalledWith('scrape:jobs', expect.any(String));
+  });
+
+  it('should filter DLQ jobs by org for tenant-scoped callers', async () => {
+    mockRedisInstance.zrevrange.mockResolvedValueOnce([
+      JSON.stringify({ job_id: 'job-2', org_id: '8', timestamp: '2026-04-21T19:00:00.000Z' }),
+      JSON.stringify({ job_id: 'job-1', org_id: '7', timestamp: '2026-04-21T18:00:00.000Z' }),
+    ]);
+    mockRedisInstance.zcard.mockResolvedValueOnce(2);
+
+    const result = await client.listDlqJobs(50, 1, 7);
+
+    expect(result).toEqual({
+      jobs: [
+        { job_id: 'job-1', org_id: '7', timestamp: '2026-04-21T18:00:00.000Z' },
+      ],
+      total: 1,
+      page: 1,
+      pageSize: 50,
+    });
+  });
+
+  it('should refuse to retry a DLQ job from another org', async () => {
+    mockRedisInstance.zrevrange.mockResolvedValueOnce([
+      JSON.stringify({
+        job_id: 'report-2',
+        org_id: '8',
+        retry_count: 3,
+        job: {
+          type: 'scrape',
+          triggerType: 'manual',
+          reportId: 2,
+        },
+      }),
+    ]);
+
+    const result = await client.retryDlqJob('report-2', 7);
+
+    expect(result).toBeNull();
+    expect(mockRedisInstance.rpush).not.toHaveBeenCalled();
+    expect(mockRedisInstance.zrem).not.toHaveBeenCalled();
   });
 
   it('should publish progress', async () => {

--- a/server/src/services/redis-client.ts
+++ b/server/src/services/redis-client.ts
@@ -1,4 +1,15 @@
 import Redis from 'ioredis';
+import {
+  createDlqJobEntry,
+  matchesDlqOrg,
+  resetDlqJobForRetry,
+  SCRAPE_DLQ_KEY,
+  SCRAPE_JOBS_KEY,
+  type DlqJobEntry,
+  type ScrapeJob,
+  type ScrapeJobAddCinema,
+  type ScrapeTraceContext,
+} from '@allo-scrapper/logger';
 import type { ProgressEvent } from './progress-tracker.js';
 import { logger } from '../utils/logger.js';
 
@@ -6,10 +17,11 @@ import { logger } from '../utils/logger.js';
 // Types
 // ---------------------------------------------------------------------------
 
-interface BaseScrapeJob {
-  reportId: number;
-  /** OpenTelemetry trace context propagated from the HTTP request */
-  traceContext?: Record<string, string>;
+export interface DlqJobListResult {
+  jobs: DlqJobEntry[];
+  total: number;
+  page: number;
+  pageSize: number;
 }
 
 export interface ScheduleChangeEvent {
@@ -24,30 +36,7 @@ export interface ScheduleChangeEvent {
   };
 }
 
-export interface ScrapeJobScrape extends BaseScrapeJob {
-  type: 'scrape';
-  triggerType: 'manual' | 'cron';
-  options?: {
-    mode?: 'weekly' | 'from_today' | 'from_today_limited';
-    days?: number;
-    cinemaId?: string;
-    filmId?: number;
-    resumeMode?: boolean;
-    pendingAttempts?: Array<{ cinema_id: string; date: string }>;
-  };
-}
-
-export interface ScrapeJobAddCinema extends BaseScrapeJob {
-  type: 'add_cinema';
-  triggerType: 'manual';
-  /** The Allociné cinema URL to add and scrape */
-  url: string;
-}
-
-/**
- * Discriminated union of all job types the scraper can process.
- */
-export type ScrapeJob = ScrapeJobScrape | ScrapeJobAddCinema;
+export type { DlqJobEntry, ScrapeJob };
 
 // ---------------------------------------------------------------------------
 // RedisClient
@@ -68,18 +57,88 @@ export class RedisClient {
 
   /** Push a scrape job onto the queue. Returns the new queue length. */
   async publishJob(job: ScrapeJob): Promise<number> {
-    return this.publisher.rpush('scrape:jobs', JSON.stringify(job));
+    return this.publisher.rpush(SCRAPE_JOBS_KEY, JSON.stringify(job));
   }
 
   /** Push an add_cinema job onto the queue. Returns the new queue length. */
-  async publishAddCinemaJob(reportId: number, url: string, traceContext?: Record<string, string>): Promise<number> {
+  async publishAddCinemaJob(reportId: number, url: string, traceContext?: ScrapeTraceContext): Promise<number> {
     const job: ScrapeJobAddCinema = { type: 'add_cinema', triggerType: 'manual', reportId, url, ...(traceContext && { traceContext }) };
-    return this.publisher.rpush('scrape:jobs', JSON.stringify(job));
+    return this.publisher.rpush(SCRAPE_JOBS_KEY, JSON.stringify(job));
   }
 
   /** Return the current depth of the scrape:jobs queue. */
   async getQueueDepth(): Promise<number> {
-    return this.publisher.llen('scrape:jobs');
+    return this.publisher.llen(SCRAPE_JOBS_KEY);
+  }
+
+  async moveJobToDlq({
+    job,
+    failureReason,
+    retryCount,
+    timestamp = new Date().toISOString(),
+  }: {
+    job: ScrapeJob;
+    failureReason: string;
+    retryCount: number;
+    timestamp?: string;
+  }): Promise<DlqJobEntry> {
+    const entry = createDlqJobEntry({ job, failureReason, retryCount, timestamp });
+
+    await this.publisher.zadd(SCRAPE_DLQ_KEY, Date.parse(timestamp), JSON.stringify(entry));
+    return entry;
+  }
+
+  async listDlqJobs(pageSize: number = 50, page: number = 1, orgId?: number): Promise<DlqJobListResult> {
+    const normalizedPageSize = Math.max(1, Math.min(pageSize, 50));
+    const normalizedPage = Math.max(1, page);
+
+    const [items, total] = await Promise.all([
+      this.publisher.zrevrange(SCRAPE_DLQ_KEY, 0, -1),
+      this.publisher.zcard(SCRAPE_DLQ_KEY),
+    ]);
+
+    const parsedJobs = items.flatMap((item: string) => {
+      try {
+        return [JSON.parse(item) as DlqJobEntry];
+      } catch (error) {
+        logger.error('[RedisClient] Failed to parse DLQ entry', { error, item });
+        return [];
+      }
+    });
+
+    const filteredJobs = parsedJobs.filter((entry) => matchesDlqOrg(entry, orgId));
+    const start = (normalizedPage - 1) * normalizedPageSize;
+    const jobs = filteredJobs.slice(start, start + normalizedPageSize);
+
+    return {
+      jobs,
+      total: orgId === undefined ? total : filteredJobs.length,
+      page: normalizedPage,
+      pageSize: normalizedPageSize,
+    };
+  }
+
+  async retryDlqJob(jobId: string, orgId?: number): Promise<DlqJobEntry | null> {
+    const entries = await this.publisher.zrevrange(SCRAPE_DLQ_KEY, 0, -1);
+    const rawEntry = entries.find((item: string) => {
+      try {
+        const entry = JSON.parse(item) as DlqJobEntry;
+        return entry.job_id === jobId && matchesDlqOrg(entry, orgId);
+      } catch {
+        return false;
+      }
+    });
+
+    if (!rawEntry) {
+      return null;
+    }
+
+    const entry = JSON.parse(rawEntry) as DlqJobEntry;
+    const retriedEntry = resetDlqJobForRetry(entry);
+    await this.publisher.rpush(SCRAPE_JOBS_KEY, JSON.stringify(retriedEntry.job));
+    await this.publisher.zrem(SCRAPE_DLQ_KEY, rawEntry);
+
+    return retriedEntry;
   }
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add Redis-backed DLQ handling for scraper jobs, including requeue-on-failure and terminal failure handoff after three attempts
- expose backend DLQ inspection and retry endpoints with tenant-safe org scoping for non-system users
- document the new API contract and align shared queue/DLQ types across server and scraper

## Validation
- cd server && npm run test:run
- cd scraper && npm run test:run
- cd packages/logger && npm run test:run

Closes #903