### PR TITLE
fix(saas): resolveTenant releases database client prematurely

### DIFF
--- a/packages/saas/src/middleware/tenant.test.ts
+++ b/packages/saas/src/middleware/tenant.test.ts
@@ -172,4 +172,60 @@ describe('resolveTenant', () => {
 
     expect(client.release).toHaveBeenCalled();
   });
+
+  it('does not release client until response finishes', async () => {
+    const { EventEmitter } = await import('events');
+    const org = { id: 1, slug: 'acme', schema_name: 'org_acme', status: 'active' };
+    const client = {
+      query: vi.fn().mockResolvedValue({ rows: [org], rowCount: 1 }),
+      release: vi.fn(),
+    };
+    const pool = { connect: vi.fn().mockResolvedValue(client) };
+    const req = makeReq('acme', pool);
+    const res = new EventEmitter() as any;
+    res.statusCode = 200;
+    res.status = vi.fn().mockReturnValue(res);
+    res.json = vi.fn().mockReturnValue(res);
+    const next = vi.fn().mockResolvedValue(undefined);
+
+    const { resolveTenant } = await import('./tenant.js');
+    const promise = resolveTenant(req as unknown as Request, res as unknown as Response, next as unknown as NextFunction);
+
+    // Wait for middleware to complete
+    await promise;
+
+    // Client must NOT be released before response finish
+    expect(client.release).not.toHaveBeenCalled();
+
+    // Simulate response finishing
+    res.emit('finish');
+
+    // Now client should be released exactly once
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases client on response close if finish never fires', async () => {
+    const { EventEmitter } = await import('events');
+    const org = { id: 1, slug: 'acme', schema_name: 'org_acme', status: 'active' };
+    const client = {
+      query: vi.fn().mockResolvedValue({ rows: [org], rowCount: 1 }),
+      release: vi.fn(),
+    };
+    const pool = { connect: vi.fn().mockResolvedValue(client) };
+    const req = makeReq('acme', pool);
+    const res = new EventEmitter() as any;
+    res.statusCode = 200;
+    res.status = vi.fn().mockReturnValue(res);
+    res.json = vi.fn().mockReturnValue(res);
+    const next = vi.fn().mockResolvedValue(undefined);
+
+    const { resolveTenant } = await import('./tenant.js');
+    await resolveTenant(req as unknown as Request, res as unknown as Response, next as unknown as NextFunction);
+
+    expect(client.release).not.toHaveBeenCalled();
+
+    res.emit('close');
+
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/saas/src/middleware/tenant.ts
+++ b/packages/saas/src/middleware/tenant.ts
@@ -34,33 +34,52 @@ export async function resolveTenant(
     }
   };
 
+  const org = await getOrgBySlug(client, slug);
+
+  if (!org) {
+    releaseOnce();
+    res.status(404).json({ success: false, error: 'Organization not found' });
+    return;
+  }
+
+  if (!ACTIVE_STATUSES.has(org.status)) {
+    releaseOnce();
+    res.status(403).json({ success: false, error: `Organization is ${org.status}` });
+    return;
+  }
+
+  // Scope all subsequent queries to the org's schema.
+  // NOTE: PostgreSQL does not support $1 parameterized form for SET commands.
+  // The schema name is safe: slugs are validated to [a-z0-9-] and converted
+  // to [a-z0-9_] by slugToSchemaName, making SQL injection impossible.
+  await client.query(`SET search_path TO "${org.schema_name}", public`);
+
+  req.org = org;
+  req.dbClient = client;
+
+  if (typeof res.on === 'function') {
+    res.on('finish', releaseOnce);
+    res.on('close', releaseOnce);
+  }
+
+  let nextResult: ReturnType<NextFunction>;
+
   try {
-    const org = await getOrgBySlug(client, slug);
+    nextResult = next();
+  } catch (error) {
+    releaseOnce();
+    next(error);
+    return;
+  }
 
-    if (!org) {
-      releaseOnce();
-      res.status(404).json({ success: false, error: 'Organization not found' });
-      return;
-    }
+  try {
+    await nextResult;
+  } catch (error) {
+    releaseOnce();
+    throw error;
+  }
 
-    if (!ACTIVE_STATUSES.has(org.status)) {
-      releaseOnce();
-      res.status(403).json({ success: false, error: `Organization is ${org.status}` });
-      return;
-    }
-
-    // Scope all subsequent queries to the org's schema.
-    // NOTE: PostgreSQL does not support $1 parameterized form for SET commands.
-    // The schema name is safe: slugs are validated to [a-z0-9-] and converted
-    // to [a-z0-9_] by slugToSchemaName, making SQL injection impossible.
-    await client.query(`SET search_path TO "${org.schema_name}", public`);
-
-    req.org = org;
-    req.dbClient = client;
-
-    await next();
-  } finally {
-    // Always release the client back to the pool (no-op if already released above)
+  if (typeof res.on !== 'function') {
     releaseOnce();
   }
 }


### PR DESCRIPTION
## Summary

Fixes issue where the `resolveTenant` middleware released the PostgreSQL client back to the pool immediately after `next()` returned, while downstream route handlers might still be executing asynchronous queries.

## Changes

- Replaced try...finally immediate release with response event-based release (`finish` / `close`)
- Preserved immediate release for early-return paths (404 org not found, 403 org suspended)
- Preserved immediate release when `next()` throws synchronously
- Added graceful fallback for environments where `res.on` is unavailable

## Tests

- Added 2 new tests verifying client is only released after response finishes
- All 9 tenant middleware tests pass

Closes #769