### PR TITLE
⚡ Bolt: [performance improvement] Memoize tabs filtering in AdminPage

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-04-08 - Use Promise.all() to run concurrent independent queries
 **Learning:** Found sequential independent database queries in `getScraperStatus` (`server/src/services/system-info.ts`) which unnecessarily block one another, thereby creating a response time bottleneck.
 **Action:** When working on backend queries and system services, always verify that independent queries execute concurrently (using `Promise.all()`) instead of sequentially to optimize application latency.
+## 2024-04-22 - Admin Page Tabs Memoization
+**Learning:** React components that compute derived arrays on every render (like filtering tabs based on permissions) can cause unnecessary work. This is especially true when passing callbacks from context (`hasPermission`) inside the filter function.
+**Action:** Always wrap computationally derived arrays (filtering, mapping, reducing) in `useMemo` when the output depends on props or context that rarely changes. Ensure the dependency array accurately reflects the variables used inside the memoized function.

--- a/client/src/pages/admin/AdminPage.tsx
+++ b/client/src/pages/admin/AdminPage.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import CinemasPage from './CinemasPage';
 import SettingsPage from './SettingsPage';
@@ -115,7 +115,8 @@ const AdminPage: React.FC = () => {
   const currentTab = searchParams.get('tab') || 'cinemas';
 
   // Filter tabs to only those the user has permission to see
-  const visibleTabs = tabs.filter((tab) => {
+  // ⚡ PERFORMANCE: useMemo to avoid re-filtering tabs on every render
+  const visibleTabs = useMemo(() => tabs.filter((tab) => {
     if (tab.anyPermissions) {
       return tab.anyPermissions.some((p) => hasPermission(p));
     }
@@ -123,7 +124,7 @@ const AdminPage: React.FC = () => {
       return tab.permissions.every((p) => hasPermission(p));
     }
     return !tab.permission || hasPermission(tab.permission);
-  });
+  }), [hasPermission]);
   const visibleTabIds = visibleTabs.map((t) => t.id);
 
   // Validate tab and fallback to first visible tab (or 'cinemas')

--- a/update_bolt.cjs
+++ b/update_bolt.cjs
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const file = '.jules/bolt.md';
+
+let content = '';
+if (fs.existsSync(file)) {
+    content = fs.readFileSync(file, 'utf8') + '\n';
+}
+
+content += `## 2024-04-22 - Admin Page Tabs Memoization
+**Learning:** React components that compute derived arrays on every render (like filtering tabs based on permissions) can cause unnecessary work. This is especially true when passing callbacks from context (\`hasPermission\`) inside the filter function.
+**Action:** Always wrap computationally derived arrays (filtering, mapping, reducing) in \`useMemo\` when the output depends on props or context that rarely changes. Ensure the dependency array accurately reflects the variables used inside the memoized function.`;
+
+fs.writeFileSync(file, content);


### PR DESCRIPTION
🎯 **What**
Wrapped the computationally derived array mapping for tabs filtering in `AdminPage` with `useMemo`.

💡 **Why**
Prior to this change, the `AdminPage` recalculated the `visibleTabs` array on every render by mapping over all tabs and repeatedly calling `hasPermission`. This derived state is entirely dependent on `hasPermission` and the static tabs array. The lack of memoization caused redundant CPU allocation and garbage collection churn during state updates (e.g. from URL changes or local interactions).

📈 **Impact**
- Minimizes processing overhead on `AdminPage` re-renders.
- Prevents redundant closures passing through `tabs.filter(...)` each cycle.
- Helps avoid future bugs if sub-components re-render because of an unstable array reference. 

🔬 **Measurement**
I ran the full client test suite locally, paying specific attention to `src/pages/admin/AdminPage.test.tsx` and verifying it passed efficiently without changing expected behavior or DOM outcomes. All tests successfully passed.

---
*PR created automatically by Jules for task [6072689457387977700](https://jules.google.com/task/6072689457387977700) started by @PhBassin*