### PR TITLE
fix(server): prevent memory exhaustion in validateImage

### DIFF
--- a/server/src/utils/image-validator-security.test.ts
+++ b/server/src/utils/image-validator-security.test.ts
@@ -1,0 +1,15 @@
+
+import { describe, it, expect } from 'vitest';
+import { validateImage } from './image-validator.js';
+
+describe('validateImage - Security/Performance', () => {
+  it('should reject extremely large base64 strings before processing to prevent DoS', async () => {
+    // Create a string larger than the 2MB limit (e.g., 3MB)
+    const hugeString = 'a'.repeat(3 * 1024 * 1024);
+    
+    const result = await validateImage(hugeString, 'logo', 200000);
+    
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Image data exceeds maximum allowed input length');
+  });
+});

--- a/server/src/utils/image-validator.ts
+++ b/server/src/utils/image-validator.ts
@@ -9,6 +9,8 @@ export interface ImageValidationResult {
   compressedSize?: number;
 }
 
+const MAX_INPUT_LENGTH = 2 * 1024 * 1024; // 2MB limit for the input string
+
 /**
  * Validates and compresses an image
  * @param imageData - Base64 string (with or without data URL prefix)
@@ -26,6 +28,15 @@ export async function validateImage(
     return {
       valid: false,
       error: 'Image data is empty',
+    };
+  }
+
+  // SECURITY: Check input string length before any processing
+  // This prevents memory exhaustion via extremely large base64 strings
+  if (imageData.length > MAX_INPUT_LENGTH) {
+    return {
+      valid: false,
+      error: 'Image data exceeds maximum allowed input length',
     };
   }
 


### PR DESCRIPTION
## Summary
- Added a 2MB limit to the input base64 string in  to prevent memory exhaustion and CPU spikes (DoS).
- Added a security test case to verify this limit.

Closes #813