### PR TITLE
docs: document BMAD issue cockpit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,13 +57,51 @@ Operational guide for contributors and agents in this monorepo. Prefer BMAD work
 
 ## Runtime and Test Gotchas
 
-- Repo conventions in existing docs/templates: create an issue first, branch from `develop`, use Conventional Commits, and reference the issue in the PR.
-- Expected flow for changes: issue -> branch from `develop` -> implement/verify -> open PR -> add one version label (`major`/`minor`/`patch`) if it targets `main`.
-- PR template expects `Closes #<issue>` and a short list of test commands actually run.
-- CI branch patterns are `feat/**`, `fix/**`, `docs/**`, `chore/**`, `ci/**`, `refactor/**`, `test/**`, `perf/**`.
-- PRs merged to `main` trigger automated versioning and releases. Add exactly one version label: `major`, `minor`, or `patch`.
-- For BMAD tracking in this repository, treat `done` as **already merged into `develop`**, not merely coded locally or pushed to a PR branch.
+- `playwright.config.ts` does **not** start the app. Start the stack yourself before `npm run e2e`.
+- Playwright base URL defaults to `http://localhost:5173`; override with `PLAYWRIGHT_BASE_URL`.
+- Scrape-heavy specs run in project `chromium-scrape-serial`.
+- Explicit test selection disables that dependency chain; for one spec, `--project=chromium --no-deps` skips it.
+- Vite dev proxy forwards both `/api` and `/test` to the backend.
+- `/test/seed-org` and `/test/cleanup-org/:id` exist only when `NODE_ENV=test`, or when backend runs in `development` with `E2E_ENABLE_ORG_FIXTURE=true`.
+- Outside those runtimes, `/test/*` is intentionally gated and returns `404`.
+
+## Runtime Truths That Drift Easily
+
+- Dev compose sets `AUTO_MIGRATE=true` by default unless overridden.
+- After migrations, the server seeds `server/src/config/cinemas.json` when the `cinemas` table is empty.
+- Dev compose sets `SAAS_ENABLED=false` and `E2E_ENABLE_ORG_FIXTURE=false` by default unless overridden.
+- Do not use any old `/api/superadmin/login` assumption. Login goes through `/api/auth/login`.
+- JWT gets `scope: 'superadmin'` only for system-role admins with no `org_slug`.
+- CI and Docker install from the repo root; if a non-Docker local install breaks on `sharp`, reinstall from `server/`.
+
+## Workflow Gates
+
+- Repo flow stays issue-first: create or confirm the issue, branch from `develop`, implement/verify locally, then open a PR only when that step is explicitly requested or clearly in scope.
+- Branch names should use CI-visible prefixes: `feat/`, `fix/`, `docs/`, `chore/`, `ci/`, `refactor/`, `test/`, or `perf/` — not generic `feature/`.
+- For BMAD-tracked work, the GitHub issue is the visible cockpit and the repo artifacts stay the execution truth: keep one active issue per story/task, then link `_bmad-output/...`, `.hermes/plans/...`, commits, and PRs back to that issue.
+- BMAD issues should carry `bmad`, exactly one phase label among `phase:gp`, `phase:ds`, `phase:cr`, `phase:wait`, `phase:done`, and `type:story` when the issue maps to a BMAD story. Use `blocked` only when waiting on an external dependency or decision.
+- Update the BMAD issue at each checkpoint: GP delivered, DS implemented, CR verdict returned, GP-after-CR delivered, and merge to `develop`.
+- Use Conventional Commits and keep the issue linked in commits/PR text.
+- PR body should include `Closes #<issue>` plus the test commands actually run.
+- If a PR targets `main`, add exactly one version label: `major`, `minor`, or `patch`.
 - BMAD order is strict: `DS -> CR -> GP -> WAIT`.
-- After a `CR`, the mandatory next step is `GP` (Generate Plan).
+- After `CR`, the mandatory next step is `GP`.
 - After `GP`, stop and wait for an explicit new order before any `CS`, `DS`, `push-flow`, or merge-related action.
-- Do not auto-advance BMAD work just because a story reached `review` or because a PR exists; only an explicit user order unlocks the next phase.
+- Do not auto-advance because a task is in review or because a PR exists.
+- In this repo, `done` means **merged into `develop`**, not merely coded, pushed, or opened in PR.
+
+## Source-of-Truth Pointers
+
+- Commands, workspaces, engine constraints: `package.json`
+- Dev topology and default dev env flags: `docker-compose.dev.yml`
+- E2E runtime behavior and project dependency rules: `playwright.config.ts`
+- Hook installation: `scripts/install-hooks.sh`
+- Actual pre-push checks: `scripts/hooks/pre-push`
+- Dev proxy for `/api` and `/test`: `client/vite.config.ts`
+- Auth and superadmin scope truth: `server/src/services/auth-service.ts`
+- DB init + one-time cinema bootstrap seed: `server/src/db/schema.ts`
+
+## Automated Versioning / Releases
+
+- PRs merged to `main` feed the version/release workflow in `.github/workflows/version-tag.yml`.
+- If a PR targets `main`, add exactly one version label: `major`, `minor`, or `patch`.

--- a/README.md
+++ b/README.md
@@ -802,12 +802,12 @@ All documentation lives under the `/docs/` directory, organized following the [D
 
 We welcome contributions! Please see [Contributing Guide](./docs/guides/development/contributing.md) for:
 - Code of Conduct
-- Development workflow (Issue → Branch → TDD → Local review → PR)
+- Development workflow (Issue → Branch → TDD → Local review → GP/WAIT for BMAD → PR)
 - Coding standards
 - Commit message conventions (Conventional Commits)
 - Testing requirements
 
-For AI coding agents, see [AGENTS.md](./AGENTS.md) for the mandatory house workflow and TDD requirements. In this repository's BMAD flow, `done` means merged into `develop`, local `CR` comes before any PR, then `GP` is the mandatory checkpoint, and after `GP` the agent must wait for an explicit new order before any `CS`, `DS`, `push-flow`, or merge-related action.
+For AI coding agents, see [AGENTS.md](./AGENTS.md) for the mandatory house workflow and TDD requirements. In this repository's BMAD flow, `done` means merged into `develop`, local `CR` comes before any PR, then `GP` is the mandatory checkpoint, and after `GP` the agent must wait for an explicit new order before any `CS`, `DS`, `push-flow`, or merge-related action. BMAD-tracked work should use a GitHub issue as the visible cockpit (`bmad` + one `phase:*` label), while `_bmad-output/...` and `.hermes/plans/...` remain the execution source of truth.
 
 **Redis integration tests (Testcontainers):**
 - Run `npm run test:integration --workspace=allo-scrapper-server` to execute Redis-backed integration tests.
@@ -831,15 +831,16 @@ For AI coding agents, see [AGENTS.md](./AGENTS.md) for the mandatory house workf
 
 **Quick contribution checklist:**
 1. Create an issue first (bug/feature/task)
-2. Create a feature branch from `develop`
+2. Create a branch from `develop` using a CI-visible prefix (`feat/`, `fix/`, `docs/`, `chore/`, `ci/`, `refactor/`, `test/`, `perf/`)
 3. Write tests before implementation (TDD)
 4. Follow Conventional Commits format
 5. Ensure all tests pass and Docker builds
 6. Run local review before any PR (`CR` for BMAD-tracked work)
 7. If this is BMAD-tracked work, run `GP` after `CR` and wait for an explicit order before any PR / push-flow / merge action
-8. Create a PR referencing the issue only when that step is actually requested
-9. **Add version label** to PR (`major`, `minor`, or `patch`) when targeting `main`
-10. Wait for review before merging
+8. For BMAD-tracked work, keep the issue labels in sync with the current checkpoint (`phase:gp`, `phase:ds`, `phase:cr`, `phase:wait`, `phase:done`)
+9. Create a PR referencing the issue only when that step is actually requested
+10. **Add version label** to PR (`major`, `minor`, or `patch`) when targeting `main`
+11. Wait for review before merging
 
 **Automated versioning** (PRs to `main` only):
 - Add label `major` (breaking changes), `minor` (features), or `patch` (fixes)

--- a/docs/guides/development/contributing.md
+++ b/docs/guides/development/contributing.md
@@ -33,6 +33,8 @@ Every contribution should follow this workflow:
 9. Pull Request   → Open PR only when that step is explicitly requested or otherwise clearly in scope
 ```
 
+For BMAD-tracked work, treat the GitHub issue as the visible workflow cockpit: keep one active issue per story/task, keep repo artifacts (`_bmad-output/...`, `.hermes/plans/...`) as the execution truth, and move the issue through the BMAD checkpoint labels as the work progresses.
+
 ---
 
 ## Issue First
@@ -66,6 +68,31 @@ In commits and PRs, reference the issue:
 - `refs #123` - References issue without closing
 - `closes #123` - Closes issue when PR is merged
 - `fixes #123` - Same as closes (for bug fixes)
+
+### BMAD-Tracked Issue Conventions
+
+For BMAD-managed work, use GitHub issues to expose the current checkpoint without replacing the repo artifacts:
+
+- Keep **one active issue per BMAD story or docs/task-sized work item**.
+- Add label `bmad`.
+- Keep **exactly one** BMAD phase label on the issue at a time:
+  - `phase:gp`
+  - `phase:ds`
+  - `phase:cr`
+  - `phase:wait`
+  - `phase:done`
+- Add `type:story` when the issue maps directly to a BMAD story.
+- Add `blocked` only when the work is waiting on an external dependency or explicit decision.
+- Link the issue to the active plan/story/PR in comments or body updates; do not duplicate the full BMAD artifact content inside GitHub.
+
+Recommended checkpoints:
+
+1. Issue opened / scoped → `bmad` + initial type/domain labels
+2. GP delivered → `phase:gp`
+3. DS in progress / delivered → `phase:ds`
+4. Local CR running → `phase:cr`
+5. GP-after-CR delivered and waiting for order → `phase:wait`
+6. Merged into `develop` → `phase:done`
 
 ---
 

--- a/docs/project/agents.md
+++ b/docs/project/agents.md
@@ -20,7 +20,7 @@ This document provides instructions for AI coding agents (Claude, GitHub Copilot
 
 ```
 1. ISSUE   → Verify or create a GitHub issue
-2. BRANCH  → Create a dedicated feature branch from develop for this issue
+2. BRANCH  → Create a dedicated issue branch from develop using a CI-visible prefix
 3. RED     → Write failing tests first (commit before implementing)
 4. GREEN   → Write minimal code to make tests pass
 5. DOCS    → Update README.md / AGENTS.md if API or behaviour changed
@@ -31,6 +31,8 @@ This document provides instructions for AI coding agents (Claude, GitHub Copilot
 10. PR     → Open Pull Request only when that step is explicitly requested or otherwise clearly in scope
               → After merge: switch back to develop, pull latest
 ```
+
+For BMAD-tracked work, the GitHub issue is the visible cockpit and the repo artifacts remain the execution truth: keep one active issue per story/task, label it with `bmad` plus exactly one `phase:*` label, and link plans / story files / commits / PRs back to that issue instead of duplicating the full artifact text in GitHub.
 
 **Conditional steps (not always required):**
 - **Docker build** — run `docker compose build` before pushing if Dockerfile or dependencies changed
@@ -62,7 +64,18 @@ gh issue create --title "fix: description" --body "Details..." --label bug
 gh issue create --title "docs: description" --body "Details..." --label documentation
 ```
 
-**Note the issue number** — you will need it for the branch name, commits, and PR.
+**Note the issue number** — you will need it for the branch name, commits, labels, and PR.
+
+### BMAD Issue Labels
+
+For BMAD-tracked work, apply these labels on the issue:
+
+- `bmad`
+- exactly one phase label: `phase:gp`, `phase:ds`, `phase:cr`, `phase:wait`, or `phase:done`
+- `type:story` when the issue maps directly to a BMAD story
+- `blocked` only when the work is waiting on an external dependency or explicit decision
+
+Update the issue labels at each BMAD checkpoint instead of opening a second tracking issue.
 
 ---
 
@@ -73,16 +86,17 @@ gh issue create --title "docs: description" --body "Details..." --label document
 ```bash
 git checkout develop
 git pull origin develop
-git checkout -b feature/<issue-number>-<short-description>
+git checkout -b <type>/<issue-number>-<short-description>
 ```
 
 **Examples:**
-- `feature/259-add-cinema-modal`
-- `feature/42-fix-parser-bug`
-- `feature/266-optimize-agents-md`
+- `feat/259-add-cinema-modal`
+- `fix/42-fix-parser-bug`
+- `docs/266-optimize-agents-md`
 
 **Rules:**
 - Always branch from `develop`, never from `main` or another feature branch
+- Branch prefixes must match CI-visible patterns: `feat/`, `fix/`, `docs/`, `chore/`, `ci/`, `refactor/`, `test/`, `perf/`
 - One issue = one branch = one PR
 - NEVER push directly to `develop` or `main`
 
@@ -231,7 +245,7 @@ git commit -m "docs: update README with <feature>"        # DOCS — if applicab
 
 ```bash
 # Push branch only when that step is actually required
-git push -u origin feature/<issue-number>-<short-description>
+git push -u origin <type>/<issue-number>-<short-description>
 
 # Create PR only when explicitly requested or otherwise clearly in scope
 gh pr create --title "feat(scope): description" --body "## Summary
@@ -365,7 +379,7 @@ docker compose --profile monitoring --profile scraper up -d  # Everything
 ```bash
 git status
 git log --oneline -10
-git checkout -b feature/<issue-number>-<short-desc> develop
+git checkout -b <type>/<issue-number>-<short-desc> develop
 ```
 
 ### GitHub CLI


### PR DESCRIPTION
## Summary
- document GitHub issues as the visible BMAD workflow cockpit
- define BMAD issue labels and checkpoint expectations
- align branch naming examples with CI-visible prefixes used by repository CI

## Tests
- not run (documentation-only changes)

Closes #996
