### PR TITLE
fix(server): accept trailing slash on DLQ admin alias

### DIFF
--- a/_bmad-output/implementation-artifacts/2-6-dlq-api-endpoints-api-only-no-ui.md
+++ b/_bmad-output/implementation-artifacts/2-6-dlq-api-endpoints-api-only-no-ui.md
@@ -1,6 +1,6 @@
 # Story 2.6: Dead-Letter Queue API Endpoints (API-only, no UI)
 
-Status: review
+Status: done
 
 <!-- Note: Corrected by bmad-correct-course 2026-04-26. See sprint-change-proposal-2026-04-26.md for full rationale. -->
 
@@ -122,6 +122,11 @@ so that admins have programmatic visibility into failed scrape jobs without need
 ### Completion Notes
 
 All tasks and subtasks complete. 835 tests pass, TypeScript strict-mode clean. Story moved to `review`.
+
+### Review Findings
+
+- [x] [Review][Patch] Admin DLQ alias rejects trailing-slash forms that the canonical routes accept [server/src/app.ts:90]
+- [x] [Review][Defer] DLQ single-job lookup depends on `job_id = report-${reportId}`, which is only safe while `scrape_reports.id` remains globally unique across all tenants [server/src/routes/scraper.ts:253] — deferred, pre-existing
 
 ## File List
 

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -5,3 +5,7 @@
 ## Deferred from: code review of 1-1-implement-org-id-validation-middleware (2026-04-17)
 
 - `server/src/routes/cinemas.ts:147` — Org-scoped cinema detail route remains public and may expose tenant data if not separately guarded; deferred as pre-existing route-policy issue outside this story slice.
+
+## Deferred from: code review of 2-6-dlq-api-endpoints-api-only-no-ui (2026-04-28)
+
+- `server/src/routes/scraper.ts:253` — DLQ single-job lookup keys on `job_id = report-${reportId}`. This is safe with the current globally incrementing `scrape_reports.id`, but it would become ambiguous if report IDs ever stop being globally unique across tenants; deferred as a pre-existing identifier design constraint.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-15
-# last_updated: 2026-04-26T01:05:00Z
+# last_updated: 2026-04-28T09:23:00Z
 # project: allo-scrapper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -28,7 +28,7 @@
 #   - done: Retrospective has been completed
 
 generated: 2026-04-15
-last_updated: 2026-04-26T01:05:00Z
+last_updated: 2026-04-28T09:23:00Z
 project: allo-scrapper
 project_key: NOKEY
 tracking_system: file-system
@@ -69,7 +69,7 @@ development_status:
   2-3-redis-job-queue-load-testing-100-concurrent-jobs: done      # branch test/story-2-3-redis-load
   2-4-redis-reconnection-handling-during-job-processing: done     # PR #919 — "harden Redis reconnect recovery"
   2-5-e2e-scraper-progress-tracking-with-10-concurrent-jobs: done # PR #921 — "track tenant scrape progress by job"
-  2-6-dlq-api-endpoints-api-only-no-ui: review
+  2-6-dlq-api-endpoints-api-only-no-ui: done
   epic-2-retrospective: optional
 
   # ─────────────────────────────────────────────────────────────

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -87,7 +87,7 @@ collectDefaultMetrics({ register: serverRegistry, prefix: 'ics_web_' });
 
 function createAdminScraperAliasRouter() {
   const router = express.Router();
-  const allowedPathPattern = /^\/dlq(?:\/[^/]+(?:\/retry)?)?$/;
+  const allowedPathPattern = /^\/dlq(?:\/[^/]+(?:\/retry)?)?\/?$/;
 
   router.use((req, res, next) => {
     if (!allowedPathPattern.test(req.path)) {

--- a/server/src/routes/scraper.test.ts
+++ b/server/src/routes/scraper.test.ts
@@ -17,7 +17,7 @@ const mockGetDlqJob = vi.fn();
 
 function mountAdminScraperDlqAlias(app: express.Express, scraperRouter: express.Router) {
   const adminAliasRouter = express.Router();
-  const allowedPathPattern = /^\/dlq(?:\/[^/]+(?:\/retry)?)?$/;
+  const allowedPathPattern = /^\/dlq(?:\/[^/]+(?:\/retry)?)?\/?$/;
 
   adminAliasRouter.use((req, res, next) => {
     if (!allowedPathPattern.test(req.path)) {
@@ -481,6 +481,17 @@ describe('Routes - Scraper', () => {
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
       expect(response.body.data.job_id).toBe('report-3');
+    });
+
+    it('GET /api/admin/scraper/dlq/ should accept the same trailing-slash form as the canonical route', async () => {
+      mockListDlqJobs.mockResolvedValue({ jobs: [{ job_id: 'report-1' }], total: 1, page: 1, pageSize: 50 });
+
+      const app = await setupAppWithAlias({ role_name: 'admin', is_system_role: true, permissions: [] });
+      const response = await request(app).get('/api/admin/scraper/dlq/');
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.jobs[0].job_id).toBe('report-1');
     });
 
     it('GET /api/admin/scraper/status should remain unavailable', async () => {


### PR DESCRIPTION
## Summary
- accept trailing-slash variants on the `/api/admin/scraper/dlq*` alias so it matches the canonical DLQ route behavior
- add a route test covering `/api/admin/scraper/dlq/` and keep the BMAD story/sprint artifacts in sync after review completion
- record the deferred identifier-design note surfaced during code review

## Testing
- `cd server && npm run test:run -- src/routes/scraper.test.ts`

Closes #930