### PR TITLE
chore(env): sync .env.example with all runtime env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -223,6 +223,10 @@ SAAS_ENABLED=false
 # Note: Health check responses are cached for 5 seconds to reduce database load
 # RATE_LIMIT_HEALTH_MAX=10
 
+# Health check rate limit window in milliseconds (default: 60000 = 1 minute)
+# Separate window from the general rate limit window — health probes are short-lived
+# RATE_LIMIT_HEALTH_WINDOW_MS=60000
+
 # ============================================================================
 # DOCKER CONFIGURATION
 # ============================================================================
@@ -313,6 +317,31 @@ REDIS_URL=redis://localhost:6379
 RUN_MODE=consumer
 
 # ============================================================================
+# SCRAPER METRICS SERVER
+# ============================================================================
+
+# Port for the Prometheus metrics HTTP endpoint exposed by the scraper process
+# Default: 9091
+# Scraped by Prometheus (or Grafana Agent) when the monitoring profile is active
+# METRICS_PORT=9091
+
+# ============================================================================
+# SCRAPER BROWSER CONFIGURATION
+# ============================================================================
+
+# Path to the Playwright browsers cache directory (optional)
+# Playwright will use its default cache path when not set
+# Useful for Docker images or environments where browsers are pre-installed elsewhere
+# Example: PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+# PLAYWRIGHT_BROWSERS_PATH=
+
+# Explicit path to the Chromium/Chrome binary (optional)
+# Takes precedence over PLAYWRIGHT_BROWSERS_PATH when set
+# Useful when the system Chrome should be used instead of the Playwright-bundled one
+# Example: CHROME_PATH=/usr/bin/chromium-browser
+# CHROME_PATH=
+
+# ============================================================================
 # LOGGING & OBSERVABILITY
 # ============================================================================
 
@@ -339,3 +368,20 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://ics-tempo:4317
 # Only set this when running the React app in development mode via Vite.
 # Default: http://localhost:3000/api
 VITE_API_BASE_URL=http://localhost:3000/api
+
+# ============================================================================
+# INTEGRATION TEST CONFIGURATION (CI / local test runs only)
+# ============================================================================
+#
+# These variables are only required when running integration tests.
+# They are NOT used by the application at runtime.
+#
+# RUN_INTEGRATION_TESTS=1 enables the integration test suites that spin up
+# real Testcontainers (PostgreSQL). When unset, those suites are skipped.
+#
+# RUN_INTEGRATION_TESTS=1
+# TEST_DB_HOST=localhost
+# TEST_DB_PORT=5432
+# TEST_DB_NAME=ics_test
+# TEST_DB_USER=postgres
+# TEST_DB_PASSWORD=postgres

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,19 +9,23 @@ Operational guide for contributors and agents in this monorepo. Prefer BMAD work
 - Workspaces: `client`, `server`, `scraper`, `packages/saas`, `packages/logger`
 - Entrypoints: `client/src/main.tsx`, `server/src/index.ts`, `scraper/src/index.ts`
 - `server`: API + frontend host, DB init/migrations, Redis scrape progress subscription, dynamic SaaS load when `SAAS_ENABLED=true`
-- `scraper`: separate service with `RUN_MODE` = `oneshot|consumer|cron|direct`
+- `scraper`: separate service; `RUN_MODE` env controls behavior:
+  - `oneshot` (default): pop one job from Redis queue, execute, exit
+  - `consumer`: long-running process that polls Redis queue continuously
+  - `cron`: run scraper on a schedule via `CRON_SCHEDULE` env (no Redis)
+  - `direct`: run scraper immediately once and exit (local dev / manual use)
 
 ## BMAD-First Workflow
 
 - Start with `bmad-help` if scope is unclear
-- Do not use `bmad-quick-dev`
+- Do not use `bmad-quick-dev` — it bypasses the required `CS -> VS -> DS -> CR -> GP -> WAIT` discipline
 - Follow this required flow: `CS -> VS -> DS -> CR -> GP -> WAIT`
 - `CS` = Clarify Scope (confirm objective, constraints, and impacted areas)
-- `VS` = Validate Scope (check assumptions against repo/docs and acceptance criteria)
+- `VS` = Validate Story (check story spec, assumptions, acceptance criteria against repo/docs)
 - `DS` = Design Solution (propose implementation approach before changing code)
 - `CR` = Change Review (self-review diff, risks, and verification coverage)
 - `GP` = Git/PR Prep (stage clean changes, write conventional commit, prepare PR context)
-- `WAIT` = Stop for user direction before starting the next cycle
+- `WAIT` = Stop and wait for an explicit user message in the chat before starting the next cycle
 - Use specialized BMAD skills only when the current step explicitly matches (PRD, architecture, test strategy, code review, etc.)
 - Standard delivery flow: issue -> branch from `develop` -> implement + verify -> PR with `Closes #<issue>`
 - Use Conventional Commits; if PR targets `main`, add exactly one label: `major|minor|patch`
@@ -42,6 +46,7 @@ Operational guide for contributors and agents in this monorepo. Prefer BMAD work
 - Client: `cd client && npm run lint && npm run test:run && npm run build`
 - Scraper: `cd scraper && npm run test:run`
 - SaaS: `cd packages/saas && npm run test:run`
+- Logger: `cd packages/logger && npm run test:run`
 
 ## CI and Hooks
 
@@ -62,9 +67,3 @@ Operational guide for contributors and agents in this monorepo. Prefer BMAD work
 - After a `CR`, the mandatory next step is `GP` (Generate Plan).
 - After `GP`, stop and wait for an explicit new order before any `CS`, `DS`, `push-flow`, or merge-related action.
 - Do not auto-advance BMAD work just because a story reached `review` or because a PR exists; only an explicit user order unlocks the next phase.
-
-## Current Source of Truth
-
-- Superadmin login is via `/api/auth/login` (not `/api/superadmin/login`)
-- `server/src/services/auth-service.ts` adds `scope: 'superadmin'` for system-role admins
-- Vite proxies both `/api` and `/test` in local dev


### PR DESCRIPTION
## Summary

- Add 4 missing runtime env vars to \`.env.example\`
- Add 6 missing test-only env vars in a clearly labelled section
- Fix \`.env\` structure: move \`SAAS_ENABLED\` to its proper documented section and add \`SCRAPER_CONCURRENCY\`
- Update \`AGENTS.md\`: expand RUN_MODE mode docs, clarify BMAD step names, add logger test command, remove stale superadmin source-of-truth section

## Why

\`.env.example\` is the onboarding reference for every new contributor and deployment. Several variables actively read by the application at runtime were absent, creating silent misconfiguration risk. \`AGENTS.md\` had a stale section and imprecise step descriptions.

## What Changed

**\`.env.example\`:**
- \`RATE_LIMIT_HEALTH_WINDOW_MS\` — separate rate-limit window for the health endpoint (default 60 000 ms)
- \`METRICS_PORT\` — Prometheus metrics server port exposed by the scraper (default 9091)
- \`PLAYWRIGHT_BROWSERS_PATH\` — optional override for Playwright browser cache directory
- \`CHROME_PATH\` — optional explicit Chromium binary path (takes precedence over Playwright cache)
- \`RUN_INTEGRATION_TESTS\`, \`TEST_DB_HOST/PORT/NAME/USER/PASSWORD\` — test-only vars, commented out with clear labelling

**\`.env\`:**
- \`SAAS_ENABLED\` moved from before the DB section to its own documented SAAS block
- \`SCRAPER_CONCURRENCY\` added with comment

**\`AGENTS.md\`:**
- Expanded \`RUN_MODE\` entry with all four modes and their behaviour
- Clarified \`bmad-quick-dev\` prohibition with reason
- Corrected \`VS\` label from "Validate Scope" to "Validate Story"
- Sharpened \`WAIT\` description to require explicit user message
- Added \`Logger\` test command to Verification section
- Removed stale "Current Source of Truth" section (superadmin login path, Vite proxy)

## Scope

Documentation only — no application logic changes.

## Validation

- Cross-checked all \`process.env.*\` calls in \`server/src\`, \`scraper/src\`, \`packages/saas/src\`, \`packages/logger/src\` against \`.env.example\` — zero gaps remaining

## Related

Closes #985