### PR TITLE
⚡ Bolt: [performance improvement] optimize getScrapeReports concurrent execution

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,5 @@
 ## 2026-04-08 - Use Promise.all() to run concurrent independent queries
 **Learning:** Found sequential independent database queries in `getScraperStatus` (`server/src/services/system-info.ts`) which unnecessarily block one another, thereby creating a response time bottleneck.
-**Action:** When working on backend queries and system services, always verify that independent queries execute concurrently (using `Promise.all()`) instead of sequentially to optimize application latency.
+**Action:** When working on backend queries and system services, always verify that independent queries execute concurrently (using `Promise.all()`) instead of sequentially to optimize application latency.## 2026-04-09 - Use Promise.all() for sequential COUNT and SELECT queries
+**Learning:** Found sequential independent database queries in `getScrapeReports` (`server/src/db/report-queries.ts`) where a total count and paginated result were fetched sequentially.
+**Action:** When refactoring sequential Postgres database queries (like `COUNT(*)` and paginated `SELECT`s) to run concurrently via `Promise.all`, avoid mutating the shared `params` array. Instead, create a cloned array (e.g., `const dataParams = [...params, limit, offset]`) for the query requiring extra parameters to prevent race conditions and unintended query manipulation.

--- a/server/src/db/report-queries.ts
+++ b/server/src/db/report-queries.ts
@@ -127,22 +127,24 @@ export async function getScrapeReports(
 
   const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
-  // Get total count
-  const countResult = await db.query<{ count: string }>(
-    `SELECT COUNT(*) as count FROM scrape_reports ${whereClause}`,
-    params
-  );
-  const total = parseInt(countResult.rows[0].count);
+  // ⚡ PERFORMANCE: Execute independent database queries concurrently
+  // to reduce total response time. Avoid mutating shared params array.
+  const dataParams = [...params, limit, offset];
+  const [countResult, result] = await Promise.all([
+    db.query<{ count: string }>(
+      `SELECT COUNT(*) as count FROM scrape_reports ${whereClause}`,
+      params
+    ),
+    db.query<ScrapeReport>(
+      `SELECT * FROM scrape_reports
+       ${whereClause}
+       ORDER BY started_at DESC
+       LIMIT $${paramIndex++} OFFSET $${paramIndex++}`,
+      dataParams
+    )
+  ]);
 
-  // Get paginated results
-  params.push(limit, offset);
-  const result = await db.query<ScrapeReport>(
-    `SELECT * FROM scrape_reports 
-     ${whereClause}
-     ORDER BY started_at DESC 
-     LIMIT $${paramIndex++} OFFSET $${paramIndex++}`,
-    params
-  );
+  const total = parseInt(countResult.rows[0].count);
 
   return {
     reports: result.rows,


### PR DESCRIPTION
🎯 **What**: Refactored `getScrapeReports` in `server/src/db/report-queries.ts` to execute independent `COUNT(*)` and paginated `SELECT` queries concurrently using `Promise.all`.

💡 **Why**: These queries were previously executing sequentially, unnecessarily blocking one another and artificially increasing the total latency of fetching scrape reports.

📊 **Impact**: Reduces total database execution time for `/api/reports` by overlapping the execution of the count and search queries. Ensures the shared parameter array is not mutated to prevent race conditions.

🔬 **Measurement**: Verify by running `npm run test -w server -- --run src/db/report-queries.test.ts` to ensure query behavior remains identical, and observe reduced latency for fetching scrape reports.

---
*PR created automatically by Jules for task [6395760456552145132](https://jules.google.com/task/6395760456552145132) started by @PhBassin*