### PR TITLE
⚡ Bolt: Use Promise.all for concurrent independent DB queries in getScrapeReports

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2026-04-08 - Use Promise.all() to run concurrent independent queries
 **Learning:** Found sequential independent database queries in `getScraperStatus` (`server/src/services/system-info.ts`) which unnecessarily block one another, thereby creating a response time bottleneck.
 **Action:** When working on backend queries and system services, always verify that independent queries execute concurrently (using `Promise.all()`) instead of sequentially to optimize application latency.
+
+## 2026-04-25 - Use Promise.all for independent DB queries in paginated endpoints
+**Learning:** Sequential database operations like COUNT and SELECT in paginated queries (`getScrapeReports`) block execution, adding unnecessary latency to the request.
+**Action:** Always wrap independent db.query calls (like COUNT and SELECT data) in Promise.all and clone param arrays (e.g., `const dataParams = [...params, limit, offset]`) to safely execute them concurrently without state mutations.

--- a/server/src/db/report-queries.ts
+++ b/server/src/db/report-queries.ts
@@ -127,22 +127,25 @@ export async function getScrapeReports(
 
   const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
-  // Get total count
-  const countResult = await db.query<{ count: string }>(
-    `SELECT COUNT(*) as count FROM scrape_reports ${whereClause}`,
-    params
-  );
-  const total = parseInt(countResult.rows[0].count);
+  // ⚡ PERFORMANCE: Run independent count and paginated data queries concurrently
+  // Use a cloned params array to prevent race conditions during query execution.
+  const dataParams = [...params, limit, offset];
 
-  // Get paginated results
-  params.push(limit, offset);
-  const result = await db.query<ScrapeReport>(
-    `SELECT * FROM scrape_reports 
-     ${whereClause}
-     ORDER BY started_at DESC 
-     LIMIT $${paramIndex++} OFFSET $${paramIndex++}`,
-    params
-  );
+  const [countResult, result] = await Promise.all([
+    db.query<{ count: string }>(
+      `SELECT COUNT(*) as count FROM scrape_reports ${whereClause}`,
+      params
+    ),
+    db.query<ScrapeReport>(
+      `SELECT * FROM scrape_reports
+       ${whereClause}
+       ORDER BY started_at DESC
+       LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+      dataParams
+    )
+  ]);
+
+  const total = parseInt(countResult.rows[0].count);
 
   return {
     reports: result.rows,


### PR DESCRIPTION
🎯 **What**
Refactored the `getScrapeReports` paginated query logic to run the `COUNT(*)` operation concurrently with the paginated `SELECT` query using `Promise.all`. Cloned the parameters array for the `SELECT` query to prevent concurrent data manipulation issues.

💡 **Why**
Sequential execution of the row count query and the data selection query adds unnecessary round-trip latency to the database. By firing them simultaneously, we can significantly reduce the overall response time of this API endpoint.

📊 **Impact**
Eliminates one sequential blocking database round-trip, potentially speeding up the `GET /api/reports` endpoint by around 30-50% depending on database network latency.

🔬 **Measurement**
Run the backend server and observe API latency when retrieving scrape reports in the application UI, or run `npm run test:run -w server -- src/routes/reports.test.ts` to ensure it still functions perfectly.

---
*PR created automatically by Jules for task [3653635285286313833](https://jules.google.com/task/3653635285286313833) started by @PhBassin*