### PR TITLE
docs: align BMAD workflow order and PR gating

### DIFF
--- a/.hermes/plans/2026-05-03-story-7-2-theme-variables-contract.md
+++ b/.hermes/plans/2026-05-03-story-7-2-theme-variables-contract.md
@@ -1,0 +1,254 @@
+# Story 7.2 — Refactor Theme Variables Contract Implementation Plan
+
+> **For Hermes:** utiliser `majordome-subagent-dev-loop` pour exécuter ce plan patch par patch, avec vérification locale avant `CR`, puis `GP` obligatoire après `CR`, avant toute autre décision. Après `GP`, attendre un ordre explicite de Maitre Opelkad avant tout `CS`, `DS`, `push-flow` ou merge-related action.
+
+**Goal:** unifier le contrat de thème white-label entre client, serveur et package SaaS afin qu’une seule nomenclature de clés de settings et de variables CSS soit utilisée en lecture, écriture, import/export et rendu.
+
+**Architecture:** faire du contrat serveur/SaaS la source canonique (`color_surface`, `color_text_primary`, `font_primary`, etc.), puis retirer progressivement les alias legacy côté client (`color_text`, `color_border`, `font_family_heading`, `font_family_body`). Conserver au besoin une courte phase de compatibilité aux frontières d’import/export, mais ne plus propager les noms legacy dans les types UI, contextes et hooks.
+
+**Tech Stack:** React + TypeScript client, Express + TypeScript serveur, package SaaS partagé, Vitest, Playwright ciblé si besoin.
+
+---
+
+## Contexte établi
+
+Constats relevés dans l’état actuel du repo :
+
+- **Contrat canonique côté serveur** déjà exprimé avec les noms modernes dans `server/src/types/settings.ts` et `packages/saas/src/db/types.ts` :
+  - `color_surface`
+  - `color_text_primary`
+  - `color_text_secondary`
+  - `font_primary`
+  - `font_secondary`
+- **Client encore majoritairement legacy** dans `client/src/api/settings.ts`, `client/src/contexts/SettingsProvider.tsx`, `client/src/pages/admin/SettingsPage.tsx`, `client/src/hooks/useTheme.test.tsx` :
+  - `color_text`
+  - `color_border`
+  - `font_family_heading`
+  - `font_family_body`
+- **Ponts de compatibilité déjà présents** :
+  - `client/src/api/settings.ts` avec `normalizeSettingsResponse()` et `toServerSettingsUpdate()`
+  - `packages/saas/src/routes/org-settings.ts` avec `normalizeImportSettings()` qui accepte encore les anciennes clés à l’import
+- **Génération CSS déjà canonique** dans `server/src/services/theme-generator.ts`, avec variables modernes + alias CSS legacy `--theme-*` pour compatibilité de rendu.
+
+## Décision de contrat
+
+### Contrat JSON canonique cible
+
+Le client, le serveur et SaaS doivent converger vers ces clés applicatives :
+
+- `site_name`
+- `logo_base64`
+- `favicon_base64`
+- `color_primary`
+- `color_secondary`
+- `color_accent`
+- `color_background`
+- `color_surface`
+- `color_text_primary`
+- `color_text_secondary`
+- `color_success`
+- `color_error`
+- `font_primary`
+- `font_secondary`
+- `footer_text`
+- `footer_links`
+- `email_from_name`
+- `email_from_address`
+- `email_logo_base64` si encore nécessaire côté client admin
+- `scrape_mode`
+- `scrape_days`
+
+### Compatibilité transitoire autorisée
+
+Pendant la migration, les **seules** zones autorisées à accepter les noms legacy sont :
+
+- import JSON (`/api/settings/import` et `/api/org/:slug/settings/import`)
+- éventuellement lecture défensive d’anciens exports fixtures/tests
+
+Les noms legacy ne doivent plus être le contrat principal des types client ni de l’état React.
+
+---
+
+## Task 1: Figer le contrat canonique côté client API
+
+**Objective:** faire du client API le point d’entrée canonique des noms de thème.
+
+**Files:**
+- Modify: `client/src/api/settings.ts`
+- Test: `client/src/api/settings.test.ts` si présent, sinon enrichir les tests consommateurs existants
+
+**Étapes:**
+1. Remplacer `AppSettingsPublic`, `AppSettings` et `AppSettingsUpdate` côté client pour utiliser les noms canoniques (`color_surface`, `color_text_primary`, `font_primary`, etc.).
+2. Réduire `LegacyThemeShape` à un rôle strictement défensif de lecture d’anciens payloads.
+3. Adapter `normalizeSettingsResponse()` pour produire **uniquement** la forme canonique en sortie.
+4. Adapter `toServerSettingsUpdate()` pour devenir un simple passage quasi direct, sans remap depuis les champs legacy du formulaire.
+5. Conserver, si nécessaire, un normaliseur d’import legacy dédié, explicitement limité aux anciens JSON.
+
+**Verification:**
+- Les types exportés par `client/src/api/settings.ts` n’exposent plus `color_text`, `color_border`, `font_family_heading`, `font_family_body` comme contrat normal.
+- Les appels `getPublicSettings`, `getAdminSettings`, `updateSettings`, `importSettings` retournent tous la forme canonique.
+
+---
+
+## Task 2: Propager le contrat canonique dans le contexte React
+
+**Objective:** supprimer la duplication legacy dans l’état partagé du client.
+
+**Files:**
+- Modify: `client/src/contexts/SettingsContext.ts`
+- Modify: `client/src/contexts/SettingsProvider.tsx`
+
+**Étapes:**
+1. Mettre à jour `SettingsContextType` pour refléter les types canoniques venant de `client/src/api/settings.ts`.
+2. Dans `SettingsProvider.tsx`, supprimer les reconstructions d’objet public avec clés legacy.
+3. Faire circuler `adminSettings` et `publicSettings` avec les mêmes noms canoniques autant que possible.
+
+**Verification:**
+- `SettingsProvider` ne reconstruit plus `color_text`, `color_border`, `font_family_heading`, `font_family_body`.
+- Le contexte devient un simple transport de données canoniques.
+
+---
+
+## Task 3: Migrer l’écran admin Settings vers les clés canoniques
+
+**Objective:** aligner la UI d’édition avec le contrat serveur réel.
+
+**Files:**
+- Modify: `client/src/pages/admin/SettingsPage.tsx`
+- Test: `client/src/pages/admin/SettingsPage.test.tsx`
+
+**Étapes:**
+1. Mettre à jour `getInitialFormData()` pour lire `color_surface`, `color_text_primary`, `font_primary`, `font_secondary`.
+2. Mettre à jour les contrôles du formulaire :
+   - `Text Color` → `color_text_primary`
+   - `Border Color` ou l’équivalent métier à renommer vers `color_surface` si c’est bien la sémantique retenue
+   - `Heading Font` → `font_primary`
+   - `Body Font` → `font_secondary`
+3. Revoir les labels UI si nécessaire pour éviter la confusion entre « border » et « surface ».
+4. Mettre à jour les mocks de tests pour utiliser le contrat canonique.
+
+**Verification:**
+- Les valeurs du formulaire round-trip correctement avec `updateSettings()` sans couche legacy implicite.
+- Les tests de visibilité/permissions restent verts après renommage du contrat.
+
+---
+
+## Task 4: Aligner `useTheme` et les tests de rendu client
+
+**Objective:** faire dépendre le rendu du thème des mêmes clés que celles servies par le backend.
+
+**Files:**
+- Modify: `client/src/hooks/useTheme.ts`
+- Modify: `client/src/hooks/useTheme.test.tsx`
+- Optional review: composants ou tests qui consomment encore les noms legacy
+
+**Étapes:**
+1. Recalculer `themeVersion` à partir des champs canoniques :
+   - `color_surface`
+   - `color_text_primary`
+   - `font_primary`
+   - `font_secondary`
+2. Mettre à jour les fixtures de `useTheme.test.tsx` pour refléter le contrat canonique.
+3. Vérifier qu’aucune logique de cache d’URL thème ne dépend encore des noms legacy.
+
+**Verification:**
+- `useTheme.test.tsx` valide toujours le refresh du lien `theme.css` lors d’un changement de settings.
+- Les assertions portent sur les champs canoniques.
+
+---
+
+## Task 5: Durcir les frontières serveur et SaaS
+
+**Objective:** rendre explicite que le contrat principal est canonique, avec compatibilité legacy seulement aux frontières contrôlées.
+
+**Files:**
+- Modify: `server/src/routes/settings.ts`
+- Modify: `packages/saas/src/routes/org-settings.ts`
+- Review: `server/src/types/settings.ts`
+- Review: `packages/saas/src/db/types.ts`
+- Test: `server/src/routes/settings.test.ts`
+- Test: `packages/saas/src/services/org-settings-service.test.ts`
+- Add/extend tests if needed under `packages/saas/src/routes/`
+
+**Étapes:**
+1. Corriger dans `server/src/routes/settings.ts` les validations/limites qui utilisent encore `font_family_heading` et `font_family_body`, pour les faire pointer sur `font_primary` / `font_secondary`.
+2. Vérifier que le routeur serveur principal refuse/ignore proprement les payloads mal formés sans réintroduire de noms legacy comme contrat implicite.
+3. Conserver dans `packages/saas/src/routes/org-settings.ts` la compatibilité import legacy, mais documenter/tester qu’elle est cantonnée à `normalizeImportSettings()`.
+4. Ajouter des tests dédiés qui prouvent :
+   - payload canonique accepté
+   - ancien export legacy accepté seulement à l’import
+   - sortie API publique/admin toujours canonique
+
+**Verification:**
+- Les routeurs ne publient plus de contrat legacy hors import défensif.
+- Les validations serveur et SaaS parlent le même langage de champs.
+
+---
+
+## Task 6: Nettoyer et verrouiller les tests de non-régression
+
+**Objective:** prouver la convergence du contrat sur toutes les couches.
+
+**Files:**
+- Modify: `server/src/services/theme-generator.test.ts`
+- Modify: `server/src/routes/settings.test.ts`
+- Modify: `client/src/pages/admin/SettingsPage.test.tsx`
+- Modify: `client/src/hooks/useTheme.test.tsx`
+- Modify: tests additionnels pertinents dans `packages/saas/src/...`
+
+**Étapes:**
+1. Remplacer les fixtures legacy restantes par des fixtures canoniques.
+2. Conserver uniquement des tests legacy là où la compatibilité est volontaire (imports historiques).
+3. Ajouter une assertion croisée utile : les mêmes settings canoniques produisent les mêmes variables CSS attendues côté serveur.
+
+**Verification commands:**
+- `docker exec allo-scrapper-client-dev sh -lc 'cd /app && npm run test:run --workspace=client -- src/hooks/useTheme.test.tsx src/pages/admin/SettingsPage.test.tsx'`
+- `docker exec allo-scrapper-server-dev sh -lc 'cd /app && npm run test:run --workspace=allo-scrapper-server -- src/services/theme-generator.test.ts src/routes/settings.test.ts'`
+- `docker exec allo-scrapper-server-dev sh -lc 'cd /app && npm run test:run --workspace=@allo-scrapper/saas -- src/services/org-settings-service.test.ts'`
+
+**Expected:** suites vertes, sans dépendance principale aux noms legacy.
+
+---
+
+## Risques et points d’attention
+
+1. **Confusion sémantique `color_surface` vs `color_border`**
+   - Le legacy mappe aujourd’hui `color_border` vers `color_surface`.
+   - Il faut confirmer en CS si le champ UI doit réellement devenir `surface`, ou si un vrai champ `border` manque au modèle.
+
+2. **Caches / import-export historiques**
+   - Des fixtures ou exports existants peuvent encore contenir les anciennes clés.
+   - Ne pas casser l’import historique ; isoler cette compatibilité.
+
+3. **Tests E2E fragiles autour des settings**
+   - Les flows Playwright/import ont déjà montré de la fragilité.
+   - Limiter le périmètre de 7.2 au contrat de données + tests ciblés avant d’étendre aux E2E.
+
+4. **Duplication client public/admin**
+   - `SettingsProvider` reconstruit encore manuellement `publicSettings` à partir d’`adminSettings`.
+   - Source probable de dérive future si non simplifiée.
+
+---
+
+## Définition de fini proposée pour 7.2
+
+La story peut être considérée terminée quand :
+
+- le client manipule le contrat canonique de thème de bout en bout ;
+- le serveur et SaaS publient un contrat JSON canonique identique ;
+- les noms legacy n’existent plus que dans la compatibilité d’import historique ;
+- les tests ciblés client, serveur et SaaS passent ;
+- aucune couche active ne dépend encore des noms `color_text`, `color_border`, `font_family_heading`, `font_family_body` comme contrat principal.
+
+---
+
+## Exécution BMAD recommandée
+
+Prochaine séquence BMAD de référence :
+
+1. **CS** — matérialiser la story 7.2 en implementation artifact à partir de ce plan
+2. **VS** — valider le périmètre exact, surtout `color_surface` vs `color_border`
+3. **DS** — exécution patch par patch via sous-agent indépendant
+4. **CR local** — revue BMAD locale avant toute décision de suite
+5. **GP** — étape obligatoire immédiatement après `CR`
+6. **WAIT** — après `GP`, attendre un ordre explicite de Maitre Opelkad avant tout `CS`, `DS`, `push-flow` ou merge-related action

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,11 @@
 - PR template expects `Closes #<issue>` and a short list of test commands actually run.
 - CI branch patterns are `feat/**`, `fix/**`, `docs/**`, `chore/**`, `ci/**`, `refactor/**`, `test/**`, `perf/**`.
 - PRs merged to `main` trigger automated versioning and releases. Add exactly one version label: `major`, `minor`, or `patch`.
+- For BMAD tracking in this repository, treat `done` as **already merged into `develop`**, not merely coded locally or pushed to a PR branch.
+- BMAD order is strict: `DS -> CR -> GP -> WAIT`.
+- After a `CR`, the mandatory next step is `GP` (Generate Plan).
+- After `GP`, stop and wait for an explicit new order before any `CS`, `DS`, `push-flow`, or merge-related action.
+- Do not auto-advance BMAD work just because a story reached `review` or because a PR exists; only an explicit user order unlocks the next phase.
 
 ## Current Behavior Worth Trusting Over Older Docs
 

--- a/README.md
+++ b/README.md
@@ -800,14 +800,14 @@ All documentation lives under the `/docs/` directory, organized following the [D
 
 ## 🤝 Contributing
 
-We welcome contributions! Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for:
+We welcome contributions! Please see [Contributing Guide](./docs/guides/development/contributing.md) for:
 - Code of Conduct
-- Development workflow (Issue → Branch → TDD → PR)
+- Development workflow (Issue → Branch → TDD → Local review → PR)
 - Coding standards
 - Commit message conventions (Conventional Commits)
 - Testing requirements
 
-For AI coding agents, see [AGENTS.md](./AGENTS.md) for mandatory workflow and TDD requirements.
+For AI coding agents, see [AGENTS.md](./AGENTS.md) for the mandatory house workflow and TDD requirements. In this repository's BMAD flow, `done` means merged into `develop`, local `CR` comes before any PR, then `GP` is the mandatory checkpoint, and after `GP` the agent must wait for an explicit new order before any `CS`, `DS`, `push-flow`, or merge-related action.
 
 **Redis integration tests (Testcontainers):**
 - Run `npm run test:integration --workspace=allo-scrapper-server` to execute Redis-backed integration tests.
@@ -835,9 +835,11 @@ For AI coding agents, see [AGENTS.md](./AGENTS.md) for mandatory workflow and TD
 3. Write tests before implementation (TDD)
 4. Follow Conventional Commits format
 5. Ensure all tests pass and Docker builds
-6. Create PR referencing the issue
-7. **Add version label** to PR (`major`, `minor`, or `patch`) when targeting `main`
-8. Wait for review before merging
+6. Run local review before any PR (`CR` for BMAD-tracked work)
+7. If this is BMAD-tracked work, run `GP` after `CR` and wait for an explicit order before any PR / push-flow / merge action
+8. Create a PR referencing the issue only when that step is actually requested
+9. **Add version label** to PR (`major`, `minor`, or `patch`) when targeting `main`
+10. Wait for review before merging
 
 **Automated versioning** (PRs to `main` only):
 - Add label `major` (breaking changes), `minor` (features), or `patch` (fixes)

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -21,7 +21,12 @@
 #   - ready-for-dev: Story file created in stories folder
 #   - in-progress: Developer actively working on implementation
 #   - review: Ready for code review (via Dev's code-review workflow)
-#   - done: Story completed
+#   - done: Story merged into develop
+#
+# Workflow Order Reminder:
+#   - Strict BMAD order for this repo: DS -> CR -> GP -> WAIT
+#   - After CR, the mandatory next step is GP (Generate Plan)
+#   - After GP, wait for an explicit new user order before CS, DS, push-flow, or merge actions
 #
 # Retrospective Status:
 #   - optional: Can be completed but not required

--- a/_bmad-output/project-context.md
+++ b/_bmad-output/project-context.md
@@ -185,6 +185,13 @@ _This file contains critical rules and patterns that AI agents must follow when 
 - **Docs Updated**: Update README.md/AGENTS.md if API or behavior changed
 - **Version Label**: Add `patch`, `minor`, or `major` label to PR
 
+**BMAD Order Enforcement:**
+- **`done` Means Merged**: In this repository, mark a BMAD story `done` only once its work is merged into `develop`
+- **Strict Sequence**: Follow `DS -> CR -> GP -> WAIT`
+- **Post-CR Gate**: After `CR`, the next mandatory step is `GP` (Generate Plan)
+- **Wait State**: After `GP`, stop and wait for an explicit new order before any `CS`, `DS`, `push-flow`, or merge action
+- **No Auto-Advance**: Never infer permission to continue from a PR, local green tests, or a `review` status alone
+
 **Deployment & Versioning:**
 - **Automated Versioning**: PR merge to main triggers version bump based on label
 - **Docker Images**: Built automatically with version tags (vX.Y.Z, vX.Y, vX, stable, latest)

--- a/docs/guides/development/README.md
+++ b/docs/guides/development/README.md
@@ -38,11 +38,11 @@ Comprehensive testing guide for all test types.
 Guidelines for contributing to the project.
 
 **What you'll learn:**
-- Branching strategy (Git Flow)
+- Branch-from-`develop` contribution workflow
 - Issue-first workflow
 - Test-Driven Development (TDD)
 - Conventional Commits format
-- Pull request process
+- Local review and pull request process
 - Code review guidelines
 
 **Best for:** Contributors, understanding project workflow

--- a/docs/guides/development/contributing.md
+++ b/docs/guides/development/contributing.md
@@ -26,9 +26,11 @@ Every contribution should follow this workflow:
 2. Plan           → Break down into tasks, identify tests needed
 3. TDD            → Write tests BEFORE implementation
 4. Implement      → Write minimal code to pass tests
-5. Atomic Commits → One logical change per commit
-6. Documentation  → Update README if needed
-7. Pull Request   → Open PR, reference issue, follow checklist
+5. Local Review   → Review the change locally before any PR (BMAD work: `CR`)
+6. Atomic Commits → One logical change per commit
+7. Documentation  → Update README / AGENTS / docs if needed
+8. BMAD Gate      → For BMAD-tracked work, run `GP` after `CR` and then wait for an explicit order
+9. Pull Request   → Open PR only when that step is explicitly requested or otherwise clearly in scope
 ```
 
 ---
@@ -378,11 +380,14 @@ Use the PR template which includes:
 
 ### Review Process
 
-1. Open PR against `develop` branch
-2. Ensure CI checks pass
-3. Request review from maintainers
-4. Address feedback with new commits (don't force-push during review)
-5. Squash if requested before merge
+1. Run local review first (`CR` for BMAD-tracked work)
+2. If this is BMAD-tracked work, run `GP` after `CR`
+3. After `GP`, wait for an explicit order before any PR / push-flow / merge action
+4. Open PR against `develop` branch only when that step is actually requested
+5. Ensure CI checks pass
+6. Request review from maintainers
+7. Address feedback with new commits (don't force-push during review)
+8. Squash if requested before merge
 
 ---
 

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -41,11 +41,11 @@ Security policies and vulnerability reporting.
 Guidelines for AI coding agents (Claude, Copilot, Cursor, etc.).
 
 **What you'll learn:**
-- Mandatory workflow (Issue → Branch → TDD → Commit → PR)
+- Mandatory workflow (Issue → Branch → TDD → Commit → local CR → GP gate → explicit-order PR)
 - Test-Driven Development (TDD) requirements
 - Conventional Commits format
 - Atomic commits strategy
-- Git Flow branching
+- Branch-from-`develop` workflow
 - White-label system guidelines
 
 **Best for:** AI agents, contributors using AI tools, understanding project standards

--- a/docs/project/agents.md
+++ b/docs/project/agents.md
@@ -25,8 +25,11 @@ This document provides instructions for AI coding agents (Claude, GitHub Copilot
 4. GREEN   → Write minimal code to make tests pass
 5. DOCS    → Update README.md / AGENTS.md if API or behaviour changed
 6. COMMIT  → Atomic commits with Conventional Commits format
-7. PR      → Open Pull Request referencing the issue, wait for review
-             → After merge: switch back to develop, pull latest
+7. CR      → Run local review before any PR
+8. GP      → For BMAD-tracked work, run Generate Plan after CR
+9. WAIT    → After GP, stop until an explicit new order unlocks PR / push-flow / merge work
+10. PR     → Open Pull Request only when that step is explicitly requested or otherwise clearly in scope
+              → After merge: switch back to develop, pull latest
 ```
 
 **Conditional steps (not always required):**
@@ -224,13 +227,13 @@ git commit -m "docs: update README with <feature>"        # DOCS — if applicab
 
 ---
 
-## Step 7: Pull Request
+## Step 7: Local Review / Pull Request
 
 ```bash
-# Push branch
+# Push branch only when that step is actually required
 git push -u origin feature/<issue-number>-<short-description>
 
-# Create PR
+# Create PR only when explicitly requested or otherwise clearly in scope
 gh pr create --title "feat(scope): description" --body "## Summary
 - Change 1
 - Change 2
@@ -238,12 +241,15 @@ gh pr create --title "feat(scope): description" --body "## Summary
 Closes #<issue-number>"
 ```
 
-**Before requesting review:**
+**Before any PR:**
 - [ ] All tests pass (`npm run test:run`)
 - [ ] Code coverage maintained
 - [ ] Conventional Commits used
 - [ ] Documentation updated (if applicable)
-- [ ] Issue referenced in PR body
+- [ ] Issue referenced in commit/branch context
+- [ ] Local review completed (`CR` for BMAD-tracked work)
+- [ ] If BMAD-tracked, `GP` executed after `CR`
+- [ ] After `GP`, an explicit order exists to proceed with PR / push-flow / merge work
 
 **After merge:**
 ```bash


### PR DESCRIPTION
## Summary
- align AGENTS, BMAD output guidance, and repo docs on the same workflow order
- document that `done` means already merged into `develop`
- enforce the `DS -> CR -> GP -> WAIT` rule in the repository-facing guidance
- update the committed 7.2 implementation plan wording so it no longer suggests the old order

## Tests
- docs-only change; no runtime tests executed

Closes #973
