### PR TITLE
test(stability): harden latent flaky tests across workspaces

### DIFF
--- a/_bmad-output/implementation-artifacts/7-1-resolve-open-scraper-and-tenant-stability-prs.md
+++ b/_bmad-output/implementation-artifacts/7-1-resolve-open-scraper-and-tenant-stability-prs.md
@@ -50,3 +50,12 @@ As a maintainer, I want to merge the open PRs for tenant release (#918) and Scra
 ### Change Log
 - Merged PR #918: deferred resolveTenant client release until response finishes (Date: 2026-05-03)
 - Merged PR #923: parser selector validation to detect Allocine structure changes (Date: 2026-05-03)
+
+## Review Findings
+
+- [x] [Review][Patch] Remove out-of-scope client tweaks from this stabilization set [client/index.html:7]
+- [x] [Review][Defer] Registration route test realism vs isolation [packages/saas/src/routes/register.test.ts:12] — deferred, route-level determinism kept for this pass; broader integration-depth decision moved to dedicated test-strategy story.
+- [x] [Review][Patch] Scheduler tests no longer drive timer callbacks under fake timers [packages/saas/src/quota-reset-scheduler.test.ts:55]
+- [x] [Review][Patch] SSE concurrency test readiness helper can fail flaky and leak pending clients on timeout [server/src/routes/scraper-progress.concurrent.integration.test.ts:172]
+- [x] [Review][Patch] Brittle internal call-count assertion in org route test [packages/saas/src/routes/org.test.ts:275]
+- [x] [Review][Defer] Story-level acceptance mismatch for scraper consumer-job regression proof [scraper/*] — deferred, pre-existing

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -43,3 +43,8 @@ Ajouter test validant comportement quand `#theaterpage-showtimes-index-ui` / `.m
 - `server/src/routes/scraper-progress.concurrent.integration.test.ts:304-306` — Heartbeat timing assertions tightly coupled to 30s cadence (±7s tolerance window). Changes to heartbeat interval or CI event-loop delays may cause flaky failures.
 - `server/src/routes/scraper-progress.concurrent.integration.test.ts:338-344,485-490` — `process.memoryUsage().rss` measures entire Vitest runner process, not just the disposable Express server. In-process testing limitation; inflated baseline from loaded modules may mask tracker leaks.
 - `server/src/routes/scraper-progress.concurrent.integration.test.ts:317,355,412` — `setTimeout(200)` for connection fan-out is a race condition. Mitigated by subsequent `getListenerCount()` assertion but may cause flaky failures in constrained CI.
+
+## Deferred from: code review of 7-1-resolve-open-scraper-and-tenant-stability-prs (2026-05-03)
+
+- `scraper/*` — Story 7.1 AC requires ensuring no regressions in scraper consumer jobs, but the current stabilization diff is test-focused in `client/`, `packages/saas/`, and `server/` only; deferred as out-of-scope for this patchset and already merged story baseline.
+- `packages/saas/src/routes/register.test.ts:12` — Route test now mocks `createOrg` for determinism; acceptable for immediate stabilization, but broader decision on integration-depth policy deferred to a dedicated test strategy story.

--- a/client/src/components/ui/Button.test.tsx
+++ b/client/src/components/ui/Button.test.tsx
@@ -27,8 +27,8 @@ describe('Button', () => {
   it('should apply primary variant styles by default', () => {
     render(<Button>Click me</Button>);
     const button = screen.getByRole('button');
-    expect(button).toHaveClass('bg-blue-600');
-    expect(button).toHaveClass('text-white');
+    expect(button).toHaveClass('bg-primary');
+    expect(button).toHaveClass('text-black');
   });
 
   it('should apply secondary variant styles', () => {

--- a/packages/saas/src/quota-reset-scheduler.test.ts
+++ b/packages/saas/src/quota-reset-scheduler.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { startQuotaResetScheduler } from './quota-reset-scheduler.js';
 import { logger } from './utils/logger.js';
 import type { DB } from './db/types.js';
@@ -32,6 +32,11 @@ describe('QuotaResetScheduler', () => {
     vi.useFakeTimers();
   });
 
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
   it('should log scheduler start using the structured logger', () => {
     vi.setSystemTime(new Date('2026-04-02T12:00:00Z'));
     startQuotaResetScheduler(mockDb as unknown as DB);
@@ -46,10 +51,8 @@ describe('QuotaResetScheduler', () => {
     mockDb.query.mockResolvedValue({ rows: [{ id: 1, slug: 'test-org' }] });
     
     startQuotaResetScheduler(mockDb as unknown as DB);
-    
-    // We only need to resolve the immediate async call to runMonthlyReset
-    await vi.setSystemTime(new Date('2026-04-01T12:00:01Z')); 
-    await vi.runAllTimersAsync();
+
+    await vi.runOnlyPendingTimersAsync();
 
     expect(mockDb.query).toHaveBeenCalledWith(
       `SELECT id, slug FROM organizations WHERE status IN ('trial', 'active')`
@@ -60,8 +63,7 @@ describe('QuotaResetScheduler', () => {
     vi.setSystemTime(new Date('2026-04-02T12:00:00Z'));
     
     startQuotaResetScheduler(mockDb as unknown as DB);
-    await vi.setSystemTime(new Date('2026-04-02T12:00:01Z'));
-    await vi.runAllTimersAsync();
+    await vi.runOnlyPendingTimersAsync();
 
     expect(mockDb.query).not.toHaveBeenCalled();
   });

--- a/packages/saas/src/routes/org.test.ts
+++ b/packages/saas/src/routes/org.test.ts
@@ -272,7 +272,13 @@ describe('GET /api/org/:slug/cinemas', () => {
       .join(' ');
     expect(errorText).toMatch(/organization mismatch/i);
     expect(db.query).not.toHaveBeenCalled();
-    expect(dbClient.query).toHaveBeenCalledTimes(2);
+    expect(dbClient.query).toHaveBeenCalled();
+    expect(dbClient.query.mock.calls.some(([sql]: [string]) =>
+      typeof sql === 'string' && sql.includes('SELECT * FROM organizations WHERE slug = $1')
+    )).toBe(true);
+    expect(dbClient.query.mock.calls.some(([sql]: [string]) =>
+      typeof sql === 'string' && sql.includes('SET search_path TO public')
+    )).toBe(true);
   });
 
   it('uses the scoped dbClient for cinema schedule details and keeps the global db untouched', async () => {

--- a/packages/saas/src/routes/register.test.ts
+++ b/packages/saas/src/routes/register.test.ts
@@ -9,6 +9,14 @@ import request from 'supertest';
 const SLUG_VALID = 'my-cinema';
 const JWT_SECRET = 'local-dev-jwt-fixture-key-1234567890abcd';
 
+const { createOrgMock } = vi.hoisted(() => ({
+  createOrgMock: vi.fn(),
+}));
+
+vi.mock('../services/org-service.js', () => ({
+  createOrg: createOrgMock,
+}));
+
 function buildApp(dbOverride?: object, poolOverride?: object) {
   const app = express();
   app.use(express.json());
@@ -35,6 +43,17 @@ function buildApp(dbOverride?: object, poolOverride?: object) {
 describe('POST /api/saas/orgs (register)', () => {
   beforeEach(() => {
     vi.stubEnv('JWT_SECRET', JWT_SECRET);
+    createOrgMock.mockResolvedValue({
+      org: {
+        id: 1,
+        name: 'Acme',
+        slug: SLUG_VALID,
+        schema_name: 'org_my_cinema',
+        status: 'trial',
+        trial_ends_at: new Date().toISOString(),
+      },
+      schemaCreated: true,
+    });
   });
 
   it('returns 400 when orgName is missing', async () => {
@@ -96,6 +115,7 @@ describe('POST /api/saas/orgs (register)', () => {
       id: 1, name: 'Acme', slug: SLUG_VALID,
       schema_name: 'org_my_cinema', status: 'trial', trial_ends_at: new Date().toISOString(),
     };
+    createOrgMock.mockResolvedValueOnce({ org, schemaCreated: true });
     const db = {
       query: vi.fn()
         .mockResolvedValueOnce({ rows: [{ count: '0' }], rowCount: 1 })

--- a/packages/saas/src/services/saas-auth-service.test.ts
+++ b/packages/saas/src/services/saas-auth-service.test.ts
@@ -39,7 +39,8 @@ describe('SaasAuthService', () => {
       const client = {
         query: vi.fn()
           .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // SET search_path OK
-          .mockRejectedValueOnce(new Error('db error')),     // INSERT fails
+          .mockRejectedValueOnce(new Error('db error'))      // INSERT fails
+          .mockResolvedValueOnce({ rows: [], rowCount: 0 }), // SET search_path TO public in finally
         release: vi.fn(),
       };
       const pool = { connect: vi.fn().mockResolvedValue(client) };

--- a/server/src/routes/scraper-progress.concurrent.integration.test.ts
+++ b/server/src/routes/scraper-progress.concurrent.integration.test.ts
@@ -166,6 +166,35 @@ interface ClientResult {
   streamEnded: boolean;
 }
 
+async function waitForListenerCount(
+  tracker: ProgressTracker,
+  expected: number,
+  timeoutMs = 10_000,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (tracker.getListenerCount() >= expected) return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  throw new Error(
+    `Timed out waiting for ${expected} listeners (got ${tracker.getListenerCount()})`,
+  );
+}
+
+async function waitForListenerCountOrDrain(
+  tracker: ProgressTracker,
+  expected: number,
+  clientPromises: Array<Promise<ClientResult>>,
+  timeoutMs = 10_000,
+): Promise<void> {
+  try {
+    await waitForListenerCount(tracker, expected, timeoutMs);
+  } catch (error) {
+    await Promise.allSettled(clientPromises);
+    throw error;
+  }
+}
+
 function openSseClient(
   port: number,
   token: string,
@@ -303,7 +332,7 @@ describe('Story 3.4 — SSE Concurrent Client Load Test (50+ clients)', () => {
       openSseClient(port, TOKEN, 1, 45_000),
     );
 
-    await new Promise((r) => setTimeout(r, 200));
+    await waitForListenerCountOrDrain(tracker, CONCURRENT_CLIENTS, clientPromises);
     expect(tracker.getListenerCount()).toBe(CONCURRENT_CLIENTS);
 
     const results = await Promise.all(clientPromises);
@@ -332,7 +361,7 @@ describe('Story 3.4 — SSE Concurrent Client Load Test (50+ clients)', () => {
     );
 
     // Give all clients a moment to establish their connections before emitting
-    await new Promise((r) => setTimeout(r, 200));
+    await waitForListenerCountOrDrain(tracker, CONCURRENT_CLIENTS, clientPromises);
 
     expect(tracker.getListenerCount()).toBe(CONCURRENT_CLIENTS);
 
@@ -397,7 +426,7 @@ describe('Story 3.4 — SSE Concurrent Client Load Test (50+ clients)', () => {
       );
 
       // Wait for connections
-      await new Promise((r) => setTimeout(r, 200));
+      await waitForListenerCountOrDrain(freshTracker, CONCURRENT_CLIENTS, clientPromises);
       expect(freshTracker.getListenerCount()).toBe(CONCURRENT_CLIENTS);
 
       // Emit the sequence
@@ -457,7 +486,7 @@ describe('Story 3.4 — SSE Concurrent Client Load Test (50+ clients)', () => {
       );
 
       // Wait for all connections to be established
-      await new Promise((r) => setTimeout(r, 300));
+      await waitForListenerCountOrDrain(shutdownTracker, CONCURRENT_CLIENTS, clientPromises);
       expect(shutdownTracker.getListenerCount()).toBe(CONCURRENT_CLIENTS);
 
       // Trigger server shutdown and track duration
@@ -500,7 +529,7 @@ describe('Story 3.4 — SSE Concurrent Client Load Test (50+ clients)', () => {
       openSseClient(port, TOKEN, 1, 10_000),
     );
 
-    await new Promise((r) => setTimeout(r, 200));
+    await waitForListenerCountOrDrain(tracker, CONCURRENT_CLIENTS, clientPromises);
 
     tracker.emit({ type: 'started', total_cinemas: 2, total_dates: 2, report_id: 9003 });
 


### PR DESCRIPTION
## Summary
- Stabilize cross-workspace test reliability by removing brittle assumptions in client/SaaS/server test code.
- Replace fixed sleep-based SSE readiness waits with listener-count synchronization plus failure draining to reduce concurrency flake risk.
- Update BMAD review artifacts with resolved findings and explicit deferred items for follow-up strategy work.

## Why
Unrelated development work was repeatedly blocked by unattended test failures and timing-sensitive behavior outside active scope. This PR makes test signals trustworthy again so feature work is not derailed by latent instability.

## Changes
- `client/src/components/ui/Button.test.tsx`
  - Align primary variant assertions with current tokenized implementation (`bg-primary`, `text-black`).
- `packages/saas/src/quota-reset-scheduler.test.ts`
  - Add timer cleanup in `afterEach`.
  - Replace `runAllTimersAsync` usage with `runOnlyPendingTimersAsync` to avoid fake-timer infinite-loop scenarios.
- `packages/saas/src/services/saas-auth-service.test.ts`
  - Extend mocked query sequence to cover `finally` cleanup (`SET search_path TO public`) on failure path.
- `packages/saas/src/routes/register.test.ts`
  - Mock `createOrg` at route-test boundary for deterministic success-path coverage.
- `packages/saas/src/routes/org.test.ts`
  - Replace brittle fixed query-count assertion with behavior-oriented assertions validating key SQL calls.
- `server/src/routes/scraper-progress.concurrent.integration.test.ts`
  - Add `waitForListenerCount` helper and replace fixed sleeps.
  - Add `waitForListenerCountOrDrain` to drain in-flight clients on readiness failure.
  - Increase readiness timeout from 5s to 10s for CI tolerance.
- `_bmad-output/implementation-artifacts/7-1-resolve-open-scraper-and-tenant-stability-prs.md`
  - Record code-review findings and dispositions.
- `_bmad-output/implementation-artifacts/deferred-work.md`
  - Append deferred review items with rationale.

## Validation
- `cd client && npm run lint && npm run test:run`
- `cd packages/saas && npm run test:run`
- `cd server && npm run test:run`
- `cd server && npm run test:run -- src/routes/scraper-progress.concurrent.integration.test.ts`
- `cd packages/saas && npm run test:run -- src/quota-reset-scheduler.test.ts src/routes/org.test.ts`

## Issue
Closes #976