### PR TITLE
fix(server): add admin DLQ API endpoints (Story 2.6)

### DIFF
--- a/packages/saas/src/routes/org.ts
+++ b/packages/saas/src/routes/org.ts
@@ -27,6 +27,8 @@ import filmsRouter from 'allo-scrapper-server/dist/routes/films.js';
 import reportsRouter from 'allo-scrapper-server/dist/routes/reports.js';
 // @ts-ignore
 import scraperRouter from 'allo-scrapper-server/dist/routes/scraper.js';
+// @ts-ignore
+import dlqRouter from 'allo-scrapper-server/dist/routes/admin/dlq.js';
 
 // ── SaaS-specific route handlers ────────────────────────────────────────────
 import orgSettingsRouter from './org-settings.js';
@@ -112,6 +114,9 @@ export function createOrgRouter(): Router {
   // ── Scraper ─────────────────────────────────────────────────────────────────
   router.post('/scraper/trigger', protectedLimiter, requireAuth as any, checkQuota('scrapes') as any);
   router.use('/scraper', protectedLimiter, scraperRouter);
+
+  // ── Admin DLQ (tenant-scoped) ────────────────────────────────────────────────
+  router.use('/admin/dlq', protectedLimiter, requireAuth as any, dlqRouter);
 
   // ── Org Settings ────────────────────────────────────────────────────────────
   router.use('/settings', protectedLimiter, orgSettingsRouter);

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -74,6 +74,7 @@ import usersRouter from './routes/users.js';
 import systemRouter from './routes/system.js';
 import rolesRouter from './routes/roles.js';
 import rateLimitsRouter from './routes/admin/rate-limits.js';
+import dlqRouter from './routes/admin/dlq.js';
 import configRouter from './routes/config.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -135,6 +136,7 @@ export function createApp() {
   app.use('/api/system', systemRouter);
   app.use('/api/roles', rolesRouter);
   app.use('/api/admin/rate-limits', rateLimitsRouter);
+  app.use('/api/admin/dlq', dlqRouter);
   app.use('/api/config', configRouter);
 
   // Health check endpoint with database connectivity check

--- a/server/src/routes/admin/dlq.test.ts
+++ b/server/src/routes/admin/dlq.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import type { DB } from '../../db/client.js';
+
+// Mock dependencies BEFORE importing the router
+vi.mock('../../utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+vi.mock('../../middleware/auth.js', () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (req.headers.authorization === 'Bearer valid-token') {
+      req.user = { id: 1, username: 'admin', role_name: 'admin', is_system_role: true, org_id: undefined };
+      next();
+    } else {
+      res.status(401).json({ success: false, error: 'Unauthorized' });
+    }
+  },
+}));
+vi.mock('../../middleware/rate-limit.js', () => ({
+  protectedLimiter: (req: any, res: any, next: any) => next(),
+}));
+vi.mock('../../middleware/permission.js', () => ({
+  requirePermission: (..._perms: string[]) => (req: any, res: any, next: any) => next(),
+}));
+
+const mockListDlqJobs = vi.fn();
+const mockGetDlqJobById = vi.fn();
+const mockRetryDlqJob = vi.fn();
+
+vi.mock('../../services/redis-client.js', () => ({
+  getRedisClient: () => ({
+    listDlqJobs: mockListDlqJobs,
+    getDlqJobById: mockGetDlqJobById,
+    retryDlqJob: mockRetryDlqJob,
+  }),
+}));
+
+// Import router AFTER mocks are set up
+import dlqRouter from './dlq.js';
+import { errorHandler } from '../../middleware/error-handler.js';
+
+describe('Routes - Admin - DLQ (Dead-Letter Queue)', () => {
+  let app: express.Application;
+  const mockDb: DB = {
+    query: vi.fn(),
+  } as unknown as DB;
+
+  const mockDlqJob = {
+    job_id: 'report-42',
+    failure_reason: 'Redis connection timeout',
+    retry_count: 3,
+    timestamp: '2026-04-26T10:00:00.000Z',
+    cinema_id: 'cinema-1',
+    org_id: 'org-1',
+    org_slug: 'acme',
+    user_id: 'user-1',
+    endpoint: '/api/scraper/trigger',
+    job: {
+      type: 'scrape' as const,
+      triggerType: 'manual' as const,
+      reportId: 42,
+      retryCount: 3,
+      options: { mode: 'weekly' as const, cinemaId: 'cinema-1' },
+    },
+  };
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.set('db', mockDb);
+    app.use('/api/admin/dlq', dlqRouter);
+    app.use(errorHandler);
+
+    vi.clearAllMocks();
+  });
+
+  describe('GET /api/admin/dlq/jobs', () => {
+    it('should return paginated DLQ jobs sorted by failed_at descending', async () => {
+      mockListDlqJobs.mockResolvedValue({
+        jobs: [
+          { job_id: 'report-2', timestamp: '2026-04-26T11:00:00.000Z', failure_reason: 'timeout', retry_count: 3, job: { reportId: 2, retryCount: 0 } },
+          { job_id: 'report-1', timestamp: '2026-04-26T10:00:00.000Z', failure_reason: 'error', retry_count: 3, job: { reportId: 1, retryCount: 0 } },
+        ],
+        total: 2,
+        page: 1,
+        pageSize: 20,
+      });
+
+      const response = await request(app)
+        .get('/api/admin/dlq/jobs?page=1&pageSize=20')
+        .set('Authorization', 'Bearer valid-token')
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.jobs).toHaveLength(2);
+      expect(response.body.data.jobs[0].job_id).toBe('report-2');
+      expect(response.body.data.total).toBe(2);
+      expect(response.body.data.page).toBe(1);
+      expect(response.body.data.pageSize).toBe(20);
+    });
+
+    it('should use default pagination (page=1, pageSize=20) when not provided', async () => {
+      mockListDlqJobs.mockResolvedValue({
+        jobs: [mockDlqJob],
+        total: 1,
+        page: 1,
+        pageSize: 20,
+      });
+
+      const response = await request(app)
+        .get('/api/admin/dlq/jobs')
+        .set('Authorization', 'Bearer valid-token')
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+    });
+
+    it('should enforce max page size of 100', async () => {
+      mockListDlqJobs.mockResolvedValue({
+        jobs: [],
+        total: 0,
+        page: 1,
+        pageSize: 100,
+      });
+
+      await request(app)
+        .get('/api/admin/dlq/jobs?page=1&pageSize=999')
+        .set('Authorization', 'Bearer valid-token')
+        .expect(200);
+    });
+
+    it('should return empty list when DLQ is empty', async () => {
+      mockListDlqJobs.mockResolvedValue({
+        jobs: [],
+        total: 0,
+        page: 1,
+        pageSize: 20,
+      });
+
+      const response = await request(app)
+        .get('/api/admin/dlq/jobs')
+        .set('Authorization', 'Bearer valid-token')
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.jobs).toHaveLength(0);
+      expect(response.body.data.total).toBe(0);
+    });
+  });
+
+  describe('GET /api/admin/dlq/jobs/:jobId', () => {
+    it('should return full DLQ job details including complete payload', async () => {
+      mockGetDlqJobById.mockResolvedValue(mockDlqJob);
+
+      const response = await request(app)
+        .get('/api/admin/dlq/jobs/report-42')
+        .set('Authorization', 'Bearer valid-token')
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.job_id).toBe('report-42');
+      expect(response.body.data.failure_reason).toBe('Redis connection timeout');
+      expect(response.body.data.job).toBeDefined();
+      expect(response.body.data.retry_count).toBe(3);
+    });
+
+    it('should return 404 when DLQ job does not exist', async () => {
+      mockGetDlqJobById.mockResolvedValue(null);
+
+      const response = await request(app)
+        .get('/api/admin/dlq/jobs/nonexistent-job')
+        .set('Authorization', 'Bearer valid-token')
+        .expect(404);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toContain('DLQ job not found');
+    });
+  });
+
+  describe('POST /api/admin/dlq/jobs/:jobId/retry', () => {
+    it('should requeue a DLQ job and return 202 Accepted', async () => {
+      mockRetryDlqJob.mockResolvedValue({
+        job_id: 'report-42',
+        retry_count: 0,
+        job: { type: 'scrape', triggerType: 'manual', reportId: 42, retryCount: 0 },
+      });
+
+      const response = await request(app)
+        .post('/api/admin/dlq/jobs/report-42/retry')
+        .set('Authorization', 'Bearer valid-token')
+        .expect(202);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.job_id).toBe('report-42');
+      expect(response.body.data.retry_count).toBe(0);
+    });
+
+    it('should return 404 when retrying a non-existent DLQ job', async () => {
+      mockRetryDlqJob.mockResolvedValue(null);
+
+      const response = await request(app)
+        .post('/api/admin/dlq/jobs/missing-job/retry')
+        .set('Authorization', 'Bearer valid-token')
+        .expect(404);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toContain('DLQ job not found');
+    });
+  });
+
+  describe('Authentication (AC: 4)', () => {
+    it('should return 401 for GET /api/admin/dlq/jobs without auth', async () => {
+      const response = await request(app)
+        .get('/api/admin/dlq/jobs')
+        .expect(401);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toBe('Unauthorized');
+    });
+
+    it('should return 401 for GET /api/admin/dlq/jobs/:jobId without auth', async () => {
+      const response = await request(app)
+        .get('/api/admin/dlq/jobs/report-42')
+        .expect(401);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toBe('Unauthorized');
+    });
+
+    it('should return 401 for POST /api/admin/dlq/jobs/:jobId/retry without auth', async () => {
+      const response = await request(app)
+        .post('/api/admin/dlq/jobs/report-42/retry')
+        .expect(401);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toBe('Unauthorized');
+    });
+  });
+});

--- a/server/src/routes/admin/dlq.ts
+++ b/server/src/routes/admin/dlq.ts
@@ -1,0 +1,110 @@
+import express, { Response, NextFunction } from 'express';
+import { requireAuth, type AuthRequest } from '../../middleware/auth.js';
+import { requirePermission } from '../../middleware/permission.js';
+import { protectedLimiter } from '../../middleware/rate-limit.js';
+import { getRedisClient } from '../../services/redis-client.js';
+import type { ApiResponse } from '../../types/api.js';
+import { NotFoundError, ValidationError } from '../../utils/errors.js';
+import { parseStrictInt } from '../../utils/number.js';
+import { logger } from '../../utils/logger.js';
+
+const router = express.Router();
+
+/**
+ * GET /api/admin/dlq/jobs
+ * List dead-letter queue jobs with pagination.
+ * Returns jobs sorted by failed_at timestamp descending.
+ */
+router.get('/jobs', protectedLimiter, requireAuth, requirePermission('scraper:trigger'), async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const page = parseStrictInt(req.query.page);
+    const pageSize = parseStrictInt(req.query.pageSize);
+    const normalizedPage = Number.isNaN(page) ? 1 : Math.max(1, page);
+    const normalizedPageSize = Number.isNaN(pageSize) ? 20 : Math.min(Math.max(1, pageSize), 100);
+
+    const result = await getRedisClient().listDlqJobs(
+      normalizedPageSize,
+      normalizedPage,
+      req.user?.is_system_role ? undefined : req.user?.org_id,
+    );
+
+    const response: ApiResponse = {
+      success: true,
+      data: result,
+    };
+
+    res.json(response);
+  } catch (error) {
+    next(error);
+  }
+});
+
+/**
+ * GET /api/admin/dlq/jobs/:jobId
+ * Get full details for a specific DLQ job.
+ * Returns the complete original payload and failure context.
+ */
+router.get('/jobs/:jobId', protectedLimiter, requireAuth, requirePermission('scraper:trigger'), async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const jobId = typeof req.params.jobId === 'string' ? req.params.jobId : undefined;
+    if (!jobId) {
+      return next(new ValidationError('Invalid DLQ job ID'));
+    }
+
+    const entry = await getRedisClient().getDlqJobById(
+      jobId,
+      req.user?.is_system_role ? undefined : req.user?.org_id,
+    );
+
+    if (!entry) {
+      return next(new NotFoundError('DLQ job not found'));
+    }
+
+    const response: ApiResponse = {
+      success: true,
+      data: entry,
+    };
+
+    res.json(response);
+  } catch (error) {
+    next(error);
+  }
+});
+
+/**
+ * POST /api/admin/dlq/jobs/:jobId/retry
+ * Requeue a dead-lettered job back to the main scraper queue.
+ * Returns 202 Accepted with the republished job details.
+ */
+router.post('/jobs/:jobId/retry', protectedLimiter, requireAuth, requirePermission('scraper:trigger'), async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const jobId = typeof req.params.jobId === 'string' ? req.params.jobId : undefined;
+    if (!jobId) {
+      return next(new ValidationError('Invalid DLQ job ID'));
+    }
+
+    const retried = await getRedisClient().retryDlqJob(
+      jobId,
+      req.user?.is_system_role ? undefined : req.user?.org_id,
+    );
+
+    if (!retried) {
+      return next(new NotFoundError('DLQ job not found'));
+    }
+
+    logger.info('[Admin DLQ] Job retried from DLQ', {
+      job_id: retried.job_id,
+      user_id: req.user?.id,
+      org_id: req.user?.org_id,
+    });
+
+    res.status(202).json({
+      success: true,
+      data: retried,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/server/src/services/redis-client.ts
+++ b/server/src/services/redis-client.ts
@@ -170,6 +170,21 @@ export class RedisClient {
     };
   }
 
+  async getDlqJobById(jobId: string, orgId?: number): Promise<DlqJobEntry | null> {
+    const entries = await this.publisher.zrevrange(SCRAPE_DLQ_KEY, 0, -1);
+    for (const item of entries) {
+      try {
+        const entry = JSON.parse(item) as DlqJobEntry;
+        if (entry.job_id === jobId && matchesDlqOrg(entry, orgId)) {
+          return entry;
+        }
+      } catch {
+        continue;
+      }
+    }
+    return null;
+  }
+
   async retryDlqJob(jobId: string, orgId?: number): Promise<DlqJobEntry | null> {
     const entries = await this.publisher.zrevrange(SCRAPE_DLQ_KEY, 0, -1);
     const rawEntry = entries.find((item: string) => {


### PR DESCRIPTION
## Summary
Implements Story 2.6 (DLQ API Endpoints) to complete Epic 2. Adds admin-scoped REST API endpoints under `/api/admin/dlq/*` for querying and managing dead-letter queue jobs.

## Endpoints Added
- **GET** `/api/admin/dlq/jobs` — Paginated list of DLQ jobs (newest first, default limit=20, max=100)
- **GET** `/api/admin/dlq/jobs/:jobId` — Full DLQ job details including complete original payload
- **POST** `/api/admin/dlq/jobs/:jobId/retry` — Republish a DLQ job back to main queue (202 Accepted)

## Architecture
- Standalone: mounted at `/api/admin/dlq/*` via `app.ts`
- SaaS: mounted at `/api/org/:slug/admin/dlq/*` via `packages/saas/src/routes/org.ts` (tenant-scoped)
- Auth via `requireAuth` + `requirePermission('scraper:trigger')` like existing admin DLQ endpoints
- Reuses existing Redis key structure (`scrape:jobs:dlq`) from PR #904

## New Files
- `server/src/routes/admin/dlq.ts` — Route handlers
- `server/src/routes/admin/dlq.test.ts` — 11 unit tests (paginated list, single job, retry, auth guards)

## Modified Files
- `server/src/app.ts` — Mount DLQ admin router
- `server/src/services/redis-client.ts` — Added `getDlqJobById()` method for single job lookup
- `packages/saas/src/routes/org.ts` — Mount tenant-scoped DLQ router

Closes #667
