### PR TITLE
test(sse): validate long-running progress stream resume behavior

### DIFF
--- a/_bmad-output/implementation-artifacts/3-3-sse-long-running-connection-validation-10-minutes-validation-report.md
+++ b/_bmad-output/implementation-artifacts/3-3-sse-long-running-connection-validation-10-minutes-validation-report.md
@@ -1,0 +1,68 @@
+# Story Validation Report: 3-3-sse-long-running-connection-validation-10-minutes
+
+Validation Date: 2026-04-29T14:55:00Z  
+Story File: `_bmad-output/implementation-artifacts/3-3-sse-long-running-connection-validation-10-minutes.md`  
+Validator: OpenCode (`bmad-create-story` validate pass)
+
+## Validation Verdict
+
+Result: **PASS WITH FIXES APPLIED**
+
+The story is implementation-ready after applying targeted fixes around SSE ID persistence, replay helper compatibility, rate-limit-aware verification, and deterministic long-running E2E setup.
+
+## What Was Validated
+
+- Story structure completeness (story, ACs, tasks, dev notes, references, agent record)
+- Acceptance-criteria traceability into implementation and verification tasks
+- Alignment with Epic 3 ordering and completed prerequisites (`3.7`, `3.1`, `3.5`, `3.2`)
+- Alignment with current SSE architecture (`/api/scraper/progress`, `ScraperService.subscribeToProgress`, `ProgressTracker`, fetch-based `subscribeToProgress`)
+- Alignment with current Playwright/runtime constraints for scraper-heavy and fixture-backed tests
+
+## Issues Found and Fixed
+
+1. **SSE ID sequence could be reset accidentally with replay history**
+- Risk: `ProgressTracker.emit()` clears the replay buffer when a new `started` event begins a new scrape session. Without an explicit warning, a dev could couple event IDs to the replay array length and create duplicate `id:` values after history resets, breaking `Last-Event-ID` semantics.
+- Fix applied in story:
+  - Added tasks requiring event IDs to remain monotonic for the process lifetime or until `ProgressTracker.reset()`.
+  - Added current-code notes and pitfalls documenting the `started` replay-buffer reset.
+  - Added server regression requirements proving IDs do not reset when replay history clears.
+
+2. **Internal replay metadata could break `getEvents()` consumers**
+- Risk: Implementing replay metadata by changing `this.events` from `ProgressEvent[]` to wrapper objects would break existing tests/debug helpers and obscure the Story 3.1 guarantee that pings are not replayed.
+- Fix applied in story:
+  - Added a task requiring `ProgressTracker.getEvents()` to keep returning `ProgressEvent[]`.
+  - Added a current-code note and server regression requirement for preserving this helper contract.
+
+3. **Long-running E2E scenario could use fast-failing fixture cinemas**
+- Risk: `/test/seed-org` adds `example.test` cinemas that intentionally fail quickly. A dev could choose those as the only scrape targets and never validate a 10+ minute active stream.
+- Fix applied in story:
+  - Added explicit guidance to use tenant baseline cinemas copied from `server/src/config/cinemas.json` or otherwise seed/choose Allocine-backed cinemas.
+  - Added current-code notes explaining the distinction between baseline cinemas and fixture failure sentinels.
+
+4. **Default fixture runtime assertion conflicts with 10+ minute validation**
+- Risk: Existing fixture helper `assertFixtureRuntimeWithinLimit()` defaults to 120 seconds. Copying that pattern into this story would make a correct long-running test fail for the wrong reason.
+- Fix applied in story:
+  - Added a task and pitfall requiring the long-running spec to skip that default assertion or pass a custom max above the test timeout.
+
+5. **Reconnect validation could be invalidated by rate-limit defaults**
+- Risk: The SSE route is protected by `protectedLimiter`, and scrape trigger routes are guarded by scrape/protected limiters. A long-running reconnect test can consume multiple requests inside the same 15-minute window, creating false failures unrelated to SSE stability.
+- Fix applied in story:
+  - Added rate-limit-aware runtime guidance (`RATE_LIMIT_SCRAPER_MAX` and deliberate protected-limit handling).
+  - Added architecture and pitfall notes requiring test-only env overrides rather than weakening production defaults.
+
+## Coverage Check (Post-Fix)
+
+- AC #1 (10+ minute open stream): covered by deterministic Playwright task, worker/runtime setup, explicit timeout, active scrape target guidance, and no default 120s fixture limit.
+- AC #2 (30-second pings plus progress events): covered by server heartbeat inheritance from Story 3.1 and browser/client assertions on pings and stream status.
+- AC #3 (unique monotonic IDs and resume): covered by server ID/replay tests, route/service `Last-Event-ID` wiring, client parser/reconnect tests, and E2E forced-reconnect assertions.
+- Tenant isolation: covered by replay-after-ID tenant filtering tasks and explicit no-leak guardrails.
+- Regression risks from Story 3.1/3.2: covered by parser EOF/split UTF-8 regressions, state-preservation tasks, and no duplicate reconnect implementation guidance.
+
+## Ready-for-Dev Confirmation
+
+Status remains `ready-for-dev`.  
+No additional blocker found for moving to `bmad-dev-story`.
+
+## Recommended Next Step
+
+- Run `DS` (`bmad-dev-story`) for `3-3-sse-long-running-connection-validation-10-minutes`.

--- a/_bmad-output/implementation-artifacts/3-3-sse-long-running-connection-validation-10-minutes.md
+++ b/_bmad-output/implementation-artifacts/3-3-sse-long-running-connection-validation-10-minutes.md
@@ -1,0 +1,297 @@
+# Story 3.3: SSE Long-Running Connection Validation (10+ Minutes)
+
+Status: review
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a QA engineer,
+I want E2E tests that validate SSE connections remain stable for 10+ minute scrapes,
+so that long-running operations don't timeout or disconnect.
+
+## Acceptance Criteria
+
+1. **Given** a scrape is triggered that takes 10+ minutes
+   **When** the scrape is processing
+   **Then** the SSE connection remains open for the entire duration
+   **And** stream liveness frames are received at least every 30 seconds
+   **And** no connection timeouts occur
+
+2. **Given** a 10-minute scrape is running
+   **When** I monitor network activity
+   **Then** heartbeat pings are sent every 30 seconds
+   **And** progress events are sent whenever scrape progress changes
+   **And** the connection shows as open from the browser/client perspective
+
+3. **Given** the server sends progress events
+   **When** I inspect the event stream and force a reconnect
+   **Then** each replayable progress event has a unique SSE event ID
+   **And** event IDs are monotonically increasing
+   **And** the client resumes from the last event ID after reconnection
+
+## Tasks / Subtasks
+
+- [x] Add RED coverage for the SSE event ID and resume contract before long-running validation (AC: 3)
+  - [x] Extend `server/src/services/progress-tracker.test.ts` to prove replayable business progress frames are written with standard SSE `id:` lines and unique monotonically increasing IDs
+  - [x] Prove heartbeat `ping` frames remain transport-only and do not consume replay/resume IDs or pollute replay history
+  - [x] Prove `Last-Event-ID` replay returns only matching tenant events after the provided ID and never replays another tenant's progress
+  - [x] Extend `client/src/api/client.test.ts` to prove the fetch-based SSE parser captures `id:` fields and sends `Last-Event-ID` on reconnect
+  - [x] Add parser regressions for multi-line `data:` blocks and split UTF-8 chunks so the new ID parsing does not regress the EOF flush fixes from Story 3.1
+
+- [x] Implement the minimal SSE event ID/resume runtime support required by AC #3 (AC: 3)
+  - [x] Keep the existing `GET /api/scraper/progress` endpoint; do not add a second SSE route, WebSocket path, polling fallback, or unauthenticated stream
+  - [x] Add event IDs at the server streaming layer using standard SSE `id: <monotonic-id>` fields, not an ad hoc JSON-only ID that the stream parser cannot use for resume
+  - [x] Store enough replay metadata in `ProgressTracker` to replay business events after `Last-Event-ID` while preserving current tenant filtering and trace-context enrichment
+  - [x] Keep `ProgressTracker.getEvents()` returning `ProgressEvent[]` for existing debugging/tests; if replay metadata is stored internally, expose it only through a new private/internal structure rather than changing this public helper's shape
+  - [x] Keep event IDs monotonic for the process lifetime or until `ProgressTracker.reset()`; do not reset the ID sequence merely because a new `started` event clears replayable business history
+  - [x] Pass the request `Last-Event-ID` header from `server/src/routes/scraper.ts` through `ScraperService.subscribeToProgress()` into `ProgressTracker.addListener()`
+  - [x] Normalize invalid, negative, non-numeric, or too-old `Last-Event-ID` values to safe replay behavior without throwing, leaking cross-tenant information, or hanging the stream
+  - [x] Preserve current replay semantics for new subscribers without `Last-Event-ID`: replay prior matching business events, but do not replay pings
+  - [x] Keep heartbeat `ping` payloads unchanged (`{ type: 'ping', timestamp: <ISO8601> }`) except for any raw-stream formatting needed around them
+
+- [x] Extend the fetch-based client SSE transport to resume from the last event ID (AC: 3)
+  - [x] Reuse `subscribeToProgress` in `client/src/api/client.ts`; do not switch to native `EventSource` because the current endpoint depends on `Authorization` headers
+  - [x] Parse complete SSE message blocks into `{ id?, data }`, supporting `id:` plus one or more `data:` lines according to the SSE format
+  - [x] Track the last processed replayable event ID inside `subscribeToProgress` and include `Last-Event-ID` on reconnect attempts only after an ID has been seen
+  - [x] Keep existing reconnection behavior from Story 3.2: heartbeat timeout at 60 seconds, exponential backoff, abort cleanup, terminal auth/server failures surfaced immediately
+  - [x] Preserve `useScrapeProgress` state across reconnects; do not reset accumulated events, tracked jobs, `scrape-progress-percentage`, or `scrape-progress-eta`
+
+- [x] Add deterministic long-running SSE validation coverage (AC: 1, 2, 3)
+  - [x] Add a focused Playwright spec under `e2e/`, such as `e2e/sse-long-running-connection.spec.ts`, and add it to the scrape-serial project list in `playwright.config.ts` if it triggers real scrape work
+  - [x] Use a fixture-backed SaaS runtime when testing org-scoped progress: `SAAS_ENABLED=true`, `E2E_ENABLE_ORG_FIXTURE=true`, authenticated `/api/org/:slug/scraper/progress`, and the existing `seedTestOrg` fixture
+  - [x] Ensure the app and scraper worker are actually running; root `npm run dev` does not start the scraper worker, so the test environment must also run `scraper` with `RUN_MODE=consumer`
+  - [x] Make the 10+ minute scenario deterministic by configuring the scraper runtime for the test, for example `SCRAPER_CONCURRENCY=1`, `RATE_LIMIT_SCRAPER_MAX` high enough for setup, and a large `SCRAPE_THEATER_DELAY_MS`, instead of relying on unpredictable public-site latency
+  - [x] Ensure the selected scrape target can actually run long enough: either use tenant baseline cinemas copied from `server/src/config/cinemas.json` or explicitly seed/choose Allocine-backed cinemas; do not rely only on the `/test/seed-org` `example.test` fixture cinemas because they fail fast and cannot validate a 10-minute active stream
+  - [x] Avoid `assertFixtureRuntimeWithinLimit()` or pass a custom max above the long-running timeout; the default fixture runtime limit is 120 seconds and would make a valid 10+ minute test fail for the wrong reason
+  - [x] Set the Playwright test timeout explicitly above the validation window, for example `test.setTimeout(12 * 60 * 1000)` or higher if cleanup is included
+  - [x] Assert the browser/client-side stream remains open for at least 10 minutes, receives `ping` frames every 30 seconds with acceptable timer tolerance, and does not show `connectionStatus` as `disconnected`
+  - [x] Assert the UI remains useful during the long run with existing test IDs: `sse-connection-status`, `scrape-progress-percentage`, and `scrape-progress-eta`
+  - [x] Force one reconnect during the long-running window and assert the next request sends `Last-Event-ID` and receives no duplicate or missing progress events for the current tenant
+
+- [x] Keep Epic 3 scope boundaries intact (AC: 1, 2, 3)
+  - [x] Do not implement Story 3.4's 50+ concurrent-client load test in this story
+  - [x] Do not implement Story 3.6's rate-limit window reset countdown behavior here
+  - [x] Do not broaden rate-limit configuration unless a focused regression proves the long-running progress endpoint is being rate-limited incorrectly
+  - [x] Do not add a global client error framework or redesign progress UI; use the existing `ScrapeProgress`, `useScrapeProgress`, and `subscribeToProgress` seams
+  - [x] Update `docs/reference/api/scraper.md` and `docs/troubleshooting/scraper.md` if the event stream format, heartbeat cadence, reconnection, or resume behavior changes
+
+- [x] Verify with focused commands after implementation (AC: 1, 2, 3)
+  - [x] Run `cd server && npm run test:run -- src/services/progress-tracker.test.ts src/routes/scraper.test.ts src/services/scraper-service.test.ts`
+  - [x] Run `cd client && npm run test:run -- src/api/client.test.ts src/hooks/useScrapeProgress.test.ts src/components/ScrapeProgress.test.tsx`
+  - [x] Run the new Playwright long-running spec against a running server, client, Redis, database, and scraper worker, for example `PLAYWRIGHT_BASE_URL=http://localhost:5173 E2E_ENABLE_ORG_FIXTURE=true npm run e2e -- --project=chromium-scrape-serial e2e/sse-long-running-connection.spec.ts`
+  - [x] Run broader `cd server && npm run test:run` and `cd client && npm run lint && npm run test:run` if shared SSE parser, progress tracker, or UI contracts change
+
+## Dev Notes
+
+### Scope and Guardrails
+
+- Story `3.3` is now unblocked because Epic 3 blockers `3.7`, `3.1`, `3.5`, and client reconnect story `3.2` are complete. The readiness report says Stories `3.2`, `3.3`, `3.4`, `3.6`, and `3.8` can run in parallel only after those blockers. [Source: `_bmad-output/planning-artifacts/implementation-readiness-report-2026-04-15.md:640-658`]
+- The epic labels this story as test-only, but AC #3 cannot pass against current runtime code without adding real SSE event IDs and `Last-Event-ID` replay support. Do not fake this with test-only assertions; implement the smallest production-safe event ID/resume contract needed to make the validation meaningful. [Source: `_bmad-output/planning-artifacts/epics.md:933-963`]
+- Interpret AC #1 "progress updates at least every 30 seconds" as stream liveness frames at least every 30 seconds. Business progress events should still be emitted only when scrape progress changes. Story 3.1 intentionally made `ping` a transport event, not business progress history. [Source: `_bmad-output/implementation-artifacts/3-1-implement-sse-heartbeat-mechanism.md:47-58`, `server/src/services/progress-tracker.ts:169-209`]
+- Keep the validation long-running and deterministic. A test that completes in seconds, mocks all networking, or runs only with fake timers is not enough for the E2E acceptance criteria.
+
+### Critical Current-Code Reality
+
+- `ProgressTracker` stores raw `ProgressEvent[]` and writes only `data: <json>\n\n` for business events. There is no stored sequence ID, no `id:` SSE field, and no `Last-Event-ID` replay filter. [Source: `server/src/services/progress-tracker.ts:61-122`, `server/src/services/progress-tracker.ts:154-163`]
+- `ProgressTracker.emit()` clears `this.events` when a new `started` event arrives and `hasActiveJobs()` is false. That replay-buffer reset must not accidentally reset the monotonic ID sequence used for resume, or a reconnect across scrape sessions can see duplicate IDs. [Source: `server/src/services/progress-tracker.ts:108-114`]
+- `ProgressTracker.getEvents()` is used by existing tests to assert that heartbeat pings do not enter replay history. Changing it to return wrapper objects would create avoidable regressions; keep metadata internal or add a separate helper only if needed. [Source: `server/src/services/progress-tracker.ts:238-240`, `server/src/services/progress-tracker.test.ts:115-138`]
+- Heartbeat pings are currently direct `data:` frames and are intentionally not added to the replay buffer. Preserve that behavior so pings do not corrupt resume semantics. [Source: `server/src/services/progress-tracker.ts:169-175`, `_bmad-output/implementation-artifacts/3-1-implement-sse-heartbeat-mechanism.md:47-51`]
+- `GET /api/scraper/progress` is already behind `protectedLimiter` and `requireAuth`, builds observability context, and delegates to `ScraperService.subscribeToProgress()`. This is the seam that should pass `Last-Event-ID`; do not bypass it. [Source: `server/src/routes/scraper.ts:303-323`]
+- `ScraperService.subscribeToProgress()` sets the SSE headers and delegates listener lifecycle to `progressTracker.addListener()`. Add resume context through this existing flow. [Source: `server/src/services/scraper-service.ts:182-211`]
+- `subscribeToProgress` in `client/src/api/client.ts` is a fetch-based SSE reader with reconnection and heartbeat watchdog support from Story 3.2. It currently parses only `data:` lines and ignores `id:` fields entirely. [Source: `client/src/api/client.ts:211-390`]
+- The client currently keeps progress state in `useScrapeProgress` and treats `ping` as a liveness signal. Do not duplicate this state owner or reset progress during resume. [Source: `client/src/hooks/useScrapeProgress.ts:269-319`]
+- The shared client `ProgressEvent` union includes `ping`, but neither client nor server types include a standard SSE frame ID because the ID should be stream metadata rather than a business payload field. [Source: `client/src/types/index.ts:103-121`, `server/src/services/progress-tracker.ts:19-38`]
+- Existing Playwright config has no `webServer`, defaults to `http://localhost:5173`, and puts scrape-heavy specs in the `chromium-scrape-serial` project. A new long-running scrape spec should follow that pattern. [Source: `playwright.config.ts:3-11`, `playwright.config.ts:50-64`, `playwright.config.ts:78-84`]
+- `seedTestOrg` creates fixture cinemas with `https://example.test/...` URLs after `createOrg()` has already seeded tenant baseline cinemas from `server/src/config/cinemas.json`. The example-test fixture cinemas are useful failure sentinels but are not valid long-running scrape targets. Choose Allocine-backed tenant cinemas for the 10-minute scenario. [Source: `packages/saas/src/services/org-service.ts:72-144`, `packages/saas/src/routes/test-fixtures.ts:112-124`, `server/src/config/cinemas.json:1-80`]
+- `assertFixtureRuntimeWithinLimit()` defaults to 120 seconds. Existing E2E specs call it at the end, but a 10+ minute validation must either not use it or pass a max above the long-running test timeout. [Source: `e2e/fixtures/org-fixture.ts:5-33`, `e2e/tenant-concurrent-scrape-progress.spec.ts:116`]
+
+### Reinvention Prevention
+
+- Reuse the current SSE pipeline:
+  - `server/src/routes/scraper.ts`
+  - `server/src/services/scraper-service.ts`
+  - `server/src/services/progress-tracker.ts`
+  - `client/src/api/client.ts`
+  - `client/src/hooks/useScrapeProgress.ts`
+  - `client/src/components/ScrapeProgress.tsx`
+- Reuse the existing Redis progress flow for real scrape events. The server subscribes to `scrape:progress` at startup and forwards received events into `progressTracker.emit()`. [Source: `server/src/index.ts:30-39`, `server/src/services/redis-client.ts:220-238`]
+- Reuse existing Playwright org fixtures instead of creating a second E2E framework or ad hoc test app. Fixture endpoints are exposed only in `NODE_ENV=test` or in development with `E2E_ENABLE_ORG_FIXTURE=true`. [Source: `e2e/fixtures/org-fixture.ts:58-122`, `packages/saas/src/routes/test-fixtures.ts:20-23`]
+- Do not switch to native `EventSource`. MDN's EventSource supports automatic last-event-id behavior, but this repo's authenticated stream needs custom `Authorization` headers, so the existing fetch reader is the correct transport seam. [Source: `client/src/api/client.ts:299-307`]
+- Do not implement event IDs by adding a second JSON property named `id` to business payloads unless the standard `id:` stream field is also present. Resume behavior depends on the event stream protocol, not only application JSON.
+
+### Cross-Story Intelligence
+
+- Story `3.1` established JSON `ping` heartbeats every 30 seconds, kept pings out of replay history, and made active listeners remain open when scrape jobs are still active. Story `3.3` should build on that, not rework heartbeat ownership. [Source: `_bmad-output/implementation-artifacts/3-1-implement-sse-heartbeat-mechanism.md:223-227`, `server/src/services/progress-tracker.ts:187-209`]
+- Story `3.1` review fixed EOF parsing for final buffered SSE payloads, including split UTF-8 chunks. Any parser refactor for `id:` fields must retain those regressions. [Source: `_bmad-output/implementation-artifacts/3-1-implement-sse-heartbeat-mechanism.md:74-76`, `_bmad-output/implementation-artifacts/3-1-implement-sse-heartbeat-mechanism.md:232-255`]
+- Story `3.2` added the client reconnection loop, `connectionStatus`, preserved progress state across reconnects, and the visible `sse-connection-status` / `scrape-progress-eta` UI contract. This story should add resume IDs to that transport, not create a second reconnect implementation. [Source: `_bmad-output/implementation-artifacts/3-2-client-sse-reconnection-logic.md:198-206`, `_bmad-output/implementation-artifacts/3-2-client-sse-reconnection-logic.md:210-215`]
+- Story `3.5` proved E2E validations can false-green when the runtime disables the real behavior under test. For this story, do not validate long-running stability against a runtime that lacks the scraper worker, Redis progress subscription, or authenticated SSE endpoint. [Source: `_bmad-output/implementation-artifacts/3-5-rate-limiting-burst-scenario-tests.md:77-86`]
+- Story `3.7` reinforced full mounted-surface testing for middleware/transport behavior. For event IDs and resume, unit tests are necessary but not sufficient; at least one route/service regression should prove the mounted SSE path passes resume context correctly. [Source: `_bmad-output/implementation-artifacts/3-7-localhost-exemption-for-docker-health-probes.md:85-89`]
+
+### Architecture Compliance Notes
+
+- Keep server code in the existing Express structure: routes in `server/src/routes/`, stream ownership in `server/src/services/`, and tests next to the code. [Source: `_bmad-output/project-context.md:101-107`, `_bmad-output/project-context.md:146-150`]
+- Keep client code in existing layers: API transport in `client/src/api/`, state derivation in `client/src/hooks/`, UI rendering in `client/src/components/`, and colocated Vitest tests. [Source: `_bmad-output/project-context.md:93-100`, `_bmad-output/project-context.md:146-150`]
+- Keep strict TypeScript typing. Do not use `any` for SSE frame metadata, progress events, JWT/auth context, tenant context, or parser output. [Source: `_bmad-output/project-context.md:60-64`, `_bmad-output/project-context.md:84-87`]
+- Preserve tenant isolation. Resume replay must apply the same `org_slug` matching as live delivery and initial replay. A `Last-Event-ID` from another tenant must not reveal whether that event exists. [Source: `server/src/services/progress-tracker.ts:67-73`, `server/src/services/progress-tracker.ts:81-87`]
+- Preserve the `protectedLimiter` contract on the long-lived SSE endpoint. Opening one stream should not consume the whole quota, but reconnect tests can make repeated `GET /progress` requests inside the same 15-minute window; configure the test runtime deliberately instead of weakening production defaults. [Source: `server/src/routes/scraper.ts:303-304`, `server/src/middleware/rate-limit.ts:185-196`]
+- Preserve structured logging and avoid `console.log` in production code. Existing client parser currently logs parse failures with `console.error`; do not broaden server-side logging anti-patterns. [Source: `_bmad-output/project-context.md:75-78`]
+
+### Library / Framework Requirements
+
+- Use the existing Express response streaming and native Fetch reader; do not add a third-party SSE parser/package unless a focused parser function becomes impossible to maintain safely.
+- Use Vitest fake timers for 10-minute server cadence/idle assertions. Do not make server unit tests sleep in real time. [Source: `server/src/services/progress-tracker.test.ts:115-230`]
+- Use Playwright for the browser-level long-running validation. The root script is `npm run e2e`; Playwright does not start the app automatically. [Source: `package.json:41-46`, `docs/guides/development/testing.md:76-90`]
+- Use the existing `chromium-scrape-serial` project for scrape-heavy specs so long-running scrape tests do not contend with other scrape specs. [Source: `playwright.config.ts:5-11`, `playwright.config.ts:50-58`]
+
+### Latest Technical Information
+
+- Standard SSE messages are UTF-8 text blocks separated by a blank line. `data:` lines are concatenated with newline separators, `id:` sets the event ID, and `retry:` is reserved for reconnection timing. All other fields are ignored. [Source: MDN Server-sent events, Event stream format, `https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format`]
+- The current repo deliberately sends unnamed `data:` messages with a JSON `type` discriminator. Adding standard `id:` lines is compatible with that format and should not require named `event:` fields. [Source: `docs/reference/api/scraper.md:162-224`]
+
+### Testing Requirements
+
+- **Server unit/service tests**: Prove ID assignment, ID monotonicity, replay-after-last-ID, tenant-scoped replay, invalid/missing `Last-Event-ID` behavior, ping non-replay, active 10+ minute listener stability with fake timers, and cleanup when a listener disconnects.
+- **Server regression tests**: Prove event IDs do not reset when the replay buffer clears on a new `started` event, and prove `getEvents()` still returns plain `ProgressEvent[]` rather than internal wrapper metadata.
+- **Route/service tests**: Prove the mounted `GET /api/scraper/progress` path reads `Last-Event-ID`, keeps existing auth/limiter behavior, and passes resume context into the tracker without bypassing tenant context.
+- **Client API tests**: Prove parser support for `id:` plus `data:`, multi-line `data:`, split chunks, EOF flush, reconnect `Last-Event-ID` header, abort cleanup, and terminal auth failure behavior.
+- **Hook/component tests**: Prove progress state and visible connection status survive reconnect/resume and that `scrape-progress-percentage` / `scrape-progress-eta` remain visible during reconnect.
+- **Playwright E2E**: Prove a browser-backed authenticated SSE stream remains open for 10+ minutes during an active scrape, receives 30-second heartbeat pings, receives business progress frames when state changes, and resumes from the last event ID after a forced reconnect.
+
+### Suggested Implementation Strategy
+
+1. RED: Add server tests for `id:` output and `Last-Event-ID` replay in `ProgressTracker`.
+2. GREEN: Store progress events with internal monotonic SSE IDs and write `id:` lines for replayable business events.
+3. RED: Add route/service tests proving `Last-Event-ID` is read from the request and passed into the tracker.
+4. GREEN: Thread `Last-Event-ID` through `routes/scraper.ts` and `ScraperService.subscribeToProgress()`.
+5. RED: Add client parser/reconnect tests for `id:` fields and `Last-Event-ID` headers.
+6. GREEN: Refactor `subscribeToProgress` parsing to keep last event ID and send it on reconnect while preserving Story 3.2 behavior.
+7. RED/GREEN: Add the long-running Playwright spec using a deterministic, explicitly configured runtime.
+8. REFACTOR: Update docs and remove any duplicated parser/test helpers introduced during RED/GREEN.
+
+### Concrete File Targets
+
+| File | Change | Purpose |
+|------|--------|---------|
+| `server/src/services/progress-tracker.ts` | UPDATE | Store monotonic SSE IDs, write `id:` fields, replay after `Last-Event-ID` |
+| `server/src/services/progress-tracker.test.ts` | UPDATE | Unit coverage for ID/replay/heartbeat/10-minute stability |
+| `server/src/services/scraper-service.ts` | UPDATE | Accept and pass resume context to `ProgressTracker` |
+| `server/src/services/scraper-service.test.ts` | UPDATE | Verify service-level resume context wiring |
+| `server/src/routes/scraper.ts` | UPDATE | Read `Last-Event-ID` from authenticated SSE requests |
+| `server/src/routes/scraper.test.ts` | UPDATE | Verify mounted route wiring and auth/tenant behavior |
+| `client/src/api/client.ts` | UPDATE | Parse `id:` fields and send `Last-Event-ID` on reconnect |
+| `client/src/api/client.test.ts` | UPDATE | Parser and reconnect resume tests |
+| `client/src/hooks/useScrapeProgress.ts` | UPDATE IF NEEDED | Preserve state if API callback contract changes |
+| `client/src/hooks/useScrapeProgress.test.ts` | UPDATE IF NEEDED | Guard state preservation during resume |
+| `client/src/components/ScrapeProgress.tsx` | UPDATE ONLY IF NEEDED | Keep long-running UI visible and testable |
+| `client/src/components/ScrapeProgress.test.tsx` | UPDATE IF NEEDED | Guard test IDs and reconnect UI during resume |
+| `e2e/sse-long-running-connection.spec.ts` | ADD | Browser-level 10+ minute SSE validation |
+| `playwright.config.ts` | UPDATE IF NEEDED | Add new scrape-heavy spec to `chromium-scrape-serial` list |
+| `docs/reference/api/scraper.md` | UPDATE | Document `id:` / `Last-Event-ID` stream contract |
+| `docs/troubleshooting/scraper.md` | UPDATE | Remove stale no-reconnect / 15-second heartbeat guidance |
+
+### Pitfalls to Avoid
+
+- Do not mark this story complete with only unit/fake-timer tests; the core value is browser-observed 10+ minute stream stability.
+- Do not let `ping` frames advance the replay cursor unless you also store them safely. The safer default is no event ID on pings.
+- Do not replay all history after reconnect when `Last-Event-ID` is present; that would duplicate progress events and break idempotency.
+- Do not reset the SSE ID counter when `this.events` is cleared for a new scrape session; duplicate IDs across one server process undermine `Last-Event-ID` semantics.
+- Do not change `getEvents()` to return metadata wrappers unless all existing tests and debug consumers are deliberately updated; a private `eventIdByEvent`/wrapper store is safer.
+- Do not trust a client-provided `Last-Event-ID` across tenants. Apply tenant filtering before replay and treat unknown IDs as a safe no-leak condition.
+- Do not reset the client's accumulated progress events on reconnect. Story 3.2 explicitly preserved progress history.
+- Do not run the Playwright long-running spec without a scraper worker. The dev compose file starts db, redis, server, and client only; it does not start the scraper worker.
+- Do not let `protectedLimiter` or `scraperLimiter` invalidate the validation by throttling setup/reconnect requests; set test-only env overrides in the long-running verification environment rather than changing production defaults.
+- Do not use only the fixture `example.test` cinemas for the long-running scrape; they are designed to fail quickly and cannot prove a stable active 10-minute SSE stream.
+- Do not use the default 120-second fixture runtime assertion in a 10+ minute Playwright spec.
+- Do not rely on public AlloCine latency to make the test last 10 minutes. Control runtime delay/concurrency or the test will be flaky.
+- Do not broaden Story 3.4 load-test scope by opening 50 clients in this story.
+- Do not broaden Story 3.6 rate-limit reset scope by adding countdown/reset assertions in this story.
+
+### Project Structure Notes
+
+- No separate PRD, architecture, or UX shard was found under `_bmad-output/planning-artifacts`; this story is grounded in `epics.md`, readiness notes, test handoff, current SSE code, previous Epic 3 story artifacts, docs, and generated project context.
+- Existing E2E tests already cover scrape progress visibility and tenant concurrent scrape progress. Extend patterns from `e2e/scrape-progress.spec.ts` and `e2e/tenant-concurrent-scrape-progress.spec.ts` rather than creating another test harness.
+- Existing UI already exposes `data-testid="sse-connection-status"`, `data-testid="scrape-progress-percentage"`, and `data-testid="scrape-progress-eta"`. Prefer assertions on those elements over adding new display-only test IDs.
+
+### Git Intelligence Summary
+
+- Recent commits are focused on hardening client SSE reconnect behavior: `fix(client): harden SSE reconnect progress handling (#941)`, `fix(client): satisfy strict TS checks in SSE tests`, and `fix(client): harden SSE reconnect progress handling`. This story should continue that pattern by tightening the real SSE contract with focused tests rather than rewriting the transport.
+- The working tree was clean when this story was created, so the next dev agent should treat any later dirty files as user or implementation changes, not story-generation leftovers.
+
+### Project Context Reference
+
+- The project requires Node `>=24`, ESM modules, strict TypeScript, and Vitest for server/client tests. [Source: `_bmad-output/project-context.md:17-53`, `_bmad-output/project-context.md:60-73`, `package.json:60-72`]
+- The project testing rules require TDD, colocated tests, Vitest for packages, and Playwright for high-value E2E workflows. [Source: `_bmad-output/project-context.md:110-136`]
+- Runtime gotcha: server startup subscribes to Redis progress events, but local dev requires starting the scraper worker separately for end-to-end scraping. [Source: `AGENTS.md`, `server/src/index.ts:30-39`]
+
+### References
+
+- Epic 3 overview and implementation order: `_bmad-output/planning-artifacts/epics.md:228-262`
+- Story 3.3 definition and deployment impact: `_bmad-output/planning-artifacts/epics.md:933-963`
+- Epic 3 dependency readiness: `_bmad-output/planning-artifacts/implementation-readiness-report-2026-04-15.md:640-658`
+- Epic notes summary for Story 3.3: `_bmad-output/planning-artifacts/notes-epics-stories.md:193-200`
+- Test handoff requirements for RISK-003: `_bmad-output/test-artifacts/test-design/allo-scrapper-handoff.md:168-195`
+- Story 3.1 heartbeat implementation and review learnings: `_bmad-output/implementation-artifacts/3-1-implement-sse-heartbeat-mechanism.md:1-255`
+- Story 3.2 reconnect implementation and file list: `_bmad-output/implementation-artifacts/3-2-client-sse-reconnection-logic.md:1-217`
+- Current progress tracker: `server/src/services/progress-tracker.ts:1-250`
+- Current scraper SSE route: `server/src/routes/scraper.ts:303-323`
+- Current scraper service subscription: `server/src/services/scraper-service.ts:182-211`
+- Server Redis progress forwarding: `server/src/index.ts:30-39`, `server/src/services/redis-client.ts:220-238`
+- Current client SSE transport: `client/src/api/client.ts:211-390`
+- Current progress hook: `client/src/hooks/useScrapeProgress.ts:219-350`
+- Current progress UI: `client/src/components/ScrapeProgress.tsx:1-258`
+- Shared client progress event type: `client/src/types/index.ts:103-121`
+- Existing scrape E2E patterns: `e2e/scrape-progress.spec.ts:1-183`, `e2e/tenant-concurrent-scrape-progress.spec.ts:1-118`
+- Playwright config: `playwright.config.ts:1-85`
+- Org fixture runtime: `e2e/fixtures/org-fixture.ts:58-122`, `packages/saas/src/routes/test-fixtures.ts:20-23`
+- Published SSE API docs: `docs/reference/api/scraper.md:162-224`
+- Stale troubleshooting reconnect docs to update: `docs/troubleshooting/scraper.md:464-496`
+- SSE stream format reference: `https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format`
+
+## Dev Agent Record
+
+### Agent Model Used
+
+github-copilot/gpt-5.5
+
+### Debug Log References
+
+- RED: `cd server && npm run test:run -- src/services/progress-tracker.test.ts` failed on missing standard SSE `id:` fields and missing `Last-Event-ID` replay filtering.
+- RED: `cd server && npm run test:run -- src/services/scraper-service.test.ts src/routes/scraper.test.ts` failed until `Last-Event-ID` was threaded from the route through `ScraperService.subscribeToProgress()` to `ProgressTracker.addListener()`.
+- RED: `cd client && npm run test:run -- src/api/client.test.ts` failed until `subscribeToProgress` captured SSE `id:` metadata and sent `Last-Event-ID` on reconnect.
+- GREEN: Real long-running Playwright validation passed in 10.1 minutes with db/Redis, server, client, and scraper worker running locally (`RUN_MODE=consumer`, `SCRAPER_CONCURRENCY=1`, `SCRAPE_THEATER_DELAY_MS=30000`).
+
+### Completion Notes List
+
+- Created an implementation-ready story for Epic 3 Story 3.3 based on the real current SSE heartbeat, client reconnect, and progress tracker implementation.
+- Captured the main hidden implementation gap: the story is labeled test-only, but event ID/resume acceptance requires minimal runtime support before a truthful long-running validation can pass.
+- Scoped long-running validation to deterministic browser-observed SSE behavior while explicitly excluding Story 3.4 concurrent-client load and Story 3.6 rate-limit reset coverage.
+- Implemented standard SSE `id:` fields for replayable business progress events with process-lifetime monotonic IDs until `ProgressTracker.reset()`.
+- Added `Last-Event-ID` replay support that filters by tenant before delivery and keeps heartbeat pings transport-only with no replay cursor impact.
+- Extended the authenticated fetch-based client SSE transport to parse `id:` plus multi-line `data:` blocks, retain EOF/split UTF-8 behavior, and resume with `Last-Event-ID` after reconnect.
+- Added an opt-in deterministic Playwright long-running validation that uses SaaS org fixtures, Allocine-backed tenant cinemas, a real scraper worker, browser-observed pings, UI liveness assertions, and forced reconnect resume validation.
+- Updated SSE API and troubleshooting documentation for 30-second pings, `id:` fields, and `Last-Event-ID` resume.
+- Verification completed: focused server/client tests, full server/client unit suites, client lint/build, workspace build, server integration/coverage, and real 10+ minute Playwright validation all passed.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/3-3-sse-long-running-connection-validation-10-minutes.md`
+- `_bmad-output/implementation-artifacts/3-3-sse-long-running-connection-validation-10-minutes-validation-report.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `server/src/services/progress-tracker.ts`
+- `server/src/services/progress-tracker.test.ts`
+- `server/src/services/scraper-service.ts`
+- `server/src/services/scraper-service.test.ts`
+- `server/src/routes/scraper.ts`
+- `server/src/routes/scraper.test.ts`
+- `client/src/api/client.ts`
+- `client/src/api/client.test.ts`
+- `e2e/sse-long-running-connection.spec.ts`
+- `playwright.config.ts`
+- `docs/reference/api/scraper.md`
+- `docs/troubleshooting/scraper.md`
+
+## Change Log
+
+- 2026-04-29: Created implementation-ready story file for Epic 3 Story 3.3 with explicit guardrails around SSE `id:` / `Last-Event-ID` support, 10+ minute deterministic validation, and current fetch-based reconnect behavior.
+- 2026-04-29: Implemented SSE event ID and resume support, added server/client/Playwright validation, updated documentation, and moved Story 3.3 to review.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-15
-# last_updated: 2026-04-29T12:39:00Z
+# last_updated: 2026-04-29T16:23:03Z
 # project: allo-scrapper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -28,7 +28,7 @@
 #   - done: Retrospective has been completed
 
 generated: 2026-04-15
-last_updated: 2026-04-29T12:39:00Z
+last_updated: 2026-04-29T16:23:03Z
 project: allo-scrapper
 project_key: NOKEY
 tracking_system: file-system
@@ -79,7 +79,7 @@ development_status:
   epic-3: in-progress
   3-1-implement-sse-heartbeat-mechanism: done
   3-2-implement-client-sse-reconnection-logic: done
-  3-3-sse-long-running-connection-validation-10-minutes: backlog
+  3-3-sse-long-running-connection-validation-10-minutes: review
   3-4-sse-concurrent-client-load-test-50-clients: backlog
   3-5-rate-limiting-burst-scenario-tests: done
   3-6-rate-limiting-window-reset-validation: backlog

--- a/client/src/api/client.test.ts
+++ b/client/src/api/client.test.ts
@@ -453,6 +453,99 @@ describe('Cinema API Client', () => {
     vi.useRealTimers();
   });
 
+  it('parses SSE id fields with multi-line data blocks', async () => {
+    const onEvent = vi.fn();
+
+    globalThis.fetch = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      lastFetchCall = { input: _input, init };
+
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        body: {
+          getReader: () => ({
+            read: vi.fn()
+              .mockResolvedValueOnce({
+                done: false,
+                value: new TextEncoder().encode('id: 42\ndata: {"type":"started",\ndata: "report_id":42,"total_cinemas":1,"total_dates":1}\n\n'),
+              })
+              .mockImplementation(() => new Promise(() => {
+                // Keep the stream open after the parsed event.
+              })),
+          }),
+        },
+      } as unknown as Response);
+    });
+
+    subscribeToProgress(onEvent);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onEvent).toHaveBeenCalledWith({
+      type: 'started',
+      report_id: 42,
+      total_cinemas: 1,
+      total_dates: 1,
+    });
+  });
+
+  it('preserves id parsing when UTF-8 data spans chunks before EOF', async () => {
+    vi.useFakeTimers();
+    const onEvent = vi.fn();
+    const onError = vi.fn();
+    const bytes = new TextEncoder().encode('id: 7\ndata: {"type":"ping","timestamp":"2026-04-28T16:10:00.000Z","label":"Cinema Étoile"}');
+    const splitAt = bytes.length - 2;
+    let fetchCallCount = 0;
+
+    globalThis.fetch = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      lastFetchCall = { input, init };
+      fetchCallCount++;
+
+      if (fetchCallCount === 1) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          body: {
+            getReader: () => ({
+              read: vi.fn()
+                .mockResolvedValueOnce({ done: false, value: bytes.slice(0, splitAt) })
+                .mockResolvedValueOnce({ done: false, value: bytes.slice(splitAt) })
+                .mockResolvedValueOnce({ done: true, value: undefined }),
+            }),
+          },
+        } as unknown as Response);
+      }
+
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        body: {
+          getReader: () => ({
+            read: vi.fn(() => new Promise(() => {
+              // Keep the reconnected stream open.
+            })),
+          }),
+        },
+      } as unknown as Response);
+    });
+
+    subscribeToProgress(onEvent, onError);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(onEvent).toHaveBeenCalledWith({
+      type: 'ping',
+      timestamp: '2026-04-28T16:10:00.000Z',
+      label: 'Cinema Étoile',
+    });
+    expect(onError).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
   describe('SSE reconnection', () => {
 
     beforeEach(() => {
@@ -755,7 +848,7 @@ await Promise.resolve();
       const onStatusChange = vi.fn();
       let fetchCallCount = 0;
 
-      globalThis.fetch = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) => {
+      globalThis.fetch = vi.fn(() => {
         fetchCallCount++;
 
         return Promise.resolve({
@@ -779,7 +872,7 @@ await Promise.resolve();
       const onStatusChange = vi.fn();
       let fetchCallCount = 0;
 
-      globalThis.fetch = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) => {
+      globalThis.fetch = vi.fn(() => {
         fetchCallCount++;
 
         if (fetchCallCount === 1) {
@@ -809,6 +902,117 @@ await Promise.resolve();
 
       expect(fetchCallCount).toBeGreaterThan(1);
       expect(onStatusChange).toHaveBeenCalledWith('connected');
+    });
+
+    it('resets the reconnect delay budget after a retry successfully reopens the stream', async () => {
+      let fetchCallCount = 0;
+
+      globalThis.fetch = vi.fn(() => {
+        fetchCallCount++;
+
+        if (fetchCallCount === 1) {
+          return Promise.reject(new Error('Connection lost'));
+        }
+
+        if (fetchCallCount === 2) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            body: {
+              getReader: () => ({
+                read: vi.fn().mockResolvedValueOnce({ done: true, value: undefined }),
+              }),
+            },
+          } as unknown as Response);
+        }
+
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          body: {
+            getReader: () => ({
+              read: vi.fn(() => new Promise(() => {
+                // Keep the retried stream open.
+              })),
+            }),
+          },
+        } as unknown as Response);
+      });
+
+      subscribeToProgress(() => {});
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(fetchCallCount).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(fetchCallCount).toBe(2);
+
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(fetchCallCount).toBeGreaterThanOrEqual(3);
+    });
+
+    it('sends Last-Event-ID on reconnect after receiving an SSE id', async () => {
+      const onEvent = vi.fn();
+      let fetchCallCount = 0;
+
+      globalThis.fetch = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        lastFetchCall = { input, init };
+        fetchCallCount++;
+
+        if (fetchCallCount === 1) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            body: {
+              getReader: () => ({
+                read: vi.fn()
+                  .mockResolvedValueOnce({
+                    done: false,
+                    value: new TextEncoder().encode('id: 19\ndata: {"type":"started","report_id":19,"total_cinemas":1,"total_dates":1}\n\n'),
+                  })
+                  .mockResolvedValueOnce({ done: true, value: undefined }),
+              }),
+            },
+          } as unknown as Response);
+        }
+
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          body: {
+            getReader: () => ({
+              read: vi.fn(() => new Promise(() => {
+                // Keep the reconnected stream open.
+              })),
+            }),
+          },
+        } as unknown as Response);
+      });
+
+      subscribeToProgress(onEvent);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const firstHeaders = lastFetchCall?.init?.headers as Record<string, string>;
+      expect(firstHeaders).not.toHaveProperty('Last-Event-ID');
+
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(fetchCallCount).toBeGreaterThan(1);
+      expect(onEvent).toHaveBeenCalledWith({
+        type: 'started',
+        report_id: 19,
+        total_cinemas: 1,
+        total_dates: 1,
+      });
+      expect(lastFetchCall?.init?.headers).toEqual(expect.objectContaining({
+        'Last-Event-ID': '19',
+      }));
     });
   });
 });

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -14,6 +14,11 @@ import type {
 
 export type ConnectionStatus = 'connected' | 'reconnecting' | 'disconnected';
 
+interface SseMessage {
+  id?: string;
+  data: string;
+}
+
 // Create axios instance
 // Use relative path by default to work with proxy in dev and same-origin in prod
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
@@ -215,6 +220,7 @@ export function subscribeToProgress(onEvent: (event: ProgressEvent) => void, onE
   let reconnectAttempt = 0;
   let isAborted = false;
   let initialConnect = true;
+  let lastEventId: string | undefined;
   const token = localStorage.getItem('token');
   const url = `${API_BASE_URL}${getScraperBasePath()}/progress`;
 
@@ -267,21 +273,45 @@ export function subscribeToProgress(onEvent: (event: ProgressEvent) => void, onE
     }, delay);
   }
 
-  const processMessage = (message: string) => {
-    const lines = message
-      .split(/\r?\n/)
-      .filter((line) => line.startsWith('data:'));
+  const parseFieldValue = (line: string, fieldName: string): string => {
+    const rawValue = line.slice(fieldName.length + 1);
+    return rawValue.startsWith(' ') ? rawValue.slice(1) : rawValue;
+  };
 
-    if (lines.length === 0) {
+  const parseSseMessage = (message: string): SseMessage | undefined => {
+    let id: string | undefined;
+    const dataLines: string[] = [];
+
+    for (const line of message.split(/\r?\n/)) {
+      if (line.startsWith('id:')) {
+        id = parseFieldValue(line, 'id');
+        continue;
+      }
+
+      if (line.startsWith('data:')) {
+        dataLines.push(parseFieldValue(line, 'data'));
+      }
+    }
+
+    if (dataLines.length === 0) {
+      return undefined;
+    }
+
+    return { id, data: dataLines.join('\n') };
+  };
+
+  const processMessage = (message: string) => {
+    const parsedMessage = parseSseMessage(message);
+
+    if (!parsedMessage) {
       return;
     }
 
-    const raw = lines
-      .map((line) => line.slice(5).trimStart())
-      .join('\n');
-
     try {
-      const data = JSON.parse(raw);
+      const data = JSON.parse(parsedMessage.data) as ProgressEvent;
+      if (parsedMessage.id && data.type !== 'ping') {
+        lastEventId = parsedMessage.id;
+      }
       onEvent(data);
     } catch (error) {
       console.error('Failed to parse SSE event:', error);
@@ -296,12 +326,16 @@ export function subscribeToProgress(onEvent: (event: ProgressEvent) => void, onE
 
     void (async () => {
       try {
+        const hadReconnectAttempt = reconnectAttempt > 0;
+        const headers: Record<string, string> = {
+          Accept: 'text/event-stream',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          ...(lastEventId ? { 'Last-Event-ID': lastEventId } : {}),
+        };
+
         const response = await fetch(url, {
           method: 'GET',
-          headers: {
-            Accept: 'text/event-stream',
-            ...(token ? { Authorization: `Bearer ${token}` } : {}),
-          },
+          headers,
           signal,
           cache: 'no-store',
         });
@@ -314,9 +348,9 @@ export function subscribeToProgress(onEvent: (event: ProgressEvent) => void, onE
           throw new Error('Progress stream is unavailable');
         }
 
-        // Connection established
+        reconnectAttempt = 0;
 
-        if (!initialConnect || reconnectAttempt > 0) {
+        if (!initialConnect || hadReconnectAttempt) {
           onStatusChange?.('connected');
         }
         initialConnect = false;

--- a/docs/reference/api/scraper.md
+++ b/docs/reference/api/scraper.md
@@ -167,7 +167,12 @@ GET /api/scraper/progress
 
 **Authentication:** Required.
 
-Persistent Server-Sent Events stream. Previously buffered events for the active scrape are replayed to new subscribers, then live events are streamed. A JSON `ping` event is sent every 30 s to keep the connection alive. Heartbeat frames are transport-only and are not replayed as scrape history to new subscribers.
+Persistent Server-Sent Events stream. Previously buffered events for the active scrape are replayed to new subscribers, then live events are streamed. Replayable business events include standard SSE `id:` fields so clients can resume with `Last-Event-ID` after reconnecting. A JSON `ping` event is sent every 30 s to keep the connection alive. Heartbeat frames are transport-only: they do not include `id:` fields and are not replayed as scrape history to new subscribers.
+
+**Request Headers:**
+- `Authorization: Bearer <token>`
+- `Accept: text/event-stream`
+- `Last-Event-ID: <event-id>` optional; replays matching tenant progress events after this ID
 
 **Response Headers:**
 - `Content-Type: text/event-stream`
@@ -177,33 +182,44 @@ Persistent Server-Sent Events stream. Previously buffered events for the active 
 
 **Event Format**
 
-All events arrive as plain `data:` lines (no named `event:` field). Each payload is JSON with a `type` discriminator:
+Events are unnamed SSE messages. Business progress messages use `id:` plus one or more `data:` lines. Each payload is JSON with a `type` discriminator:
 
 ```
 data: {"type":"ping","timestamp":"2026-04-28T15:18:00.000Z"}
 ```
 
 ```
+id: 1
 data: {"type":"started","total_cinemas":3,"total_dates":7}
 
+id: 2
 data: {"type":"cinema_started","cinema_name":"Épée de Bois","cinema_id":"W7504","index":1}
 
+id: 3
 data: {"type":"date_started","date":"2026-02-19","cinema_name":"Épée de Bois"}
 
+id: 4
 data: {"type":"film_started","film_title":"Mon Film","film_id":123456}
 
+id: 5
 data: {"type":"film_completed","film_title":"Mon Film","showtimes_count":5}
 
+id: 6
 data: {"type":"film_failed","film_title":"Mon Film","error":"HTTP 404"}
 
+id: 7
 data: {"type":"date_completed","date":"2026-02-19","films_count":12}
 
+id: 8
 data: {"type":"date_failed","date":"2026-02-19","cinema_name":"Épée de Bois","error":"HTTP 503"}
 
+id: 9
 data: {"type":"cinema_completed","cinema_name":"Épée de Bois","total_films":42}
 
+id: 10
 data: {"type":"completed","summary":{"total_cinemas":3,"successful_cinemas":3,"failed_cinemas":0,"total_films":87,"total_showtimes":412,"total_dates":7,"duration_ms":34210,"errors":[]}}
 
+id: 11
 data: {"type":"failed","error":"Fatal error message"}
 ```
 
@@ -259,14 +275,31 @@ When the scraper detects HTTP 429 from the source:
 curl -N -H "Authorization: Bearer $TOKEN" http://localhost:3000/api/scraper/progress
 ```
 
+Resume after the last processed business event:
+
+```bash
+curl -N \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Last-Event-ID: 42" \
+  http://localhost:3000/api/scraper/progress
+```
+
 ```javascript
-const eventSource = new EventSource('/api/scraper/progress');
-eventSource.onmessage = (e) => {
-  const data = JSON.parse(e.data);
-  if (data.type === 'completed' || data.type === 'failed') {
-    eventSource.close();
+let lastEventId;
+
+async function connectProgressStream(token) {
+  const response = await fetch('/api/scraper/progress', {
+    headers: {
+      Accept: 'text/event-stream',
+      Authorization: `Bearer ${token}`,
+      ...(lastEventId ? { 'Last-Event-ID': lastEventId } : {}),
+    },
+  });
+
+  for await (const chunk of response.body) {
+    // Parse SSE blocks, store each business event `id:`, and reconnect with it.
   }
-};
+}
 ```
 
 ---

--- a/docs/troubleshooting/scraper.md
+++ b/docs/troubleshooting/scraper.md
@@ -423,26 +423,35 @@ Fatal error: ...
 
 ```bash
 # Connect to progress stream
-curl -N http://localhost:3000/api/scraper/progress
+curl -N -H "Authorization: Bearer $TOKEN" http://localhost:3000/api/scraper/progress
 
-# Expected heartbeat (every 15 seconds)
-: heartbeat
+# Expected heartbeat (every 30 seconds)
+data: {"type":"ping","timestamp":"2026-04-28T15:18:00.000Z"}
 
 # Expected events during scrape
-event: cinema_started
+id: 1
+data: {"type":"started","total_cinemas":3,"total_dates":7}
+
+id: 2
 data: {"type":"cinema_started","cinema_name":"UGC Ciné Cité Les Halles"}
 
-event: date_started
+id: 3
 data: {"type":"date_started","cinema_name":"UGC Ciné Cité Les Halles","date":"2026-03-05"}
 
-event: film_scraped
-data: {"type":"film_scraped","film_title":"Dune: Part Two","showtime_count":8}
-
-event: film_failed
+id: 4
 data: {"type":"film_failed","film_title":"Unknown","error":"Parser error"}
 
-event: date_completed
+id: 5
 data: {"type":"date_completed","cinema_name":"UGC Ciné Cité Les Halles","date":"2026-03-05"}
+```
+
+To test resume behavior after reconnect, reuse the last business event ID:
+
+```bash
+curl -N \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Last-Event-ID: 3" \
+  http://localhost:3000/api/scraper/progress
 ```
 
 ---
@@ -466,33 +475,40 @@ curl http://localhost:3000/api/scraper/status
    - Add `proxy_buffering off;` to nginx
 
 3. **Client timeout:**
-   - Heartbeat sent every 15 seconds
-   - Client must handle keep-alive
+   - Heartbeat `ping` frames are sent every 30 seconds
+   - Client must reset its keep-alive watchdog when `ping` frames arrive
 
 ---
 
 ### Connection Drops
 
 **Behavior:**
-- Disconnected clients **removed silently**
-- No automatic reconnection
+- Disconnected clients are removed from the server listener set
+- The first-party browser client automatically reconnects with exponential backoff
+- Reconnected clients send `Last-Event-ID` after receiving a replayable business event ID
 - No error emitted to remaining clients
 
 **Client responsibility:**
 - Detect connection drop
-- Reconnect manually
-- Handle reconnection logic
+- Reconnect manually if not using the first-party client transport
+- Preserve the last replayable business event ID and send it as `Last-Event-ID`
+- Ignore heartbeat `ping` frames for replay cursors; pings have no SSE `id:`
 
-**Example (JavaScript):**
+**Example (JavaScript with authenticated `fetch`):**
 
 ```javascript
-function connectSSE() {
-  const eventSource = new EventSource('/api/scraper/progress');
-  
-  eventSource.onerror = () => {
-    eventSource.close();
-    setTimeout(connectSSE, 5000);  // Reconnect after 5s
-  };
+let lastEventId;
+
+async function connectSSE(token) {
+  const response = await fetch('/api/scraper/progress', {
+    headers: {
+      Accept: 'text/event-stream',
+      Authorization: `Bearer ${token}`,
+      ...(lastEventId ? { 'Last-Event-ID': lastEventId } : {}),
+    },
+  });
+
+  // Parse SSE blocks. When a non-ping block has `id:`, save it to lastEventId.
 }
 ```
 

--- a/e2e/sse-long-running-connection.spec.ts
+++ b/e2e/sse-long-running-connection.spec.ts
@@ -1,0 +1,368 @@
+import { test, expect } from './fixtures/org-fixture';
+
+const useOrgFixture = process.env['E2E_ENABLE_ORG_FIXTURE'] === 'true';
+const enableLongRunningSse = process.env['E2E_LONG_RUNNING_SSE'] === 'true';
+const configuredConcurrency = Number(process.env['SCRAPER_CONCURRENCY'] ?? '0');
+const configuredTheaterDelayMs = Number(process.env['SCRAPE_THEATER_DELAY_MS'] ?? '0');
+
+interface LoginResponse {
+  success: boolean;
+  data: {
+    token: string;
+    user: {
+      id: number;
+      username: string;
+      role_id: number;
+      role_name: string;
+      is_system_role: boolean;
+      permissions: string[];
+      org_slug?: string;
+    };
+  };
+}
+
+interface CinemaResponse {
+  success: boolean;
+  data: Array<{ id: string; name: string; url?: string }>;
+}
+
+interface BrowserSseMonitorState {
+  businessEventIds: string[];
+  businessEventTypes: string[];
+  connectionCount: number;
+  duplicateEventIds: string[];
+  errors: string[];
+  isOpen: boolean;
+  lastEventId?: string;
+  monotonicViolations: string[];
+  pingReceivedAt: number[];
+  requestLastEventIds: Array<string | null>;
+  stopped: boolean;
+}
+
+interface BrowserSseMonitor {
+  state: BrowserSseMonitorState;
+  forceReconnect: () => Promise<void>;
+  stop: () => void;
+}
+
+declare global {
+  interface Window {
+    __sseLongRunMonitor?: BrowserSseMonitor;
+  }
+}
+
+function getLongestGapMs(timestamps: number[]): number {
+  if (timestamps.length < 2) {
+    return 0;
+  }
+
+  let longestGapMs = 0;
+  for (let i = 1; i < timestamps.length; i++) {
+    longestGapMs = Math.max(longestGapMs, timestamps[i] - timestamps[i - 1]);
+  }
+  return longestGapMs;
+}
+
+test.describe('SSE long-running connection validation', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.skip(!useOrgFixture, 'Requires fixture-backed SaaS runtime (E2E_ENABLE_ORG_FIXTURE=true)');
+  test.skip(!enableLongRunningSse, 'Long-running SSE validation is opt-in (E2E_LONG_RUNNING_SSE=true)');
+  test.skip(
+    configuredConcurrency !== 1 || configuredTheaterDelayMs < 30000,
+    'Requires deterministic scraper runtime: SCRAPER_CONCURRENCY=1 and SCRAPE_THEATER_DELAY_MS>=30000',
+  );
+
+  test('keeps an authenticated tenant SSE stream alive for 10+ minutes and resumes after Last-Event-ID reconnect', async ({ page, request, seedTestOrg }) => {
+    test.setTimeout(13 * 60 * 1000);
+
+    const org = await seedTestOrg({ planId: 2 });
+    const loginResponse = await request.post('/api/auth/login', {
+      data: {
+        username: org.admin.username,
+        password: org.admin.password,
+      },
+    });
+    expect(loginResponse.ok()).toBe(true);
+
+    const loginBody = await loginResponse.json() as LoginResponse;
+    const token = loginBody.data.token;
+
+    const cinemasResponse = await request.get(`/api/org/${org.orgSlug}/cinemas`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(cinemasResponse.ok()).toBe(true);
+
+    const cinemasBody = await cinemasResponse.json() as CinemaResponse;
+    const allocineCinemas = cinemasBody.data.filter((cinema) => cinema.url?.includes('allocine.fr'));
+    expect(allocineCinemas.length).toBeGreaterThanOrEqual(21);
+
+    await page.goto('/');
+    await page.evaluate(([savedToken, user]) => {
+      localStorage.setItem('token', savedToken);
+      localStorage.setItem('user', JSON.stringify(user));
+    }, [
+      token,
+      {
+        ...loginBody.data.user,
+        org_slug: org.orgSlug,
+      },
+    ]);
+
+    await page.goto(`/org/${org.orgSlug}/admin?tab=cinemas`);
+    await expect(page.getByTestId('scrape-all-button')).toBeVisible({ timeout: 10000 });
+
+    await page.evaluate(([savedToken, orgSlug]) => {
+      const state: BrowserSseMonitorState = {
+        businessEventIds: [],
+        businessEventTypes: [],
+        connectionCount: 0,
+        duplicateEventIds: [],
+        errors: [],
+        isOpen: false,
+        monotonicViolations: [],
+        pingReceivedAt: [],
+        requestLastEventIds: [],
+        stopped: false,
+      };
+      const seenEventIds = new Set<string>();
+      const decoder = new TextDecoder();
+      const originalFetch = window.fetch.bind(window);
+      let activeConnectionId = 0;
+      let activeReader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+      let activeStreamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+      let buffer = '';
+
+      const parseValue = (line: string, fieldName: string): string => {
+        const rawValue = line.slice(fieldName.length + 1);
+        return rawValue.startsWith(' ') ? rawValue.slice(1) : rawValue;
+      };
+
+      const handleFrame = (frame: string): void => {
+        let id: string | undefined;
+        const dataLines: string[] = [];
+
+        for (const line of frame.split(/\r?\n/)) {
+          if (line.startsWith('id:')) {
+            id = parseValue(line, 'id');
+            continue;
+          }
+
+          if (line.startsWith('data:')) {
+            dataLines.push(parseValue(line, 'data'));
+          }
+        }
+
+        if (dataLines.length === 0) {
+          return;
+        }
+
+        try {
+          const payload = JSON.parse(dataLines.join('\n')) as { type?: string };
+          if (payload.type === 'ping') {
+            state.pingReceivedAt.push(Date.now());
+            return;
+          }
+
+          state.businessEventTypes.push(String(payload.type));
+
+          if (!id) {
+            state.errors.push(`missing business event id for ${String(payload.type)}`);
+            return;
+          }
+
+          const previousId = state.lastEventId ? Number(state.lastEventId) : undefined;
+          const currentId = Number(id);
+          if (previousId !== undefined && currentId <= previousId) {
+            state.monotonicViolations.push(`${id} <= ${state.lastEventId}`);
+          }
+          if (seenEventIds.has(id)) {
+            state.duplicateEventIds.push(id);
+          }
+
+          seenEventIds.add(id);
+          state.businessEventIds.push(id);
+          state.lastEventId = id;
+        } catch (error) {
+          state.errors.push(error instanceof Error ? error.message : String(error));
+        }
+      };
+
+      const isProgressRequest = (input: RequestInfo | URL): boolean => {
+        const url = typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+        return url.includes(`/api/org/${orgSlug}/scraper/progress`);
+      };
+
+      const getLastEventIdHeader = (headers?: HeadersInit): string | null => {
+        if (!headers) {
+          return null;
+        }
+
+        if (headers instanceof Headers) {
+          return headers.get('Last-Event-ID');
+        }
+
+        if (Array.isArray(headers)) {
+          const entry = headers.find(([key]) => key.toLowerCase() === 'last-event-id');
+          return entry?.[1] ?? null;
+        }
+
+        const record = headers as Record<string, string>;
+        return record['Last-Event-ID'] ?? record['last-event-id'] ?? null;
+      };
+
+      window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const response = await originalFetch(input, init);
+
+        if (!isProgressRequest(input)) {
+          return response;
+        }
+
+        const connectionId = ++activeConnectionId;
+        state.connectionCount += 1;
+        state.requestLastEventIds.push(getLastEventIdHeader(init?.headers));
+
+        if (!response.ok || !response.body) {
+          state.errors.push(
+            !response.ok
+              ? `SSE monitor failed with status ${response.status}`
+              : 'SSE monitor response has no body'
+          );
+          return response;
+        }
+
+        state.isOpen = true;
+        buffer = '';
+
+        const reader = response.body.getReader();
+        activeReader = reader;
+
+        const monitoredBody = new ReadableStream<Uint8Array>({
+          start(controller) {
+            activeStreamController = controller;
+
+            void (async () => {
+              try {
+                while (!state.stopped) {
+                  const { done, value } = await reader.read();
+                  if (done) {
+                    buffer += decoder.decode();
+                    if (buffer.trim()) {
+                      handleFrame(buffer);
+                      buffer = '';
+                    }
+                    controller.close();
+                    break;
+                  }
+
+                  buffer += decoder.decode(value, { stream: true });
+                  const frames = buffer.split(/\r?\n\r?\n/);
+                  buffer = frames.pop() ?? '';
+                  for (const frame of frames) {
+                    handleFrame(frame);
+                  }
+
+                  controller.enqueue(value);
+                }
+              } catch (error) {
+                if (!state.stopped) {
+                  state.errors.push(error instanceof Error ? error.message : String(error));
+                }
+                controller.error(error);
+              } finally {
+                if (activeConnectionId === connectionId) {
+                  state.isOpen = false;
+                }
+              }
+            })();
+          },
+          cancel(reason) {
+            return reader.cancel(reason);
+          },
+        });
+
+        return new Response(monitoredBody, {
+          status: response.status,
+          statusText: response.statusText,
+          headers: response.headers,
+        });
+      };
+
+      window.__sseLongRunMonitor = {
+        state,
+        forceReconnect: async () => {
+          if (!activeReader || !activeStreamController) {
+            throw new Error('No active SSE reader to reconnect');
+          }
+
+          await activeReader.cancel('forced reconnect from test');
+          activeStreamController.error(new Error('forced reconnect from test'));
+        },
+        stop: () => {
+          state.stopped = true;
+          void activeReader?.cancel('test cleanup');
+          window.fetch = originalFetch;
+        },
+      };
+    }, [token, org.orgSlug]);
+
+    const triggerResponsePromise = page.waitForResponse((response) => {
+      return response.request().method() === 'POST'
+        && response.url().includes(`/api/org/${org.orgSlug}/scraper/trigger`);
+    });
+    await page.getByTestId('scrape-all-button').click();
+    const triggerResponse = await triggerResponsePromise;
+    expect(triggerResponse.ok()).toBe(true);
+
+    const progress = page.getByTestId('scrape-progress');
+    await expect(progress).toBeVisible({ timeout: 10000 });
+    await expect(progress.getByTestId('sse-connection-status')).toHaveText(/Connecté/i, { timeout: 60000 });
+    await expect(progress.getByTestId('scrape-progress-percentage').first()).toBeVisible({ timeout: 60000 });
+    await expect(progress.getByTestId('scrape-progress-eta')).toBeVisible({ timeout: 60000 });
+
+    await expect.poll(async () => page.evaluate(() => window.__sseLongRunMonitor?.state.lastEventId ?? null), {
+      timeout: 60000,
+    }).not.toBeNull();
+
+    const lastEventIdBeforeReconnect = await page.evaluate(() => window.__sseLongRunMonitor?.state.lastEventId);
+    expect(lastEventIdBeforeReconnect).toBeTruthy();
+
+    await page.evaluate(() => window.__sseLongRunMonitor?.forceReconnect());
+
+    await expect.poll(async () => page.evaluate(() => window.__sseLongRunMonitor?.state.connectionCount ?? 0), {
+      timeout: 10000,
+    }).toBeGreaterThanOrEqual(2);
+    await expect.poll(async () => page.evaluate(() => window.__sseLongRunMonitor?.state.requestLastEventIds.at(-1) ?? null), {
+      timeout: 10000,
+    }).toBe(lastEventIdBeforeReconnect);
+    await expect.poll(async () => page.evaluate(() => window.__sseLongRunMonitor?.state.isOpen ?? false), {
+      timeout: 10000,
+    }).toBe(true);
+    await expect(progress.getByTestId('sse-connection-status')).toHaveText(/Connecté/i, { timeout: 60000 });
+
+    await page.waitForTimeout(10 * 60 * 1000);
+
+    const snapshot = await page.evaluate(() => window.__sseLongRunMonitor?.state);
+    expect(snapshot).toBeTruthy();
+    expect(snapshot?.errors).toEqual([]);
+    expect(snapshot?.isOpen).toBe(true);
+    expect(snapshot?.duplicateEventIds).toEqual([]);
+    expect(snapshot?.monotonicViolations).toEqual([]);
+    expect(snapshot?.businessEventTypes).toContain('started');
+    expect(snapshot?.businessEventTypes).toContain('cinema_started');
+    expect(snapshot?.businessEventTypes).not.toContain('completed');
+    expect(snapshot?.businessEventTypes).not.toContain('failed');
+    expect(snapshot?.pingReceivedAt.length).toBeGreaterThanOrEqual(19);
+    expect(getLongestGapMs(snapshot?.pingReceivedAt ?? [])).toBeLessThanOrEqual(45000);
+
+    await expect(progress.getByTestId('sse-connection-status')).toHaveText(/Connecté/i, { timeout: 60000 });
+    await expect(progress.getByTestId('scrape-progress-percentage').first()).toBeVisible();
+
+    await page.evaluate(() => window.__sseLongRunMonitor?.stop());
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,6 +6,7 @@ const scrapeSpecs = [
   '**/scrape-progress.spec.ts',
   '**/cinema-scrape.spec.ts',
   '**/tenant-concurrent-scrape-progress.spec.ts',
+  '**/sse-long-running-connection.spec.ts',
   '**/reports-navigation.spec.ts',
   '**/day-filter.spec.ts',
 ];

--- a/server/src/routes/scraper.test.ts
+++ b/server/src/routes/scraper.test.ts
@@ -303,7 +303,32 @@ describe('Routes - Scraper', () => {
             org_id: 42,
             org_slug: 'acme',
           }),
-        })
+        }),
+        undefined
+      );
+    });
+
+    it('should pass Last-Event-ID header to the progress subscription', async () => {
+      mockSubscribeToProgress.mockImplementation((res, _onClose, _context, _lastEventId) => {
+        res.status(200).end();
+        return () => {};
+      });
+      const app = await setupApp({ org_id: 42, org_slug: 'acme' });
+
+      const response = await request(app)
+        .get('/api/scraper/progress')
+        .set('Last-Event-ID', '23');
+
+      expect(response.status).toBe(200);
+      expect(mockSubscribeToProgress).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(Function),
+        expect.objectContaining({
+          endpoint: '/api/scraper/progress',
+          method: 'GET',
+          user: expect.objectContaining({ org_slug: 'acme' }),
+        }),
+        '23'
       );
     });
 

--- a/server/src/routes/scraper.ts
+++ b/server/src/routes/scraper.ts
@@ -312,9 +312,11 @@ router.get('/progress', protectedLimiter, requireAuth, (req, res, next) => {
       user: (req as AuthRequest).user,
     };
 
+    const lastEventId = req.get('Last-Event-ID');
+
     const cleanup = scraperService.subscribeToProgress(res, () => {
       // Optional additional cleanup on route level if needed
-    }, observabilityContext);
+    }, observabilityContext, lastEventId);
 
     req.on('close', cleanup);
   } catch (error) {

--- a/server/src/services/progress-tracker.test.ts
+++ b/server/src/services/progress-tracker.test.ts
@@ -1,6 +1,47 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ProgressTracker } from './progress-tracker.js';
 
+interface ParsedSseFrame {
+  id?: string;
+  data: Record<string, unknown>;
+}
+
+function parseSseFrame(chunk: string): ParsedSseFrame {
+  let id: string | undefined;
+  const dataLines: string[] = [];
+
+  for (const line of chunk.trimEnd().split(/\r?\n/)) {
+    if (line.startsWith('id:')) {
+      id = line.slice(3).trimStart();
+      continue;
+    }
+
+    if (line.startsWith('data:')) {
+      dataLines.push(line.slice(5).trimStart());
+    }
+  }
+
+  return {
+    id,
+    data: JSON.parse(dataLines.join('\n')) as Record<string, unknown>,
+  };
+}
+
+function addListenerWithLastEventId(
+  tracker: ProgressTracker,
+  listener: unknown,
+  traceContext: { org_slug?: string } | undefined,
+  lastEventId: string,
+): void {
+  const addListener = tracker.addListener as unknown as (
+    res: unknown,
+    listenerTrace?: { org_slug?: string },
+    resumeAfterEventId?: string,
+  ) => void;
+
+  addListener.call(tracker, listener, traceContext, lastEventId);
+}
+
 describe('ProgressTracker', () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -34,8 +75,7 @@ describe('ProgressTracker', () => {
     });
 
     expect(writes.length).toBe(1);
-    const payload = writes[0].replace(/^data:\s*/, '').trim();
-    const parsed = JSON.parse(payload);
+    const parsed = parseSseFrame(writes[0]).data;
 
     expect(parsed.type).toBe('started');
     expect(parsed.traceContext).toEqual(expect.objectContaining({
@@ -76,7 +116,7 @@ describe('ProgressTracker', () => {
     tracker.addListener(listener, { org_slug: 'acme' });
 
     expect(writes).toHaveLength(1);
-    const payload = JSON.parse(writes[0].replace(/^data:\s*/, '').trim());
+    const payload = parseSseFrame(writes[0]).data;
     expect(payload.report_id).toBe(10);
   });
 
@@ -108,8 +148,201 @@ describe('ProgressTracker', () => {
     });
 
     expect(writes).toHaveLength(1);
-    const payload = JSON.parse(writes[0].replace(/^data:\s*/, '').trim());
+    const payload = parseSseFrame(writes[0]).data;
     expect(payload.report_id).toBe(11);
+  });
+
+  it('writes replayable business events with unique monotonically increasing SSE ids', () => {
+    const tracker = new ProgressTracker();
+    const writes: string[] = [];
+    const listener = {
+      write: (chunk: string) => {
+        writes.push(chunk);
+      },
+      end: () => {},
+    } as any;
+
+    tracker.addListener(listener);
+    tracker.emit({
+      type: 'started',
+      report_id: 1,
+      total_cinemas: 1,
+      total_dates: 1,
+    });
+    tracker.emit({
+      type: 'cinema_started',
+      report_id: 1,
+      cinema_name: 'Cinema One',
+      cinema_id: 'C1',
+      index: 0,
+    });
+
+    const frames = writes.map(parseSseFrame);
+
+    expect(frames).toEqual([
+      expect.objectContaining({ id: '1', data: expect.objectContaining({ type: 'started' }) }),
+      expect.objectContaining({ id: '2', data: expect.objectContaining({ type: 'cinema_started' }) }),
+    ]);
+    expect(Number(frames[1].id)).toBeGreaterThan(Number(frames[0].id));
+    expect(new Set(frames.map((frame) => frame.id)).size).toBe(frames.length);
+  });
+
+  it('replays only matching tenant events after the provided Last-Event-ID', () => {
+    const tracker = new ProgressTracker();
+
+    tracker.emit({
+      type: 'started',
+      report_id: 10,
+      total_cinemas: 1,
+      total_dates: 1,
+      traceContext: { org_slug: 'acme' },
+    });
+    tracker.emit({
+      type: 'started',
+      report_id: 11,
+      total_cinemas: 1,
+      total_dates: 1,
+      traceContext: { org_slug: 'other' },
+    });
+    tracker.emit({
+      type: 'cinema_started',
+      report_id: 10,
+      cinema_name: 'Cinema Acme',
+      cinema_id: 'C10',
+      index: 0,
+      traceContext: { org_slug: 'acme' },
+    });
+
+    const writes: string[] = [];
+    const listener = {
+      write: (chunk: string) => {
+        writes.push(chunk);
+      },
+      end: () => {},
+    } as any;
+
+    addListenerWithLastEventId(tracker, listener, { org_slug: 'acme' }, '1');
+
+    expect(writes).toHaveLength(1);
+    expect(parseSseFrame(writes[0])).toEqual({
+      id: '3',
+      data: expect.objectContaining({
+        type: 'cinema_started',
+        report_id: 10,
+        traceContext: expect.objectContaining({ org_slug: 'acme' }),
+      }),
+    });
+  });
+
+  it('normalizes invalid and negative Last-Event-ID values to a full tenant-scoped replay', () => {
+    const tracker = new ProgressTracker();
+
+    tracker.emit({
+      type: 'started',
+      report_id: 20,
+      total_cinemas: 1,
+      total_dates: 1,
+      traceContext: { org_slug: 'acme' },
+    });
+
+    const writes: string[] = [];
+    const listener = {
+      write: (chunk: string) => {
+        writes.push(chunk);
+      },
+      end: () => {},
+    } as any;
+
+    addListenerWithLastEventId(tracker, listener, { org_slug: 'acme' }, 'not-a-number');
+    addListenerWithLastEventId(tracker, listener, { org_slug: 'acme' }, '-7');
+
+    expect(writes).toHaveLength(2);
+    expect(parseSseFrame(writes[0])).toEqual({
+      id: '1',
+      data: expect.objectContaining({ type: 'started', report_id: 20 }),
+    });
+    expect(parseSseFrame(writes[1])).toEqual({
+      id: '1',
+      data: expect.objectContaining({ type: 'started', report_id: 20 }),
+    });
+  });
+
+  it('falls back to a full tenant-scoped replay when Last-Event-ID is ahead of the retained buffer', () => {
+    const tracker = new ProgressTracker();
+
+    tracker.emit({
+      type: 'started',
+      report_id: 21,
+      total_cinemas: 1,
+      total_dates: 1,
+      traceContext: { org_slug: 'acme' },
+    });
+
+    const writes: string[] = [];
+    const listener = {
+      write: (chunk: string) => {
+        writes.push(chunk);
+      },
+      end: () => {},
+    } as any;
+
+    addListenerWithLastEventId(tracker, listener, { org_slug: 'acme' }, '999');
+
+    expect(writes).toHaveLength(1);
+    expect(parseSseFrame(writes[0])).toEqual({
+      id: '1',
+      data: expect.objectContaining({ type: 'started', report_id: 21 }),
+    });
+  });
+
+  it('does not reset the SSE id sequence when a new started event clears replay history', () => {
+    const tracker = new ProgressTracker();
+
+    tracker.emit({
+      type: 'started',
+      report_id: 1,
+      total_cinemas: 1,
+      total_dates: 1,
+    });
+    tracker.emit({
+      type: 'completed',
+      report_id: 1,
+      summary: {
+        total_cinemas: 1,
+        successful_cinemas: 1,
+        failed_cinemas: 0,
+        total_films: 1,
+        total_showtimes: 1,
+        total_dates: 1,
+        duration_ms: 1,
+        errors: [],
+      },
+    });
+    tracker.emit({
+      type: 'started',
+      report_id: 2,
+      total_cinemas: 1,
+      total_dates: 1,
+    });
+
+    const writes: string[] = [];
+    const listener = {
+      write: (chunk: string) => {
+        writes.push(chunk);
+      },
+      end: () => {},
+    } as any;
+
+    tracker.addListener(listener);
+
+    expect(writes).toHaveLength(1);
+    expect(parseSseFrame(writes[0])).toEqual({
+      id: '3',
+      data: expect.objectContaining({ type: 'started', report_id: 2 }),
+    });
+    expect(tracker.getEvents()).toEqual([
+      expect.objectContaining({ type: 'started', report_id: 2 }),
+    ]);
   });
 
   it('emits JSON ping heartbeats every 30 seconds without polluting replay history', () => {
@@ -134,7 +367,40 @@ describe('ProgressTracker', () => {
       type: 'ping',
       timestamp: expect.any(String),
     });
+    expect(writes[0]).not.toMatch(/^id:/m);
     expect(tracker.getEvents()).toEqual([]);
+  });
+
+  it('does not assign heartbeat pings replay ids or consume the next business event id', () => {
+    vi.useFakeTimers();
+
+    const tracker = new ProgressTracker();
+    const writes: string[] = [];
+    const listener = {
+      write: (chunk: string) => {
+        writes.push(chunk);
+      },
+      end: () => {},
+    } as any;
+
+    tracker.addListener(listener);
+    vi.advanceTimersByTime(30000);
+    tracker.emit({
+      type: 'started',
+      report_id: 30,
+      total_cinemas: 1,
+      total_dates: 1,
+    });
+
+    expect(writes).toHaveLength(2);
+    expect(writes[0]).not.toMatch(/^id:/m);
+    expect(parseSseFrame(writes[1])).toEqual({
+      id: '1',
+      data: expect.objectContaining({ type: 'started', report_id: 30 }),
+    });
+    expect(tracker.getEvents()).toEqual([
+      expect.objectContaining({ type: 'started', report_id: 30 }),
+    ]);
   });
 
   it('sends heartbeat pings to tenant-scoped listeners', () => {

--- a/server/src/services/progress-tracker.ts
+++ b/server/src/services/progress-tracker.ts
@@ -56,10 +56,17 @@ export interface ScrapeSummary {
   status?: 'success' | 'partial_success' | 'failed' | 'rate_limited';
 }
 
+interface ReplayableProgressEvent {
+  id: number;
+  event: ProgressEvent;
+}
+
 // Progress tracker class
 export class ProgressTracker {
   private listeners: Set<Response> = new Set();
   private events: ProgressEvent[] = [];
+  private replayableEvents: ReplayableProgressEvent[] = [];
+  private nextEventId = 1;
   private heartbeatInterval?: NodeJS.Timeout;
   private traceContextByListener: Map<Response, ProgressTraceContext | undefined> = new Map();
   private lastBusinessActivityByListener: Map<Response, number> = new Map();
@@ -73,17 +80,29 @@ export class ProgressTracker {
   }
 
   // Add a new SSE listener
-  addListener(res: Response, traceContext?: ProgressTraceContext): void {
+  addListener(res: Response, traceContext?: ProgressTraceContext, lastEventId?: string): void {
     this.listeners.add(res);
     this.traceContextByListener.set(res, traceContext);
     this.lastBusinessActivityByListener.set(res, Date.now());
 
+    const latestReplayableEventId = this.replayableEvents.at(-1)?.id;
+    const normalizedLastEventId = this.normalizeLastEventId(lastEventId);
+    const resumeAfterId = latestReplayableEventId !== undefined
+      && normalizedLastEventId !== undefined
+      && normalizedLastEventId > latestReplayableEventId
+      ? undefined
+      : normalizedLastEventId;
+
     // Send existing events to new listener
-    for (const event of this.events) {
-      if (!this.matchesListener(event, traceContext)) {
+    for (const replayableEvent of this.replayableEvents) {
+      if (resumeAfterId !== undefined && replayableEvent.id <= resumeAfterId) {
         continue;
       }
-      this.sendToListener(res, event);
+
+      if (!this.matchesListener(replayableEvent.event, traceContext)) {
+        continue;
+      }
+      this.sendToListener(res, replayableEvent.event, replayableEvent.id);
     }
 
     // Start heartbeat if this is the first listener
@@ -108,17 +127,34 @@ export class ProgressTracker {
   emit(event: ProgressEvent): void {
     if (event.type === 'started' && !this.hasActiveJobs()) {
       this.events = [];
+      this.replayableEvents = [];
     }
 
+    const eventId = this.nextEventId++;
     this.events.push(event);
+    this.replayableEvents.push({ id: eventId, event });
 
     // Send to all connected listeners
     for (const listener of this.listeners) {
       if (!this.matchesListener(event, this.traceContextByListener.get(listener))) {
         continue;
       }
-      this.sendToListener(listener, event);
+      this.sendToListener(listener, event, eventId);
     }
+  }
+
+  private normalizeLastEventId(lastEventId?: string): number | undefined {
+    if (lastEventId === undefined) {
+      return undefined;
+    }
+
+    const normalized = lastEventId.trim();
+    if (!/^\d+$/.test(normalized)) {
+      return undefined;
+    }
+
+    const parsed = Number(normalized);
+    return Number.isSafeInteger(parsed) ? parsed : undefined;
   }
 
   private getLatestEventsByJob(listenerTrace?: ProgressTraceContext): Map<string, ProgressEvent> {
@@ -152,7 +188,7 @@ export class ProgressTracker {
   }
 
   // Send an event to a specific listener
-  private sendToListener(res: Response, event: ProgressEvent): void {
+  private sendToListener(res: Response, event: ProgressEvent, eventId: number): void {
     try {
       const listenerTrace = this.traceContextByListener.get(res);
       const payload: ProgressEvent = listenerTrace
@@ -160,7 +196,7 @@ export class ProgressTracker {
         : event;
 
       this.lastBusinessActivityByListener.set(res, Date.now());
-      res.write(`data: ${JSON.stringify(payload)}\n\n`);
+      res.write(`id: ${eventId}\ndata: ${JSON.stringify(payload)}\n\n`);
     } catch (error) {
       this.removeListener(res);
     }
@@ -220,6 +256,8 @@ export class ProgressTracker {
   // Clear all events and listeners
   reset(): void {
     this.events = [];
+    this.replayableEvents = [];
+    this.nextEventId = 1;
     this.stopHeartbeat();
     
     // Close all active connections

--- a/server/src/services/scraper-service.test.ts
+++ b/server/src/services/scraper-service.test.ts
@@ -251,7 +251,7 @@ describe('ScraperService', () => {
       const cleanup = scraperService.subscribeToProgress(mockRes, mockOnClose);
       
       expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Type', 'text/event-stream');
-      expect(progressTracker.addListener).toHaveBeenCalledWith(mockRes, undefined);
+      expect(progressTracker.addListener).toHaveBeenCalledWith(mockRes, undefined, undefined);
       
       cleanup();
       
@@ -287,7 +287,37 @@ describe('ScraperService', () => {
           endpoint: '/api/org/acme/scraper/progress',
           method: 'GET',
           traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
-        })
+        }),
+        undefined
+      );
+    });
+
+    it('should pass Last-Event-ID resume context to progress tracker', () => {
+      const mockRes = { setHeader: vi.fn() };
+      const mockOnClose = vi.fn();
+
+      scraperService.subscribeToProgress(mockRes, mockOnClose, {
+        endpoint: '/api/org/acme/scraper/progress',
+        method: 'GET',
+        user: {
+          id: 3,
+          username: 'tenant-user',
+          role_name: 'admin',
+          is_system_role: false,
+          permissions: [],
+          org_id: 42,
+          org_slug: 'acme',
+        },
+      }, '17');
+
+      expect(progressTracker.addListener).toHaveBeenCalledWith(
+        mockRes,
+        expect.objectContaining({
+          org_id: '42',
+          org_slug: 'acme',
+          user_id: '3',
+        }),
+        '17'
       );
     });
   });

--- a/server/src/services/scraper-service.ts
+++ b/server/src/services/scraper-service.ts
@@ -182,13 +182,13 @@ export class ScraperService {
   /**
    * Subscribes an HTTP response stream to the progress tracker events.
    */
-  subscribeToProgress(res: any, onClose: () => void, context?: ScrapeObservabilityContext) {
+  subscribeToProgress(res: any, onClose: () => void, context?: ScrapeObservabilityContext, lastEventId?: string) {
     res.setHeader('Content-Type', 'text/event-stream');
     res.setHeader('Cache-Control', 'no-cache');
     res.setHeader('Connection', 'keep-alive');
     res.setHeader('X-Accel-Buffering', 'no'); // Disable nginx buffering
 
-    progressTracker.addListener(res, this.buildProgressTraceContext(context));
+    progressTracker.addListener(res, this.buildProgressTraceContext(context), lastEventId);
     logger.info('SSE client connected', {
       listeners: progressTracker.getListenerCount(),
       org_id: context?.user?.org_id,


### PR DESCRIPTION
## Summary

This PR validates and hardens long-running authenticated SSE progress streams for scraper jobs by adding standard SSE event IDs, `Last-Event-ID` resume support, and deterministic coverage across server, client, and Playwright layers. It also updates the scraper API/troubleshooting docs so the published contract matches the shipped behavior.

## Related Issue

No issue number was provided for this change.

## Type of Change

- [x] `fix` - Bug fix (non-breaking change that fixes an issue)
- [ ] `feat` - New feature (non-breaking change that adds functionality)
- [ ] `feat!` - Breaking change (fix or feature that would cause existing functionality to change)
- [x] `docs` - Documentation only changes
- [x] `test` - Adding or updating tests
- [ ] `refactor` - Code change that neither fixes a bug nor adds a feature
- [ ] `perf` - Performance improvement
- [ ] `chore` - Maintenance (dependencies, configuration, etc.)
- [ ] `ci` - CI/CD changes

## Changes Made

- Added monotonic SSE `id:` fields for replayable scraper progress events and threaded `Last-Event-ID` from the route through `ScraperService` into `ProgressTracker`.
- Hardened replay behavior for tenant-scoped streams, including invalid/negative/ahead-of-buffer cursor handling and preserving heartbeat `ping` frames as transport-only events.
- Extended the authenticated fetch-based client SSE transport to parse `id:` fields, preserve multiline/UTF-8 parsing behavior, reconnect with `Last-Event-ID`, and reset reconnect budgeting after successful reopen.
- Added and expanded targeted server/client tests for SSE IDs, replay filtering, reconnect behavior, and route/service wiring.
- Added a dedicated long-running Playwright spec for story 3.3 and registered it under the scrape-serial project.
- Updated scraper API reference and troubleshooting documentation to describe the real SSE contract, including heartbeat cadence and resume semantics.
- Added story and validation artifacts and moved story `3-3-sse-long-running-connection-validation-10-minutes` to `review` in sprint tracking.

## Testing

### Tests Added/Modified

- [x] Unit tests added
- [x] Unit tests updated
- [ ] Integration tests added
- [ ] No tests needed (explain why)

### Test Commands Run

```bash
cd server && npm run test:run -- src/services/progress-tracker.test.ts
cd client && npm run test:run -- src/api/client.test.ts
cd server && npm run test:run -- src/services/progress-tracker.test.ts src/services/scraper-service.test.ts src/routes/scraper.test.ts
cd client && npm run test:run -- src/api/client.test.ts src/hooks/useScrapeProgress.test.ts src/components/ScrapeProgress.test.tsx
```

## Documentation

- [ ] README.md updated (if applicable)
- [ ] DEPLOYMENT.md updated (if applicable)
- [ ] Code comments added for complex logic
- [x] No documentation changes needed

Note: API/reference documentation was updated in `docs/reference/api/scraper.md` and `docs/troubleshooting/scraper.md`.

## Checklist

### Before Submitting

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Each commit is atomic (one logical change per commit)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (TDD)
- [ ] All tests pass locally (`npm run test:run`)
- [ ] Code coverage is maintained or improved

### Code Quality

- [x] My code follows the existing code style
- [x] I have removed any debugging code or console.logs
- [x] No new warnings are introduced
- [ ] TypeScript compiles without errors

## Screenshots (if applicable)

Not applicable.

## Additional Notes

- Branch: `test/story-3-3-sse-resume-validation`
- Commit: `19c145b` (`test(sse): validate long-running progress stream resume behavior`)
- This PR includes both production changes and validation artifacts because story 3.3 requires runtime support for truthful long-running SSE resume verification, not only test scaffolding.
- I intentionally did not claim the full workspace test suite, lint, build, or the 10+ minute Playwright run in this PR because those commands were not rerun in this session.