### PR TITLE
test(e2e): wrap theme application suite in test.describe.serial

### DIFF
--- a/e2e/theme-application.spec.ts
+++ b/e2e/theme-application.spec.ts
@@ -76,7 +76,7 @@ function buildFixtureFilmId(slug: string, index: number): number {
   return base + index - 1;
 }
 
-test.describe('White-Label Theme Application', () => {
+test.describe.serial('White-Label Theme Application', () => {
   test.skip(!useOrgFixture, 'Requires fixture-backed SaaS runtime (E2E_ENABLE_ORG_FIXTURE=true)');
 
   test('applies seeded theme tokens to real tenant routes and visible UI', async ({ page, seedTestOrg }) => {


### PR DESCRIPTION
## Summary

- Change `test.describe` to `test.describe.serial` in `e2e/theme-application.spec.ts`

## Why

The suite contains multiple tests that write to the same org's settings (save, reset, import/export). Parallel execution within a single worker can cause one test's write to be observed by another test's read assertions, producing non-deterministic failures. `test.describe.serial` guarantees sequential execution within the describe block.

## What Changed

- `e2e/theme-application.spec.ts`: one-line change, `test.describe` → `test.describe.serial`

## Validation

No test logic changed — this is an execution order guarantee only.
- Spec file parses and Playwright recognises `test.describe.serial`

## Related

- Closes #967
- Deferred from code review of PR #962 (Story 5.1)