### PR TITLE
fix(client): improve email validation and fix slug check race condition in RegisterPage

### DIFF
--- a/client/src/pages/RegisterPage.test.tsx
+++ b/client/src/pages/RegisterPage.test.tsx
@@ -114,6 +114,44 @@ describe('RegisterPage — step 1', () => {
       expect(screen.getByTestId('step-2')).toBeInTheDocument();
     });
   });
+
+  it('ignores stale slug check responses (race condition)', async () => {
+    // First call (slow) returns false for 'slow-slug'
+    // Second call (fast) returns true for 'fast-slug'
+    let callCount = 0;
+    vi.mocked(checkSlugAvailable).mockImplementation((slug: string) => {
+      callCount++;
+      if (slug === 'slow-slug') {
+        return new Promise((resolve) => setTimeout(() => resolve(false), 300));
+      }
+      return Promise.resolve(true);
+    });
+
+    renderPage();
+
+    // Type first slug (triggers slow check)
+    fireEvent.change(screen.getByTestId('input-slug'), { target: { value: 'slow-slug' } });
+
+    // Wait a bit then type second slug (triggers fast check)
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 100));
+    });
+
+    fireEvent.change(screen.getByTestId('input-slug'), { target: { value: 'fast-slug' } });
+
+    // Wait for fast check to resolve
+    await waitFor(() => {
+      expect(screen.getByTestId('slug-feedback')).toHaveTextContent(/available/i);
+    });
+
+    // Wait long enough for slow check to resolve too
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 400));
+    });
+
+    // Final state should still be 'available' (from fast check), not 'taken' (from slow check)
+    expect(screen.getByTestId('slug-feedback')).toHaveTextContent(/available/i);
+  });
 });
 
 describe('RegisterPage — step 2', () => {
@@ -147,6 +185,62 @@ describe('RegisterPage — step 2', () => {
   it('advances to step 3 with valid credentials', async () => {
     fireEvent.change(screen.getByTestId('input-admin-email'), {
       target: { value: 'admin@test.com' },
+    });
+    fireEvent.change(screen.getByTestId('input-admin-password'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByTestId('btn-step2-next'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('step-3')).toBeInTheDocument();
+    });
+  });
+
+  it('rejects email without @ symbol', async () => {
+    fireEvent.change(screen.getByTestId('input-admin-email'), {
+      target: { value: 'invalidemail.com' },
+    });
+    fireEvent.change(screen.getByTestId('input-admin-password'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByTestId('btn-step2-next'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/valid email address/i);
+    });
+  });
+
+  it('rejects email with only @ but no domain', async () => {
+    fireEvent.change(screen.getByTestId('input-admin-email'), {
+      target: { value: 'test@' },
+    });
+    fireEvent.change(screen.getByTestId('input-admin-password'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByTestId('btn-step2-next'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/valid email address/i);
+    });
+  });
+
+  it('rejects email with spaces', async () => {
+    fireEvent.change(screen.getByTestId('input-admin-email'), {
+      target: { value: 'test user@example.com' },
+    });
+    fireEvent.change(screen.getByTestId('input-admin-password'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByTestId('btn-step2-next'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/valid email address/i);
+    });
+  });
+
+  it('accepts a valid email address', async () => {
+    fireEvent.change(screen.getByTestId('input-admin-email'), {
+      target: { value: 'user.name+tag@example.co.uk' },
     });
     fireEvent.change(screen.getByTestId('input-admin-password'), {
       target: { value: 'password123' },

--- a/client/src/pages/RegisterPage.tsx
+++ b/client/src/pages/RegisterPage.tsx
@@ -69,6 +69,7 @@ const RegisterPage: React.FC = () => {
 
   // ── Async slug availability check (debounced 500 ms) ────────────────────
   const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{1,28}[a-z0-9]$/;
+  const lastCheckedSlugRef = React.useRef<string>('');
 
   const checkSlug = useCallback(
     (value: string) => {
@@ -77,9 +78,17 @@ const RegisterPage: React.FC = () => {
         return;
       }
       setSlugState('checking');
+      lastCheckedSlugRef.current = value;
       checkSlugAvailable(value)
-        .then((available) => setSlugState(available ? 'available' : 'taken'))
-        .catch(() => setSlugState('idle'));
+        .then((available) => {
+          // Ignore stale responses
+          if (value !== lastCheckedSlugRef.current) return;
+          setSlugState(available ? 'available' : 'taken');
+        })
+        .catch(() => {
+          if (value !== lastCheckedSlugRef.current) return;
+          setSlugState('idle');
+        });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []
@@ -120,7 +129,9 @@ const RegisterPage: React.FC = () => {
 
   const handleStep2Next = () => {
     setStep2Error('');
-    if (!adminEmail || !adminEmail.includes('@')) {
+    // RFC 5322 simplified regex for email validation
+    const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!adminEmail || !EMAIL_REGEX.test(adminEmail)) {
       setStep2Error('Please enter a valid email address.');
       return;
     }


### PR DESCRIPTION
## Summary
- Replace basic '@' check with RFC 5322 simplified regex for admin email validation
- Add lastCheckedSlugRef to ignore stale async responses in slug availability check
- Add unit tests covering email validation edge cases and race condition handling

Closes #770