### PR TITLE
fix(security): enforce tenant-aware SSE connection quotas

### DIFF
--- a/server/src/routes/scraper.test.ts
+++ b/server/src/routes/scraper.test.ts
@@ -2,6 +2,7 @@ import { errorHandler } from '../middleware/error-handler.js';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import request from 'supertest';
 import express from 'express';
+import { AppError } from '../utils/errors.js';
 
 const mockTriggerScrape = vi.fn();
 const mockTriggerResume = vi.fn();
@@ -332,6 +333,32 @@ describe('Routes - Scraper', () => {
       );
     });
 
+    it('should preserve org_id context for the progress subscription when org_slug is absent', async () => {
+      mockSubscribeToProgress.mockImplementation((res, _onClose, _context, _lastEventId) => {
+        res.status(200).end();
+        return () => {};
+      });
+      const app = await setupApp({ org_id: 42, org_slug: undefined });
+
+      const response = await request(app).get('/api/scraper/progress');
+
+      expect(response.status).toBe(200);
+      expect(mockSubscribeToProgress).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(Function),
+        expect.objectContaining({
+          endpoint: '/api/scraper/progress',
+          method: 'GET',
+          user: expect.objectContaining({
+            id: 1,
+            org_id: 42,
+            org_slug: undefined,
+          }),
+        }),
+        undefined
+      );
+    });
+
     it('should run the SSE cleanup callback when the request closes', async () => {
       const cleanup = vi.fn();
       mockSubscribeToProgress.mockImplementation((res) => {
@@ -345,6 +372,22 @@ describe('Routes - Scraper', () => {
 
       expect(response.status).toBe(200);
       expect(cleanup).toHaveBeenCalled();
+    });
+
+    it('should return 429 when the user already has 3 concurrent progress connections', async () => {
+      mockSubscribeToProgress.mockImplementation(() => {
+        throw new AppError('Maximum of 3 concurrent progress connections per user exceeded', 429);
+      });
+
+      const app = await setupApp({ org_id: 42, org_slug: 'acme' });
+
+      const response = await request(app).get('/api/scraper/progress');
+
+      expect(response.status).toBe(429);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Maximum of 3 concurrent progress connections per user exceeded',
+      });
     });
   });
 

--- a/server/src/services/progress-tracker.ts
+++ b/server/src/services/progress-tracker.ts
@@ -123,6 +123,10 @@ export class ProgressTracker {
     }
   }
 
+  hasListener(res: Response): boolean {
+    return this.listeners.has(res);
+  }
+
   // Emit a progress event to all listeners
   emit(event: ProgressEvent): void {
     if (event.type === 'started' && !this.hasActiveJobs()) {

--- a/server/src/services/scraper-service.test.ts
+++ b/server/src/services/scraper-service.test.ts
@@ -11,6 +11,7 @@ vi.mock('./redis-client.js');
 vi.mock('./progress-tracker.js', () => ({
   progressTracker: {
     addListener: vi.fn(),
+    hasListener: vi.fn().mockReturnValue(true),
     removeListener: vi.fn(),
     getListenerCount: vi.fn().mockReturnValue(1),
   },
@@ -23,6 +24,8 @@ describe('ScraperService', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    ScraperService.resetProgressConnectionTrackingForTests();
+    vi.mocked(progressTracker.hasListener).mockReturnValue(true);
     scraperService = new ScraperService(mockDb);
   });
 
@@ -257,6 +260,275 @@ describe('ScraperService', () => {
       
       expect(progressTracker.removeListener).toHaveBeenCalledWith(mockRes);
       expect(mockOnClose).toHaveBeenCalled();
+    });
+
+    it('should reject a fourth concurrent progress connection for the same user', () => {
+      const context = {
+        user: {
+          id: 7,
+          username: 'tenant-user',
+          role_name: 'admin',
+          is_system_role: false,
+          permissions: [],
+          org_id: 42,
+          org_slug: 'acme',
+        },
+      };
+
+      const cleanup1 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), context);
+      const cleanup2 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), context);
+      const cleanup3 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), context);
+
+      expect(() => scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), context)).toThrow(
+        'Maximum of 3 concurrent progress connections per user exceeded'
+      );
+
+      cleanup1();
+      cleanup2();
+      cleanup3();
+    });
+
+    it('should scope concurrent progress connections by org slug and user id', () => {
+      const acmeContext = {
+        user: {
+          id: 7,
+          username: 'tenant-user',
+          role_name: 'admin',
+          is_system_role: false,
+          permissions: [],
+          org_id: 42,
+          org_slug: 'acme',
+        },
+      };
+      const bravoContext = {
+        user: {
+          ...acmeContext.user,
+          org_id: 77,
+          org_slug: 'bravo',
+        },
+      };
+
+      const cleanup1 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), acmeContext);
+      const cleanup2 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), acmeContext);
+      const cleanup3 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), acmeContext);
+
+      const otherTenantCleanup = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), bravoContext);
+
+      expect(() => scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), acmeContext)).toThrow(
+        'Maximum of 3 concurrent progress connections per user exceeded'
+      );
+
+      cleanup1();
+      cleanup2();
+      cleanup3();
+      otherTenantCleanup();
+    });
+
+    it('should fall back to org id in the connection key when org slug is absent', () => {
+      const firstOrgContext = {
+        user: {
+          id: 7,
+          username: 'tenant-user',
+          role_name: 'admin',
+          is_system_role: false,
+          permissions: [],
+          org_id: 42,
+        },
+      };
+      const secondOrgContext = {
+        user: {
+          ...firstOrgContext.user,
+          org_id: 77,
+        },
+      };
+
+      const cleanup1 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), firstOrgContext);
+      const cleanup2 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), firstOrgContext);
+      const cleanup3 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), firstOrgContext);
+
+      const otherTenantCleanup = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), secondOrgContext);
+
+      expect(() => scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), firstOrgContext)).toThrow(
+        'Maximum of 3 concurrent progress connections per user exceeded'
+      );
+
+      cleanup1();
+      cleanup2();
+      cleanup3();
+      otherTenantCleanup();
+    });
+
+    it('should use distinct namespaces for org slug, org id fallback, and system scope in the connection key', () => {
+      const slugContext = {
+        user: {
+          id: 7,
+          username: 'tenant-user',
+          role_name: 'admin',
+          is_system_role: false,
+          permissions: [],
+          org_id: 42,
+          org_slug: '42',
+        },
+      };
+      const orgIdFallbackContext = {
+        user: {
+          id: 7,
+          username: 'tenant-user',
+          role_name: 'admin',
+          is_system_role: false,
+          permissions: [],
+          org_id: 42,
+        },
+      };
+      const systemContext = {
+        user: {
+          id: 7,
+          username: 'system-user',
+          role_name: 'superadmin',
+          is_system_role: true,
+          permissions: [],
+        },
+      };
+
+      const cleanupSlug1 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), slugContext);
+      const cleanupSlug2 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), slugContext);
+      const cleanupSlug3 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), slugContext);
+
+      const cleanupOrgFallback = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), orgIdFallbackContext);
+      const cleanupSystem = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), systemContext);
+
+      expect(() => scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), slugContext)).toThrow(
+        'Maximum of 3 concurrent progress connections per user exceeded'
+      );
+
+      cleanupSlug1();
+      cleanupSlug2();
+      cleanupSlug3();
+      cleanupOrgFallback();
+      cleanupSystem();
+    });
+
+    it('should allow a new connection after disconnect cleanup releases the slot', () => {
+      const context = {
+        user: {
+          id: 7,
+          username: 'tenant-user',
+          role_name: 'admin',
+          is_system_role: false,
+          permissions: [],
+          org_id: 42,
+          org_slug: 'acme',
+        },
+      };
+
+      const cleanup1 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), context);
+      const cleanup2 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), context);
+      const cleanup3 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), context);
+
+      cleanup2();
+
+      const cleanup4 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), context);
+
+      cleanup1();
+      cleanup3();
+      cleanup4();
+    });
+
+    it('should release the reserved slot when tracker subscription fails', () => {
+      const context = {
+        user: {
+          id: 7,
+          username: 'tenant-user',
+          role_name: 'admin',
+          is_system_role: false,
+          permissions: [],
+          org_id: 42,
+          org_slug: 'acme',
+        },
+      };
+
+      vi.mocked(progressTracker.addListener)
+        .mockImplementationOnce(() => {
+          throw new Error('tracker failed');
+        })
+        .mockImplementation(() => undefined);
+
+      expect(() => scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), context)).toThrow('tracker failed');
+
+      const cleanup1 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), context);
+      const cleanup2 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), context);
+      const cleanup3 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), context);
+
+      cleanup1();
+      cleanup2();
+      cleanup3();
+    });
+
+    it('should release the reserved slot when setting SSE headers fails before tracker subscription', () => {
+      const context = {
+        user: {
+          id: 7,
+          username: 'tenant-user',
+          role_name: 'admin',
+          is_system_role: false,
+          permissions: [],
+          org_id: 42,
+          org_slug: 'acme',
+        },
+      };
+      const setHeader = vi.fn()
+        .mockImplementationOnce(() => undefined)
+        .mockImplementationOnce(() => {
+          throw new Error('headers already sent');
+        });
+
+      expect(() => scraperService.subscribeToProgress({ setHeader }, vi.fn(), context)).toThrow('headers already sent');
+
+      const cleanup1 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), context);
+      const cleanup2 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), context);
+      const cleanup3 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), context);
+
+      expect(() => scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), context)).toThrow(
+        'Maximum of 3 concurrent progress connections per user exceeded'
+      );
+
+      cleanup1();
+      cleanup2();
+      cleanup3();
+    });
+
+    it('should release the reserved slot when the listener dies during initial replay', () => {
+      const context = {
+        user: {
+          id: 7,
+          username: 'tenant-user',
+          role_name: 'admin',
+          is_system_role: false,
+          permissions: [],
+          org_id: 42,
+          org_slug: 'acme',
+        },
+      };
+
+      vi.mocked(progressTracker.addListener).mockImplementationOnce(() => undefined);
+      vi.mocked(progressTracker.hasListener)
+        .mockReturnValueOnce(false)
+        .mockReturnValue(true);
+
+      const cleanupAfterReplayFailure = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), context);
+
+      const cleanup1 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), context);
+      const cleanup2 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), context);
+      const cleanup3 = scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), context);
+
+      expect(() => scraperService.subscribeToProgress({ setHeader: vi.fn() }, vi.fn(), context)).toThrow(
+        'Maximum of 3 concurrent progress connections per user exceeded'
+      );
+
+      cleanupAfterReplayFailure();
+      cleanup1();
+      cleanup2();
+      cleanup3();
     });
 
     it('should pass tenant trace context to progress tracker', () => {

--- a/server/src/services/scraper-service.ts
+++ b/server/src/services/scraper-service.ts
@@ -7,6 +7,7 @@ import { logger } from '../utils/logger.js';
 import type { ScrapeAttempt } from '../db/scrape-attempt-queries.js';
 import type { AuthRequest } from '../middleware/auth.js';
 import type { ProgressTraceContext } from './progress-tracker.js';
+import { AppError } from '../utils/errors.js';
 
 interface ScrapeTriggerOptions {
   cinemaId?: string;
@@ -21,7 +22,67 @@ interface ScrapeObservabilityContext {
 }
 
 export class ScraperService {
+  private static readonly MAX_PROGRESS_CONNECTIONS_PER_USER = 3;
+  private static readonly progressConnectionsByUser = new Map<string, number>();
+
   constructor(private db: DB) {}
+
+  static resetProgressConnectionTrackingForTests() {
+    this.progressConnectionsByUser.clear();
+  }
+
+  private getProgressConnectionUserKey(context?: ScrapeObservabilityContext): string | undefined {
+    if (context?.user?.id === undefined) {
+      return undefined;
+    }
+
+    const orgScope = context.user.org_slug
+      ? `slug:${context.user.org_slug}`
+      : context.user.org_id !== undefined
+        ? `org:${String(context.user.org_id)}`
+        : 'system:global';
+
+    return `${orgScope}:user:${String(context.user.id)}`;
+  }
+
+  private getActiveProgressConnectionCount(userKey?: string): number {
+    if (!userKey) {
+      return 0;
+    }
+
+    return ScraperService.progressConnectionsByUser.get(userKey) ?? 0;
+  }
+
+  private reserveProgressConnection(userKey?: string): void {
+    if (!userKey) {
+      return;
+    }
+
+    const activeConnections = this.getActiveProgressConnectionCount(userKey);
+    if (activeConnections >= ScraperService.MAX_PROGRESS_CONNECTIONS_PER_USER) {
+      throw new AppError(
+        `Maximum of ${ScraperService.MAX_PROGRESS_CONNECTIONS_PER_USER} concurrent progress connections per user exceeded`,
+        429,
+      );
+    }
+
+    ScraperService.progressConnectionsByUser.set(userKey, activeConnections + 1);
+  }
+
+  private releaseProgressConnection(userKey?: string): void {
+    if (!userKey) {
+      return;
+    }
+
+    const activeConnections = this.getActiveProgressConnectionCount(userKey);
+
+    if (activeConnections <= 1) {
+      ScraperService.progressConnectionsByUser.delete(userKey);
+      return;
+    }
+
+    ScraperService.progressConnectionsByUser.set(userKey, activeConnections - 1);
+  }
 
   private buildTraceContext(context?: ScrapeObservabilityContext): Record<string, string> | undefined {
     if (!context) return undefined;
@@ -183,24 +244,47 @@ export class ScraperService {
    * Subscribes an HTTP response stream to the progress tracker events.
    */
   subscribeToProgress(res: any, onClose: () => void, context?: ScrapeObservabilityContext, lastEventId?: string) {
-    res.setHeader('Content-Type', 'text/event-stream');
-    res.setHeader('Cache-Control', 'no-cache');
-    res.setHeader('Connection', 'keep-alive');
-    res.setHeader('X-Accel-Buffering', 'no'); // Disable nginx buffering
+    const userKey = this.getProgressConnectionUserKey(context);
+    this.reserveProgressConnection(userKey);
 
-    progressTracker.addListener(res, this.buildProgressTraceContext(context), lastEventId);
-    logger.info('SSE client connected', {
-      listeners: progressTracker.getListenerCount(),
-      org_id: context?.user?.org_id,
-      user_id: context?.user?.id,
-      endpoint: context?.endpoint,
-      method: context?.method,
-    });
+    try {
+      res.setHeader('Content-Type', 'text/event-stream');
+      res.setHeader('Cache-Control', 'no-cache');
+      res.setHeader('Connection', 'keep-alive');
+      res.setHeader('X-Accel-Buffering', 'no'); // Disable nginx buffering
+
+      progressTracker.addListener(res, this.buildProgressTraceContext(context), lastEventId);
+      if (!progressTracker.hasListener(res)) {
+        this.releaseProgressConnection(userKey);
+        return () => {};
+      }
+
+      logger.info('SSE client connected', {
+        listeners: progressTracker.getListenerCount(),
+        user_connections: this.getActiveProgressConnectionCount(userKey),
+        org_id: context?.user?.org_id,
+        user_id: context?.user?.id,
+        endpoint: context?.endpoint,
+        method: context?.method,
+      });
+    } catch (error) {
+      this.releaseProgressConnection(userKey);
+      throw error;
+    }
+
+    let cleanedUp = false;
 
     return () => {
+      if (cleanedUp) {
+        return;
+      }
+
+      cleanedUp = true;
       progressTracker.removeListener(res);
+      this.releaseProgressConnection(userKey);
       logger.info('SSE client disconnected', {
         listeners: progressTracker.getListenerCount(),
+        user_connections: this.getActiveProgressConnectionCount(userKey),
         org_id: context?.user?.org_id,
         user_id: context?.user?.id,
         endpoint: context?.endpoint,


### PR DESCRIPTION
## Summary
This PR closes the remaining scope of #630: hardening the authenticated SSE progress endpoint against abusive or accidental over-subscription.

Authentication on `/api/scraper/progress` already exists on `develop`. The remaining risk was elsewhere: a single authenticated user could still open multiple concurrent Server-Sent Events connections to the progress stream and keep backend resources occupied unnecessarily.

This change introduces an explicit per-user concurrent connection cap on the progress SSE endpoint, makes that cap tenant-aware, and guarantees cleanup when a connection fails during SSE setup.

Closes #630

## Why this change matters
From a functional perspective, the progress stream is meant to represent the current scraping activity for a logged-in user, not to serve as an unlimited fan-out channel.

Without a guardrail, the same user could:
- open several browser tabs or repeated retries and accumulate redundant live progress streams;
- keep stale connections alive longer than intended;
- consume backend listener / memory / stream capacity disproportionately;
- create noisy failure modes for themselves and potentially degrade service quality for others.

In short: authentication answers “who may connect”, but this PR also answers “how many concurrent progress streams one user may hold at once”.

## Functional behavior after this PR
### Normal behavior
- an authenticated user can subscribe to `/api/scraper/progress` as before;
- up to 3 concurrent progress SSE connections are allowed per user and scope;
- disconnecting a stream frees the slot so a later connection can succeed.

### When the limit is exceeded
- the endpoint rejects the extra connection deterministically with HTTP `429 Too Many Requests`;
- existing active streams continue to work;
- the rejection is explicit instead of silently degrading or leaking server-side listeners.

### Multi-tenant / scope considerations
The quota key is now explicitly namespaced by execution scope:
- `slug:<org_slug>:user:<id>`
- `org:<org_id>:user:<id>`
- `system:global:user:<id>`

This matters functionally because the same numeric user id should not accidentally share the same concurrency bucket across different tenant contexts or system/global scope. The limit remains “per user in context”, not “per raw user id everywhere”.

## Technical changes
- add an explicit concurrent SSE connection cap for authenticated progress subscriptions;
- return `429` when the cap is exceeded;
- namespace connection-quota keys by tenant/scope to avoid ambiguous cross-scope collisions;
- guarantee reserved-slot cleanup if SSE setup fails before the listener is fully established;
- extend route and service tests around quota enforcement and cleanup.

## Failure and cleanup semantics
This PR specifically hardens early-failure paths that are easy to miss in happy-path testing:
- SSE header setup failure;
- listener registration failure;
- failure during initial progress replay.

If any of those steps fail, the reserved connection slot is released immediately so the user does not get “phantom” `429` responses on later retries.

## What this PR does not change
- it does not change authentication behavior for the endpoint;
- it does not widen access to the stream;
- it does not alter the business meaning of progress events;
- it does not introduce tenant-level cross-user throttling — the limit remains scoped to one authenticated user in one context.

## User-visible impact
For normal usage, there should be no visible change except improved robustness.

The only newly visible behavior is when the same authenticated user opens too many concurrent progress streams: the extra attempt now fails fast and predictably with `429`, instead of consuming resources or leaving inconsistent server state.

## Verification
### Targeted tests
- `docker compose -f docker-compose.dev.yml run --rm server sh -lc "npm install --legacy-peer-deps >/tmp/npm-install.log 2>&1 && cd server && npm run test:run -- src/services/scraper-service.test.ts src/routes/scraper.test.ts"`
- Result: `57/57` tests passed

### Local PR image validation
- pulled `ghcr.io/phbassin/allo-scrapper:pr-999`
- pulled `ghcr.io/phbassin/allo-scrapper-scraper:pr-999`
- started isolated Docker validation stack on port `3001`
- verified `GET /api/health` returned `200` with healthy database status

### CI
- PR checks green
- Docker build/push green
- PR image published as `pr-999`

## Reviewer guide
Suggested review focus:
1. quota key construction is explicit and scope-safe;
2. connection-slot lifecycle is balanced on success, disconnect, and early SSE setup failures;
3. `429` behavior is deterministic and covered by tests;
4. patch scope stays limited to the progress SSE hardening described in #630.
