### PR TITLE
fix(saas): type requirePermission calls with PermissionName in org-settings

### DIFF
--- a/packages/saas/src/routes/org-settings.ts
+++ b/packages/saas/src/routes/org-settings.ts
@@ -29,6 +29,7 @@ import {
 import { requireAuth } from 'allo-scrapper-server/dist/middleware/auth.js';
 // @ts-ignore
 import { requirePermission } from 'allo-scrapper-server/dist/middleware/permission.js';
+import type { PermissionName } from 'allo-scrapper-server/dist/types/role.js';
 
 const router = Router();
 
@@ -329,11 +330,17 @@ async function updateSettingsHandler(req: Request, res: Response, next: NextFunc
   }
 }
 
-const requireSettingsRead = [requireAuth as any, requirePermission('settings:read') as any] as const;
-const requireSettingsUpdate = [requireAuth as any, requirePermission('settings:update') as any] as const;
-const requireSettingsExport = [requireAuth as any, requirePermission('settings:export') as any] as const;
-const requireSettingsImport = [requireAuth as any, requirePermission('settings:import') as any] as const;
-const requireSettingsReset = [requireAuth as any, requirePermission('settings:reset') as any] as const;
+const PERM_SETTINGS_READ: PermissionName    = 'settings:read';
+const PERM_SETTINGS_UPDATE: PermissionName  = 'settings:update';
+const PERM_SETTINGS_EXPORT: PermissionName  = 'settings:export';
+const PERM_SETTINGS_IMPORT: PermissionName  = 'settings:import';
+const PERM_SETTINGS_RESET: PermissionName   = 'settings:reset';
+
+const requireSettingsRead = [requireAuth as any, requirePermission(PERM_SETTINGS_READ) as any] as const;
+const requireSettingsUpdate = [requireAuth as any, requirePermission(PERM_SETTINGS_UPDATE) as any] as const;
+const requireSettingsExport = [requireAuth as any, requirePermission(PERM_SETTINGS_EXPORT) as any] as const;
+const requireSettingsImport = [requireAuth as any, requirePermission(PERM_SETTINGS_IMPORT) as any] as const;
+const requireSettingsReset = [requireAuth as any, requirePermission(PERM_SETTINGS_RESET) as any] as const;
 
 router.get('/', async (req: Request, res: Response, next: NextFunction) => {
   try {


### PR DESCRIPTION
## Summary

- Import `PermissionName` from `allo-scrapper-server/dist/types/role.js` in `org-settings.ts`
- Assign each permission string literal to a typed `PermissionName` constant before passing to `requirePermission`

## Why

The five `requirePermission(...)` calls in SaaS org-settings were passing bare string literals. A typo (e.g. `'settings:exprt'`) would compile silently and deny access at runtime with no compile-time signal. The `PermissionName` union type already covers all valid permission strings in the server; this PR propagates that safety into the SaaS package.

## What Changed

- `packages/saas/src/routes/org-settings.ts`: add `import type { PermissionName }` and five typed `PERM_*` constants

## Validation

- `cd packages/saas && npx tsc --noEmit` → exit 0

## Related

- Closes #965
- Companion to #963 / PR #964 (remove @ts-ignore)
- Deferred from code review of PR #962 (Story 5.1)