### PR TITLE
fix(server): allow base64 images to bypass maxStringLength validation

### DIFF
--- a/server/src/middleware/input-validation.test.ts
+++ b/server/src/middleware/input-validation.test.ts
@@ -80,4 +80,20 @@ describe('Middleware: validateInputSize', () => {
 
     expect(res.body.error).toContain('too many items');
   });
+
+  it('should allow long base64 strings if they are intended for image uploads', async () => {
+    app.use(express.json());
+    // Set a strict limit that would normally block a base64 image
+    app.post('/upload', validateInputSize({ maxStringLength: 100 }), (req, res) => {
+      res.status(200).json({ success: true });
+    });
+
+    const base64Image = 'data:image/png;base64,' + 'a'.repeat(1000); // 1000 chars > 100 limit
+    const res = await request(app)
+      .post('/upload')
+      .send({ image: base64Image })
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+  });
 });

--- a/server/src/middleware/input-validation.ts
+++ b/server/src/middleware/input-validation.ts
@@ -32,7 +32,9 @@ function validateObject(obj: any, limits: ValidationLimits, path: string = '', d
     const currentPath = path ? `${path}.${key}` : key;
 
     if (typeof value === 'string') {
-      if (limits.maxStringLength && value.length > limits.maxStringLength) {
+      // Allow long strings if they look like base64 images
+      const isBase64Image = value.startsWith('data:image/') && value.includes(';base64,');
+      if (!isBase64Image && limits.maxStringLength && value.length > limits.maxStringLength) {
         throw new ValidationError(`String parameter '${currentPath}' is too long (max ${limits.maxStringLength} chars)`, currentPath);
       }
     } else if (Array.isArray(value)) {


### PR DESCRIPTION
## Summary
- Updated  middleware to detect base64 image strings.
- Base64 images now bypass the  limit to prevent blocking valid image uploads.
- Added a regression test in .

Closes #814