### PR TITLE
fix(scraper): harden Redis retry persistence

### DIFF
--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -61,6 +61,13 @@ export interface DlqJobEntry {
 export const SCRAPE_JOBS_KEY = 'scrape:jobs';
 export const SCRAPE_DLQ_KEY = 'scrape:jobs:dlq';
 export const MAX_SCRAPE_JOB_RETRY_ATTEMPTS = 3;
+export const SCRAPE_JOB_RETRY_DELAYS_MS = [1000, 2000, 4000] as const;
+
+export function getScrapeJobRetryDelayMs(retryAttempt: number): number {
+  if (retryAttempt <= 1) return SCRAPE_JOB_RETRY_DELAYS_MS[0];
+  if (retryAttempt === 2) return SCRAPE_JOB_RETRY_DELAYS_MS[1];
+  return SCRAPE_JOB_RETRY_DELAYS_MS[2];
+}
 
 export function getDlqJobId(job: ScrapeJob): string {
   return `report-${job.reportId}`;

--- a/scraper/src/redis/client.test.ts
+++ b/scraper/src/redis/client.test.ts
@@ -7,6 +7,9 @@ const blpopMock = vi.fn();
 const publishMock = vi.fn();
 const lpopMock = vi.fn();
 const zaddMock = vi.fn();
+const rpushMock = vi.fn();
+const loggerWarnMock = vi.fn();
+const loggerErrorMock = vi.fn();
 
 vi.mock('ioredis', () => {
   class MockRedis {
@@ -15,6 +18,7 @@ vi.mock('ioredis', () => {
     quit = quitMock;
     blpop = blpopMock;
     lpop = lpopMock;
+    rpush = rpushMock;
     publish = publishMock;
     zadd = zaddMock;
   }
@@ -29,8 +33,8 @@ const loggerInfoMock = vi.fn();
 vi.mock('../utils/logger.js', () => ({
   logger: {
     info: (...args: unknown[]) => loggerInfoMock(...args),
-    warn: vi.fn(),
-    error: vi.fn(),
+    warn: (...args: unknown[]) => loggerWarnMock(...args),
+    error: (...args: unknown[]) => loggerErrorMock(...args),
     debug: vi.fn(),
   },
 }));
@@ -38,7 +42,15 @@ vi.mock('../utils/logger.js', () => ({
 describe('scraper redis client trace context', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useRealTimers();
     loggerInfoMock.mockReset();
+    loggerWarnMock.mockReset();
+    loggerErrorMock.mockReset();
+    blpopMock.mockReset();
+    lpopMock.mockReset();
+    publishMock.mockReset();
+    zaddMock.mockReset();
+    rpushMock.mockReset();
   });
 
   it('keeps traceContext metadata when parsing queued jobs', async () => {
@@ -161,6 +173,187 @@ describe('scraper redis client trace context', () => {
       'scrape:jobs:dlq',
       expect.any(Number),
       expect.stringContaining('"org_id":"42"')
+    );
+  });
+
+  it('requeues failed jobs only after exponential backoff', async () => {
+    vi.useFakeTimers();
+
+    const { RedisJobConsumer } = await import('./client.js');
+
+    const retryCandidate = {
+      type: 'scrape',
+      triggerType: 'manual',
+      reportId: 94,
+      retryCount: 0,
+      traceContext: {
+        org_id: '42',
+      },
+    };
+
+    blpopMock
+      .mockResolvedValueOnce(['scrape:jobs', JSON.stringify(retryCandidate)])
+      .mockResolvedValueOnce(null);
+
+    const consumer = new RedisJobConsumer('redis://localhost:6379');
+
+    const startPromise = consumer.start(async () => {
+      consumer.stop();
+      throw new Error('retryable failure');
+    });
+
+    await Promise.resolve();
+    expect(rpushMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(rpushMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await Promise.resolve();
+    await startPromise;
+
+    expect(rpushMock).toHaveBeenCalledWith(
+      'scrape:jobs',
+      expect.stringContaining('"retryCount":1')
+    );
+  });
+
+  it('uses the shared retry schedule when requeue persistence fails', async () => {
+    vi.useFakeTimers();
+
+    const { RedisJobConsumer } = await import('./client.js');
+
+    const retryCandidate = {
+      type: 'scrape',
+      triggerType: 'manual',
+      reportId: 96,
+      retryCount: 0,
+      traceContext: {
+        org_id: '42',
+      },
+    };
+
+    blpopMock
+      .mockResolvedValueOnce(['scrape:jobs', JSON.stringify(retryCandidate)])
+      .mockResolvedValueOnce(null);
+    rpushMock
+      .mockRejectedValueOnce(new Error('redis write failed'))
+      .mockResolvedValueOnce(1);
+
+    const consumer = new RedisJobConsumer('redis://localhost:6379');
+
+    const startPromise = consumer.start(async () => {
+      consumer.stop();
+      throw new Error('retryable failure');
+    });
+
+    await Promise.resolve();
+    expect(rpushMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await Promise.resolve();
+    expect(rpushMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(rpushMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await Promise.resolve();
+    await startPromise;
+
+    expect(rpushMock).toHaveBeenCalledTimes(2);
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      '[RedisJobConsumer] Failed to requeue job after handler failure',
+      expect.objectContaining({
+        job_id: 'report-96',
+        retry_count: 1,
+        persistence_attempt: 1,
+      })
+    );
+  });
+
+  it('does not requeue jobs after terminal retry threshold', async () => {
+    vi.useFakeTimers();
+
+    const { RedisJobConsumer } = await import('./client.js');
+
+    const dlqCandidate = {
+      type: 'scrape',
+      triggerType: 'manual',
+      reportId: 95,
+      retryCount: 2,
+      traceContext: {
+        org_id: '42',
+      },
+    };
+
+    blpopMock
+      .mockResolvedValueOnce(['scrape:jobs', JSON.stringify(dlqCandidate)])
+      .mockResolvedValueOnce(null);
+
+    const consumer = new RedisJobConsumer('redis://localhost:6379');
+
+    await consumer.start(async () => {
+      consumer.stop();
+      throw new Error('terminal failure');
+    });
+
+    expect(rpushMock).not.toHaveBeenCalled();
+    expect(zaddMock).toHaveBeenCalledWith(
+      'scrape:jobs:dlq',
+      expect.any(Number),
+      expect.stringContaining('"retry_count":3')
+    );
+  });
+
+  it('keeps retrying DLQ persistence when terminal failure recording hits Redis errors', async () => {
+    vi.useFakeTimers();
+
+    const { RedisJobConsumer } = await import('./client.js');
+
+    const dlqCandidate = {
+      type: 'scrape',
+      triggerType: 'manual',
+      reportId: 97,
+      retryCount: 2,
+      traceContext: {
+        org_id: '42',
+      },
+    };
+
+    blpopMock
+      .mockResolvedValueOnce(['scrape:jobs', JSON.stringify(dlqCandidate)])
+      .mockResolvedValueOnce(null);
+    zaddMock
+      .mockRejectedValueOnce(new Error('redis dlq write failed'))
+      .mockResolvedValueOnce(1);
+
+    const consumer = new RedisJobConsumer('redis://localhost:6379');
+
+    const startPromise = consumer.start(async () => {
+      consumer.stop();
+      throw new Error('terminal failure');
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(zaddMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(zaddMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await Promise.resolve();
+    await startPromise;
+
+    expect(zaddMock).toHaveBeenCalledTimes(2);
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      '[RedisJobConsumer] Failed to persist terminal job to DLQ',
+      expect.objectContaining({
+        job_id: 'report-97',
+        retry_count: 3,
+        persistence_attempt: 1,
+      })
     );
   });
 });

--- a/scraper/src/redis/client.ts
+++ b/scraper/src/redis/client.ts
@@ -1,6 +1,8 @@
 import Redis from 'ioredis';
 import {
   createDlqJobEntry,
+  getDlqJobId,
+  getScrapeJobRetryDelayMs,
   MAX_SCRAPE_JOB_RETRY_ATTEMPTS,
   SCRAPE_DLQ_KEY,
   SCRAPE_JOBS_KEY,
@@ -55,6 +57,78 @@ export class RedisJobConsumer {
    * Start consuming jobs from the scrape:jobs queue.
    * Calls handler for each job. Blocks waiting for jobs (BLPOP).
    */
+  private async sleep(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private async persistTerminalFailure(entry: DlqJobEntry): Promise<void> {
+    for (let persistenceAttempt = 1; ; persistenceAttempt += 1) {
+      try {
+        await this.client.zadd(SCRAPE_DLQ_KEY, Date.parse(entry.timestamp), JSON.stringify(entry));
+        logger.warn('[RedisJobConsumer] Job moved to DLQ', {
+          job_id: entry.job_id,
+          reportId: entry.job.reportId,
+          retry_count: entry.retry_count,
+          timestamp: entry.timestamp,
+          error: entry.failure_reason,
+          org_id: entry.org_id,
+        });
+        return;
+      } catch (persistErr) {
+        logger.error('[RedisJobConsumer] Failed to persist terminal job to DLQ', {
+          job_id: entry.job_id,
+          reportId: entry.job.reportId,
+          retry_count: entry.retry_count,
+          persistence_attempt: persistenceAttempt,
+          timestamp: new Date().toISOString(),
+          error: persistErr instanceof Error ? persistErr.message : String(persistErr),
+          org_id: entry.org_id,
+        });
+        await this.sleep(getScrapeJobRetryDelayMs(persistenceAttempt));
+      }
+    }
+  }
+
+  private async requeueFailedJob(job: ScrapeJob, nextRetryCount: number, retryDelayMs: number, failureReason: string): Promise<void> {
+    logger.warn('[RedisJobConsumer] Scheduling failed job retry', {
+      job_id: getDlqJobId(job),
+      reportId: job.reportId,
+      retry_count: nextRetryCount,
+      retry_delay_ms: retryDelayMs,
+      timestamp: new Date().toISOString(),
+      error: failureReason,
+      org_id: job.traceContext?.org_id,
+    });
+
+    await this.sleep(retryDelayMs);
+
+    for (let persistenceAttempt = 1; ; persistenceAttempt += 1) {
+      try {
+        await this.client.rpush(SCRAPE_JOBS_KEY, JSON.stringify({
+          ...job,
+          retryCount: nextRetryCount,
+        }));
+        logger.warn('[RedisJobConsumer] Requeued failed job', {
+          reportId: job.reportId,
+          retry_count: nextRetryCount,
+          org_id: job.traceContext?.org_id,
+        });
+        return;
+      } catch (persistErr) {
+        logger.error('[RedisJobConsumer] Failed to requeue job after handler failure', {
+          job_id: getDlqJobId(job),
+          reportId: job.reportId,
+          retry_count: nextRetryCount,
+          persistence_attempt: persistenceAttempt,
+          timestamp: new Date().toISOString(),
+          error: persistErr instanceof Error ? persistErr.message : String(persistErr),
+          org_id: job.traceContext?.org_id,
+        });
+        await this.sleep(getScrapeJobRetryDelayMs(persistenceAttempt));
+      }
+    }
+  }
+
   async start(handler: (job: ScrapeJob) => Promise<void>): Promise<void> {
     this.running = true;
     logger.info('[RedisJobConsumer] Waiting for scrape jobs on scrape:jobs');
@@ -90,11 +164,17 @@ export class RedisJobConsumer {
         try {
           await handler(job);
         } catch (err) {
-          logger.error('[RedisJobConsumer] Job handler failed', { err });
+          const failureReason = err instanceof Error ? err.message : String(err);
+          logger.error('[RedisJobConsumer] Job handler failed', {
+            job_id: getDlqJobId(job),
+            reportId: job.reportId,
+            retry_count: (job.retryCount ?? 0) + 1,
+            timestamp: new Date().toISOString(),
+            error: failureReason,
+          });
 
           const nextRetryCount = (job.retryCount ?? 0) + 1;
           if (nextRetryCount >= MAX_SCRAPE_JOB_RETRY_ATTEMPTS) {
-            const failureReason = err instanceof Error ? err.message : String(err);
             const entry: DlqJobEntry = createDlqJobEntry({
               job: {
                 ...job,
@@ -104,22 +184,9 @@ export class RedisJobConsumer {
               retryCount: nextRetryCount,
             });
 
-            await this.client.zadd(SCRAPE_DLQ_KEY, Date.parse(entry.timestamp), JSON.stringify(entry));
-            logger.warn('[RedisJobConsumer] Job moved to DLQ', {
-              reportId: job.reportId,
-              retry_count: nextRetryCount,
-              org_id: job.traceContext?.org_id,
-            });
+            await this.persistTerminalFailure(entry);
           } else {
-            await this.client.rpush(SCRAPE_JOBS_KEY, JSON.stringify({
-              ...job,
-              retryCount: nextRetryCount,
-            }));
-            logger.warn('[RedisJobConsumer] Requeued failed job', {
-              reportId: job.reportId,
-              retry_count: nextRetryCount,
-              org_id: job.traceContext?.org_id,
-            });
+            await this.requeueFailedJob(job, nextRetryCount, getScrapeJobRetryDelayMs(nextRetryCount), failureReason);
           }
         }
       } catch (err: any) {

--- a/server/src/services/redis-client.test.ts
+++ b/server/src/services/redis-client.test.ts
@@ -31,6 +31,17 @@ describe('RedisClient', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useRealTimers();
+    mockRedisInstance.rpush.mockReset().mockResolvedValue(1);
+    mockRedisInstance.llen.mockReset().mockResolvedValue(0);
+    mockRedisInstance.zadd.mockReset().mockResolvedValue(1);
+    mockRedisInstance.zrevrange.mockReset().mockResolvedValue([]);
+    mockRedisInstance.zcard.mockReset().mockResolvedValue(0);
+    mockRedisInstance.zrem.mockReset().mockResolvedValue(1);
+    mockRedisInstance.publish.mockReset().mockResolvedValue(1);
+    mockRedisInstance.subscribe.mockReset().mockResolvedValue(undefined);
+    mockRedisInstance.on.mockReset();
+    mockRedisInstance.quit.mockReset().mockResolvedValue('OK');
     client = new RedisClient('redis://test');
   });
 
@@ -42,6 +53,104 @@ describe('RedisClient', () => {
   it('should publish add_cinema job', async () => {
     await client.publishAddCinemaJob(42, 'http://test');
     expect(mockRedisInstance.rpush).toHaveBeenCalledWith('scrape:jobs', expect.any(String));
+  });
+
+  it('should retry publishJob with exponential backoff before succeeding', async () => {
+    vi.useFakeTimers();
+    mockRedisInstance.rpush
+      .mockRejectedValueOnce(new Error('redis timeout 1'))
+      .mockRejectedValueOnce(new Error('redis timeout 2'))
+      .mockResolvedValueOnce(1);
+
+    const publishPromise = client.publishJob({
+      type: 'scrape',
+      reportId: 11,
+      triggerType: 'manual',
+      traceContext: { org_id: '7' },
+    }).catch((error) => {
+      throw error;
+    });
+
+    await Promise.resolve();
+    expect(mockRedisInstance.rpush).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(mockRedisInstance.rpush).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await Promise.resolve();
+    expect(mockRedisInstance.rpush).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(mockRedisInstance.rpush).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await Promise.resolve();
+
+    await expect(publishPromise).resolves.toBe(1);
+    expect(mockRedisInstance.rpush).toHaveBeenCalledTimes(3);
+  });
+
+  it('should move publishJob payload to DLQ after terminal enqueue failures', async () => {
+    vi.useFakeTimers();
+    mockRedisInstance.rpush.mockRejectedValue(new Error('redis hard failure'));
+
+    const publishPromise = client.publishJob({
+      type: 'scrape',
+      reportId: 12,
+      triggerType: 'manual',
+      options: { cinemaId: 'C1234' },
+      traceContext: { org_id: '7', org_slug: 'acme' },
+    });
+    const rejectionExpectation = expect(publishPromise).rejects.toThrow('redis hard failure');
+
+    await Promise.resolve();
+    expect(mockRedisInstance.rpush).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await Promise.resolve();
+    expect(mockRedisInstance.rpush).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(2000);
+    await Promise.resolve();
+
+    await rejectionExpectation;
+    expect(mockRedisInstance.rpush).toHaveBeenCalledTimes(3);
+    expect(mockRedisInstance.zadd).toHaveBeenCalledWith(
+      'scrape:jobs:dlq',
+      expect.any(Number),
+      expect.stringContaining('"reportId":12')
+    );
+    expect(mockRedisInstance.zadd).toHaveBeenCalledWith(
+      'scrape:jobs:dlq',
+      expect.any(Number),
+      expect.stringContaining('"retry_count":3')
+    );
+  });
+
+  it('should retry publishAddCinemaJob with the same backoff contract', async () => {
+    vi.useFakeTimers();
+    mockRedisInstance.rpush
+      .mockRejectedValueOnce(new Error('redis timeout 1'))
+      .mockRejectedValueOnce(new Error('redis timeout 2'))
+      .mockResolvedValueOnce(1);
+
+    const publishPromise = client.publishAddCinemaJob(42, 'http://test', { org_id: '5' }).catch((error) => {
+      throw error;
+    });
+
+    await Promise.resolve();
+    expect(mockRedisInstance.rpush).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await Promise.resolve();
+    expect(mockRedisInstance.rpush).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(2000);
+    await Promise.resolve();
+
+    await expect(publishPromise).resolves.toBe(1);
+    expect(mockRedisInstance.rpush).toHaveBeenCalledTimes(3);
   });
 
   it('should get queue depth', async () => {

--- a/server/src/services/redis-client.ts
+++ b/server/src/services/redis-client.ts
@@ -1,7 +1,10 @@
 import Redis from 'ioredis';
 import {
   createDlqJobEntry,
+  getDlqJobId,
+  getScrapeJobRetryDelayMs,
   matchesDlqOrg,
+  MAX_SCRAPE_JOB_RETRY_ATTEMPTS,
   resetDlqJobForRetry,
   SCRAPE_DLQ_KEY,
   SCRAPE_JOBS_KEY,
@@ -55,15 +58,64 @@ export class RedisClient {
   // Job queue (scrape:jobs)  – backend → scraper
   // --------------------------------------------------------------------------
 
+  private async sleep(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private async publishWithRetry(job: ScrapeJob): Promise<number> {
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= MAX_SCRAPE_JOB_RETRY_ATTEMPTS; attempt += 1) {
+      try {
+        return await this.publisher.rpush(SCRAPE_JOBS_KEY, JSON.stringify(job));
+      } catch (error) {
+        lastError = error;
+        const errorMessage = error instanceof Error ? error.message : String(error);
+
+        logger.warn('[RedisClient] Failed to enqueue scrape job', {
+          job_id: getDlqJobId(job),
+          report_id: job.reportId,
+          retry_count: attempt,
+          timestamp: new Date().toISOString(),
+          error: errorMessage,
+        });
+
+        if (attempt >= MAX_SCRAPE_JOB_RETRY_ATTEMPTS) {
+          await this.moveJobToDlq({
+            job: {
+              ...job,
+              retryCount: attempt,
+            },
+            failureReason: errorMessage,
+            retryCount: attempt,
+          });
+
+          logger.error('[RedisClient] Job moved to DLQ after enqueue retries exhausted', {
+            job_id: getDlqJobId(job),
+            report_id: job.reportId,
+            retry_count: attempt,
+            timestamp: new Date().toISOString(),
+            error: errorMessage,
+          });
+          throw error;
+        }
+
+        await this.sleep(getScrapeJobRetryDelayMs(attempt));
+      }
+    }
+
+    throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  }
+
   /** Push a scrape job onto the queue. Returns the new queue length. */
   async publishJob(job: ScrapeJob): Promise<number> {
-    return this.publisher.rpush(SCRAPE_JOBS_KEY, JSON.stringify(job));
+    return this.publishWithRetry(job);
   }
 
   /** Push an add_cinema job onto the queue. Returns the new queue length. */
   async publishAddCinemaJob(reportId: number, url: string, traceContext?: ScrapeTraceContext): Promise<number> {
     const job: ScrapeJobAddCinema = { type: 'add_cinema', triggerType: 'manual', reportId, url, ...(traceContext && { traceContext }) };
-    return this.publisher.rpush(SCRAPE_JOBS_KEY, JSON.stringify(job));
+    return this.publishWithRetry(job);
   }
 
   /** Return the current depth of the scrape:jobs queue. */

--- a/server/src/services/scraper-service.test.ts
+++ b/server/src/services/scraper-service.test.ts
@@ -50,6 +50,24 @@ describe('ScraperService', () => {
       }));
     });
 
+    it('should mark the report failed when queue publish exhausts retry attempts', async () => {
+      const publishError = new Error('redis enqueue failed');
+      const mockPublish = vi.fn().mockRejectedValue(publishError);
+      vi.mocked(redisClient.getRedisClient).mockReturnValue({ publishJob: mockPublish } as any);
+      vi.mocked(reportQueries.createScrapeReport).mockResolvedValue(48 as any);
+
+      await expect(scraperService.triggerScrape({})).rejects.toThrow('redis enqueue failed');
+
+      expect(reportQueries.updateScrapeReport).toHaveBeenCalledWith(
+        mockDb,
+        48,
+        expect.objectContaining({
+          status: 'failed',
+          errors: [{ cinema_name: 'System', error: 'redis enqueue failed' }],
+        })
+      );
+    });
+
     it('should attach org observability context to queued job metadata', async () => {
       const mockPublish = vi.fn().mockResolvedValue(1);
       vi.mocked(redisClient.getRedisClient).mockReturnValue({ publishJob: mockPublish } as any);
@@ -173,6 +191,24 @@ describe('ScraperService', () => {
           pendingAttempts: [],
         },
       }));
+    });
+
+    it('should mark the resume report failed when queue publish exhausts retry attempts', async () => {
+      const publishError = new Error('redis enqueue failed');
+      const mockPublish = vi.fn().mockRejectedValue(publishError);
+      vi.mocked(redisClient.getRedisClient).mockReturnValue({ publishJob: mockPublish } as any);
+      vi.mocked(reportQueries.createScrapeReport).mockResolvedValue(49 as any);
+
+      await expect(scraperService.triggerResume(123, [])).rejects.toThrow('redis enqueue failed');
+
+      expect(reportQueries.updateScrapeReport).toHaveBeenCalledWith(
+        mockDb,
+        49,
+        expect.objectContaining({
+          status: 'failed',
+          errors: [{ cinema_name: 'System', error: 'redis enqueue failed' }],
+        })
+      );
     });
 
     it('should attach org observability context on resume jobs', async () => {

--- a/server/src/services/scraper-service.ts
+++ b/server/src/services/scraper-service.ts
@@ -1,6 +1,6 @@
 import { getRedisClient } from './redis-client.js';
 import { progressTracker } from './progress-tracker.js';
-import { createScrapeReport, getLatestScrapeReport } from '../db/report-queries.js';
+import { createScrapeReport, getLatestScrapeReport, updateScrapeReport } from '../db/report-queries.js';
 import { getCinemas } from '../db/cinema-queries.js';
 import type { DB } from '../db/client.js';
 import { logger } from '../utils/logger.js';
@@ -98,16 +98,31 @@ export class ScraperService {
 
     const traceContext = this.buildTraceContext(context);
 
-    const queueDepth = await getRedisClient().publishJob({
-      type: 'scrape',
-      reportId,
-      triggerType: 'manual',
-      options: {
-        ...(cinemaId && { cinemaId }),
-        ...(filmId && { filmId }),
-      },
-      ...(traceContext && { traceContext }),
-    });
+    let queueDepth: number;
+    try {
+      queueDepth = await getRedisClient().publishJob({
+        type: 'scrape',
+        reportId,
+        triggerType: 'manual',
+        options: {
+          ...(cinemaId && { cinemaId }),
+          ...(filmId && { filmId }),
+        },
+        ...(traceContext && { traceContext }),
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      try {
+        await updateScrapeReport(this.db, reportId, {
+          status: 'failed',
+          completed_at: new Date().toISOString(),
+          errors: [{ cinema_name: 'System', error: errorMessage }],
+        });
+      } catch {
+        // Ignore report update failure and surface the original enqueue error.
+      }
+      throw error;
+    }
 
     return { reportId, queueDepth };
   }
@@ -131,16 +146,31 @@ export class ScraperService {
 
     const traceContext = this.buildTraceContext(context);
 
-    const queueDepth = await getRedisClient().publishJob({
-      type: 'scrape',
-      reportId,
-      triggerType: 'manual',
-      options: {
-        resumeMode: true,
-        pendingAttempts: pendingList,
-      },
-      ...(traceContext && { traceContext }),
-    });
+    let queueDepth: number;
+    try {
+      queueDepth = await getRedisClient().publishJob({
+        type: 'scrape',
+        reportId,
+        triggerType: 'manual',
+        options: {
+          resumeMode: true,
+          pendingAttempts: pendingList,
+        },
+        ...(traceContext && { traceContext }),
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      try {
+        await updateScrapeReport(this.db, reportId, {
+          status: 'failed',
+          completed_at: new Date().toISOString(),
+          errors: [{ cinema_name: 'System', error: errorMessage }],
+        });
+      } catch {
+        // Ignore report update failure and surface the original enqueue error.
+      }
+      throw error;
+    }
 
     return { reportId, queueDepth };
   }


### PR DESCRIPTION
## Summary
- use one shared Redis backoff helper for server enqueue retries and scraper consumer retries
- keep retrying Redis requeue and DLQ persistence so jobs popped by the consumer are not silently lost on transient write failures
- add focused timer-based coverage for exact retry delays, terminal DLQ handoff, and enqueue failure report updates

## Testing
- cd server && npm run test:run -- src/services/redis-client.test.ts src/services/scraper-service.test.ts
- cd scraper && npm run test:run -- src/redis/client.test.ts

Closes #905