### PR TITLE
⚡ Bolt: Optimize getScrapeReports by running queries concurrently

### DIFF
--- a/server/src/db/report-queries.ts
+++ b/server/src/db/report-queries.ts
@@ -127,22 +127,25 @@ export async function getScrapeReports(
 
   const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
-  // Get total count
-  const countResult = await db.query<{ count: string }>(
-    `SELECT COUNT(*) as count FROM scrape_reports ${whereClause}`,
-    params
-  );
-  const total = parseInt(countResult.rows[0].count);
+  // ⚡ PERFORMANCE: Execute independent database queries concurrently to prevent
+  // sequential execution bottlenecks and reduce total API response time.
+  const dataParams = [...params, limit, offset];
 
-  // Get paginated results
-  params.push(limit, offset);
-  const result = await db.query<ScrapeReport>(
-    `SELECT * FROM scrape_reports 
-     ${whereClause}
-     ORDER BY started_at DESC 
-     LIMIT $${paramIndex++} OFFSET $${paramIndex++}`,
-    params
-  );
+  const [countResult, result] = await Promise.all([
+    db.query<{ count: string }>(
+      `SELECT COUNT(*) as count FROM scrape_reports ${whereClause}`,
+      params
+    ),
+    db.query<ScrapeReport>(
+      `SELECT * FROM scrape_reports
+       ${whereClause}
+       ORDER BY started_at DESC
+       LIMIT $${paramIndex++} OFFSET $${paramIndex++}`,
+      dataParams
+    )
+  ]);
+
+  const total = parseInt(countResult.rows[0].count);
 
   return {
     reports: result.rows,


### PR DESCRIPTION
💡 What: Refactored the `getScrapeReports` function in `server/src/db/report-queries.ts` to execute its `COUNT(*)` and paginated `SELECT` queries concurrently using `Promise.all()` instead of sequentially.
🎯 Why: To eliminate a sequential execution bottleneck and reduce the overall response latency for fetching scrape reports.
📊 Impact: Expected to reduce the total API response time for fetching scrape reports.
🔬 Measurement: Verified that tests pass via `npm run test -w server` and that logic functions properly.

---
*PR created automatically by Jules for task [17879076368128755344](https://jules.google.com/task/17879076368128755344) started by @PhBassin*