### PR TITLE
fix(security): replace jwt.decode with jwt.verify in rate limiter + perf optimizations

### DIFF
--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -8,6 +8,9 @@ import FilmSearchBar from '../components/FilmSearchBar';
 import ScrollToTop from '../components/ScrollToTop';
 import { AuthContext } from '../contexts/AuthContext';
 import CinemasQuickLinks from '../components/CinemasQuickLinks';
+import type { FilmWithShowtimes } from '../types';
+
+const EMPTY_ARRAY: FilmWithShowtimes[] = [];
 
 export default function HomePage() {
   const queryClient = useQueryClient();
@@ -27,13 +30,15 @@ export default function HomePage() {
     queryFn: () => selectedDate ? getFilmsByDate(selectedDate) : getWeeklyFilms(),
   });
 
-  const allFilms = filmsData?.films || [];
-  // When "Maintenant" is active, hide films whose showtimes are all in the past
-  const films = afterTime
-    ? allFilms.filter(film =>
-        film.cinemas.some(c => c.showtimes.some(s => s.time >= afterTime))
-      )
-    : allFilms;
+  const allFilms: FilmWithShowtimes[] = filmsData?.films || EMPTY_ARRAY;
+  // ⚡ PERFORMANCE: Memoize to avoid expensive O(N*M) nested filtering on every render
+  const films = useMemo(() => {
+    return afterTime
+      ? allFilms.filter(film =>
+          film.cinemas.some(c => c.showtimes.some(s => s.time >= afterTime))
+        )
+      : allFilms;
+  }, [allFilms, afterTime]);
   const weekStart = filmsData?.weekStart || '';
 
   const isLoading = isLoadingCinemas || isLoadingFilms;

--- a/client/src/pages/admin/AdminPage.tsx
+++ b/client/src/pages/admin/AdminPage.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import CinemasPage from './CinemasPage';
 import SettingsPage from './SettingsPage';
@@ -114,8 +114,8 @@ const AdminPage: React.FC = () => {
   const { hasPermission } = useContext(AuthContext);
   const currentTab = searchParams.get('tab') || 'cinemas';
 
-  // Filter tabs to only those the user has permission to see
-  const visibleTabs = tabs.filter((tab) => {
+  // ⚡ PERFORMANCE: useMemo to avoid re-filtering tabs on every render
+  const visibleTabs = useMemo(() => tabs.filter((tab) => {
     if (tab.anyPermissions) {
       return tab.anyPermissions.some((p) => hasPermission(p));
     }
@@ -123,7 +123,7 @@ const AdminPage: React.FC = () => {
       return tab.permissions.every((p) => hasPermission(p));
     }
     return !tab.permission || hasPermission(tab.permission);
-  });
+  }), [hasPermission]);
   const visibleTabIds = visibleTabs.map((t) => t.id);
 
   // Validate tab and fallback to first visible tab (or 'cinemas')

--- a/server/src/db/report-queries.ts
+++ b/server/src/db/report-queries.ts
@@ -127,22 +127,25 @@ export async function getScrapeReports(
 
   const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
-  // Get total count
-  const countResult = await db.query<{ count: string }>(
-    `SELECT COUNT(*) as count FROM scrape_reports ${whereClause}`,
-    params
-  );
-  const total = parseInt(countResult.rows[0].count);
+  // ⚡ PERFORMANCE: Execute independent COUNT and SELECT queries concurrently
+  // to reduce total response time. Clone params before pushing limit/offset
+  // to avoid mutating the shared array used by the count query.
+  const dataParams = [...params, limit, offset];
+  const [countResult, result] = await Promise.all([
+    db.query<{ count: string }>(
+      `SELECT COUNT(*) as count FROM scrape_reports ${whereClause}`,
+      params
+    ),
+    db.query<ScrapeReport>(
+      `SELECT * FROM scrape_reports 
+       ${whereClause}
+       ORDER BY started_at DESC 
+       LIMIT $${paramIndex++} OFFSET $${paramIndex++}`,
+      dataParams
+    )
+  ]);
 
-  // Get paginated results
-  params.push(limit, offset);
-  const result = await db.query<ScrapeReport>(
-    `SELECT * FROM scrape_reports 
-     ${whereClause}
-     ORDER BY started_at DESC 
-     LIMIT $${paramIndex++} OFFSET $${paramIndex++}`,
-    params
-  );
+  const total = parseInt(countResult.rows[0].count);
 
   return {
     reports: result.rows,

--- a/server/src/middleware/rate-limit.test.ts
+++ b/server/src/middleware/rate-limit.test.ts
@@ -15,7 +15,6 @@ import {
 } from './rate-limit.js';
 
 const TEST_SECRET = 'a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6';
-process.env.JWT_SECRET = TEST_SECRET;
 
 // Helper: sign a minimal JWT for rate-limit key tests
 const makeToken = (userId: number, options?: { username?: string; orgSlug?: string; scope?: string }): string =>
@@ -30,13 +29,16 @@ describe('Rate Limiting Middleware', () => {
   let app: express.Application;
 
   let originalNodeEnv: string | undefined;
+  let originalJwtSecret: string | undefined;
   let originalRateLimitWindowMs: string | undefined;
   let originalRateLimitProtectedMax: string | undefined;
 
   beforeEach(() => {
     originalNodeEnv = process.env.NODE_ENV;
+    originalJwtSecret = process.env.JWT_SECRET;
     originalRateLimitWindowMs = process.env.RATE_LIMIT_WINDOW_MS;
     originalRateLimitProtectedMax = process.env.RATE_LIMIT_PROTECTED_MAX;
+    process.env.JWT_SECRET = TEST_SECRET;
     process.env.NODE_ENV = 'development';
     app = express();
     app.use(express.json());
@@ -46,6 +48,11 @@ describe('Rate Limiting Middleware', () => {
 
   afterEach(() => {
     process.env.NODE_ENV = originalNodeEnv;
+    if (originalJwtSecret === undefined) {
+      delete process.env.JWT_SECRET;
+    } else {
+      process.env.JWT_SECRET = originalJwtSecret;
+    }
     if (originalRateLimitWindowMs === undefined) {
       delete process.env.RATE_LIMIT_WINDOW_MS;
     } else {

--- a/server/src/middleware/rate-limit.test.ts
+++ b/server/src/middleware/rate-limit.test.ts
@@ -14,14 +14,17 @@ import {
   isTrustedLocalHealthProbe,
 } from './rate-limit.js';
 
-// Helper: sign a minimal JWT for rate-limit key tests (secret doesn't matter — we use jwt.decode)
+const TEST_SECRET = 'a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6';
+process.env.JWT_SECRET = TEST_SECRET;
+
+// Helper: sign a minimal JWT for rate-limit key tests
 const makeToken = (userId: number, options?: { username?: string; orgSlug?: string; scope?: string }): string =>
   jwt.sign({
     id: userId,
     username: options?.username ?? `user${userId}`,
     ...(options?.orgSlug ? { org_slug: options.orgSlug } : {}),
     ...(options?.scope ? { scope: options.scope } : {}),
-  }, 'test-secret');
+  }, TEST_SECRET);
 
 describe('Rate Limiting Middleware', () => {
   let app: express.Application;

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -3,7 +3,16 @@ import jwt from 'jsonwebtoken';
 import type { Request, Response } from 'express';
 import { validateJWTSecret } from '../utils/jwt-secret-validator.js';
 
-const getJwtSecret = () => validateJWTSecret();
+let jwtSecretCache: string | null = null;
+
+const getJwtSecret = (): string => {
+  if (jwtSecretCache) {
+    return jwtSecretCache;
+  }
+
+  jwtSecretCache = validateJWTSecret();
+  return jwtSecretCache;
+};
 
 const LOCALHOST_IPS = new Set(['127.0.0.1', '::1']);
 
@@ -54,11 +63,13 @@ const WINDOW_MS = parseEnvInt('RATE_LIMIT_WINDOW_MS', 15 * 60 * 1000); // 15 min
  * Falls back to req.ip for unauthenticated requests.
  */
 export const authenticatedKeyGenerator = (req: Request): string => {
+  const jwtSecret = getJwtSecret();
+
   try {
     const authHeader = req.headers.authorization;
     if (authHeader?.startsWith('Bearer ')) {
       const token = authHeader.split(' ')[1];
-      const decoded = jwt.verify(token, getJwtSecret()) as {
+      const decoded = jwt.verify(token, jwtSecret) as {
         id?: number | string;
         username?: string;
         org_slug?: string;

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -1,6 +1,9 @@
 import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import jwt from 'jsonwebtoken';
 import type { Request, Response } from 'express';
+import { validateJWTSecret } from '../utils/jwt-secret-validator.js';
+
+const getJwtSecret = () => validateJWTSecret();
 
 const LOCALHOST_IPS = new Set(['127.0.0.1', '::1']);
 
@@ -55,7 +58,7 @@ export const authenticatedKeyGenerator = (req: Request): string => {
     const authHeader = req.headers.authorization;
     if (authHeader?.startsWith('Bearer ')) {
       const token = authHeader.split(' ')[1];
-      const decoded = jwt.decode(token) as {
+      const decoded = jwt.verify(token, getJwtSecret()) as {
         id?: number | string;
         username?: string;
         org_slug?: string;


### PR DESCRIPTION
## Summary

- **[SECURITY]** Replace \`jwt.decode\` with \`jwt.verify\` in \`authenticatedKeyGenerator\` to prevent rate-limit spoofing/DoS via forged tokens
- **[PERF]** Run \`COUNT(*)\` and paginated \`SELECT\` concurrently in \`getScrapeReports\` via \`Promise.all\`
- **[PERF]** Memoize \`films\` filter in \`HomePage\` and \`visibleTabs\` in \`AdminPage\` with \`useMemo\`

## Why

**Security:** \`jwt.decode\` does not verify the token signature. An attacker could craft a token with any \`id\` to exhaust another user's rate-limit bucket (targeted DoS), or rotate unique IDs on every request to bypass limits entirely. \`jwt.verify\` rejects tampered or expired tokens; the existing \`try/catch\` naturally falls back to IP-based limiting.

**Performance:** The two DB queries in \`getScrapeReports\` are fully independent — running them sequentially wastes wall-clock time proportional to one full round-trip. The \`films\` O(N×M) filter in \`HomePage\` ran on every state update (scrape progress, search bar input, etc.) due to an unstable inline \`[]\` default reference. \`AdminPage\` re-filtered tabs on every render unnecessarily.

## What Changed

- \`server/src/middleware/rate-limit.ts\`: import \`validateJWTSecret\`, lazy-load secret via \`getJwtSecret()\`, replace \`jwt.decode\` with \`jwt.verify\`
- \`server/src/middleware/rate-limit.test.ts\`: set \`JWT_SECRET\` to a valid 32+-char secret before tests; align \`makeToken\` to sign with the same secret
- \`server/src/db/report-queries.ts\`: clone \`params\` before pushing limit/offset, wrap count + select in \`Promise.all\`
- \`client/src/pages/HomePage.tsx\`: extract stable \`EMPTY_ARRAY\` constant, wrap \`films\` derivation in \`useMemo\`
- \`client/src/pages/admin/AdminPage.tsx\`: add \`useMemo\` import, wrap \`visibleTabs\` filter in \`useMemo([hasPermission])\`

## Validation

- \`cd server && npm run test:run\` → **882 tests passed**
- \`cd client && npm run lint && npm run test:run\` → **538 tests passed, lint clean**

## Related

Closes #987
Supersedes and closes duplicate draft PRs: #841 #871 #882 #883 #886 #894 #899 #912 #917 #920 #922 #925 #926 #931 #939 #942 #943 #946 #959 #961