### PR TITLE
fix(server): trust localhost health probes through private hops

### DIFF
--- a/server/src/middleware/rate-limit.test.ts
+++ b/server/src/middleware/rate-limit.test.ts
@@ -463,5 +463,39 @@ describe('Rate Limiting Middleware', () => {
       expect(isTrustedLocalHealthProbe(spoofedLoopbackRequest)).toBe(false);
       expect(isTrustedLocalHealthProbe(proxiedExternalRequest)).toBe(false);
     });
+
+    it('should trust loopback probes forwarded through a private container hop', () => {
+      const dockerBridgeRequest = {
+        ip: '127.0.0.1',
+        headers: { 'x-forwarded-for': '127.0.0.1' },
+        socket: { remoteAddress: '172.18.0.5' },
+      } as express.Request;
+
+      const clusterSidecarRequest = {
+        ip: '::1',
+        headers: { 'x-forwarded-for': '::1' },
+        socket: { remoteAddress: '10.42.0.9' },
+      } as express.Request;
+
+      expect(isTrustedLocalHealthProbe(dockerBridgeRequest)).toBe(true);
+      expect(isTrustedLocalHealthProbe(clusterSidecarRequest)).toBe(true);
+    });
+
+    it('should reject forwarded chains that contain a non-loopback address', () => {
+      const spoofedForwardedChainRequest = {
+        ip: '127.0.0.1',
+        headers: { 'x-forwarded-for': '203.0.113.50, 127.0.0.1' },
+        socket: { remoteAddress: '172.18.0.5' },
+      } as express.Request;
+
+      const ipv6MappedBridgeRequest = {
+        ip: '127.0.0.1',
+        headers: { 'x-forwarded-for': '127.0.0.1' },
+        socket: { remoteAddress: '::ffff:172.18.0.5' },
+      } as express.Request;
+
+      expect(isTrustedLocalHealthProbe(spoofedForwardedChainRequest)).toBe(false);
+      expect(isTrustedLocalHealthProbe(ipv6MappedBridgeRequest)).toBe(true);
+    });
   });
 });

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -2,7 +2,17 @@ import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import jwt from 'jsonwebtoken';
 import type { Request } from 'express';
 
-const LOCALHOST_IPS = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
+const LOCALHOST_IPS = new Set(['127.0.0.1', '::1']);
+
+const PRIVATE_IP_PATTERNS = [
+  /^10\./,
+  /^192\.168\./,
+  /^172\.(1[6-9]|2\d|3[0-1])\./,
+  /^169\.254\./,
+  /^fc/i,
+  /^fd/i,
+  /^fe80:/i,
+];
 
 // Helper to parse env var as number with fallback
 const parseEnvInt = (key: string, defaultValue: number): number => {
@@ -79,11 +89,31 @@ export const authenticatedKeyGenerator = (req: Request): string => {
   return ipKeyGenerator(req.ip ?? 'unknown');
 };
 
-export const isTrustedLocalHealthProbe = (req: Request): boolean => {
-  const forwardedIp = req.ip ?? '';
-  const socketIp = req.socket.remoteAddress ?? '';
+const normalizeIp = (value: string): string => value.replace(/^::ffff:/, '');
 
-  return LOCALHOST_IPS.has(forwardedIp) && LOCALHOST_IPS.has(socketIp);
+const isLoopbackIp = (value: string): boolean => LOCALHOST_IPS.has(normalizeIp(value));
+
+const isPrivateIp = (value: string): boolean => PRIVATE_IP_PATTERNS.some((pattern) => pattern.test(normalizeIp(value)));
+
+export const isTrustedLocalHealthProbe = (req: Request): boolean => {
+  const forwardedIp = normalizeIp(req.ip ?? '');
+  const socketIp = normalizeIp(req.socket.remoteAddress ?? '');
+  const rawForwardedFor = req.headers?.['x-forwarded-for'];
+
+  const forwardedChain = (Array.isArray(rawForwardedFor) ? rawForwardedFor.join(',') : rawForwardedFor ?? '')
+    .split(',')
+    .map((value) => normalizeIp(value.trim()))
+    .filter(Boolean);
+
+  if (!isLoopbackIp(forwardedIp)) {
+    return false;
+  }
+
+  if (!(isLoopbackIp(socketIp) || isPrivateIp(socketIp))) {
+    return false;
+  }
+
+  return forwardedChain.every(isLoopbackIp);
 };
 
 // General API rate limiter (applies to all /api/* routes)


### PR DESCRIPTION
## Summary
- allow localhost health probes forwarded through trusted private container or sidecar hops
- keep rejecting spoofed forwarded chains that include any non-loopback address
- add targeted middleware coverage for the private-hop and spoofed-chain cases

## Testing
- `cd server && npm run test:run -- src/middleware/rate-limit.test.ts`

Follow-up to #933