### PR TITLE
fix: harden metrics and settings boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,8 +664,9 @@ Authorization: Bearer <org-admin-token>
 Dedicated metrics endpoint for multi-tenant monitoring:
 
 ```bash
-# Metrics endpoint (open, unauthenticated)
+# Metrics endpoint (superadmin authentication required)
 GET /api/saas/metrics
+Authorization: Bearer <superadmin-token>
 ```
 
 **Available Metrics:**

--- a/packages/saas/src/plugin.test.ts
+++ b/packages/saas/src/plugin.test.ts
@@ -8,11 +8,17 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import express from 'express';
 import type { Express } from 'express';
 import request from 'supertest';
+import jwt from 'jsonwebtoken';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+const TEST_JWT_SECRET = 'a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6';
+
+function mintToken(payload: Record<string, unknown>): string {
+  return jwt.sign(payload, TEST_JWT_SECRET, { expiresIn: '1h' });
+}
 
 // We spy on runMigrations imported dynamically inside plugin.ts.
 // Since plugin.ts uses a dynamic import to avoid cross-rootDir compile-time
@@ -29,7 +35,7 @@ describe('saasPlugin', () => {
   beforeEach(() => {
     app = express();
     vi.clearAllMocks();
-    vi.stubEnv('JWT_SECRET', 'local-dev-jwt-fixture-key-1234567890abcd');
+    vi.stubEnv('JWT_SECRET', TEST_JWT_SECRET);
   });
 
   afterEach(() => {
@@ -95,6 +101,40 @@ describe('saasPlugin', () => {
 
     const res = await request(app).post('/test/seed-org').send({});
     expect(res.status).toBe(404);
+  });
+
+  it('protects /api/saas/metrics behind superadmin authentication', async () => {
+    const { saasPlugin } = await import('./plugin.js');
+    const db = { query: vi.fn() };
+    const pool = { connect: vi.fn() };
+
+    await saasPlugin.register(app, { db, pool });
+
+    const unauthorized = await request(app).get('/api/saas/metrics');
+    expect(unauthorized.status).toBe(401);
+
+    const tenantToken = mintToken({
+      id: 1,
+      username: 'tenant-admin',
+      role_name: 'admin',
+      is_system_role: false,
+      permissions: ['system:health'],
+      org_slug: 'acme',
+    });
+
+    const forbidden = await request(app)
+      .get('/api/saas/metrics')
+      .set('Authorization', `Bearer ${tenantToken}`);
+    expect(forbidden.status).toBe(403);
+
+    const superadminToken = jwt.sign({ id: 'super-1', username: 'superadmin', scope: 'superadmin' }, TEST_JWT_SECRET, { expiresIn: '1h' });
+
+    const authorized = await request(app)
+      .get('/api/saas/metrics')
+      .set('Authorization', `Bearer ${superadminToken}`);
+
+    expect(authorized.status).toBe(200);
+    expect(authorized.headers['content-type']).toContain('text/plain');
   });
 
 

--- a/packages/saas/src/plugin.ts
+++ b/packages/saas/src/plugin.ts
@@ -17,6 +17,7 @@ import { createTestFixturesNotFoundRouter, createTestFixturesRouter } from './ro
 import { createOrgMetricsMiddleware, getOrgRegistry } from './middleware/org-metrics.js';
 import { startQuotaResetScheduler } from './quota-reset-scheduler.js';
 import { requireSuperadmin } from './middleware/superadmin-auth.js';
+import { protectedLimiter } from 'allo-scrapper-server/dist/middleware/rate-limit.js';
 import type { DB } from './db/types.js';
 import { logger } from './utils/logger.js';
 
@@ -72,7 +73,7 @@ export const saasPlugin: AppPlugin = {
     }
 
     // Prometheus metrics endpoint for org-level metrics
-    app.get('/api/saas/metrics', requireSuperadmin as any, async (_req, res) => {
+    app.get('/api/saas/metrics', protectedLimiter, requireSuperadmin as any, async (_req, res) => {
       try {
         res.set('Content-Type', getOrgRegistry().contentType);
         const metrics = await getOrgRegistry().metrics();

--- a/packages/saas/src/plugin.ts
+++ b/packages/saas/src/plugin.ts
@@ -16,6 +16,7 @@ import { createSuperadminRouter } from './routes/superadmin.js';
 import { createTestFixturesNotFoundRouter, createTestFixturesRouter } from './routes/test-fixtures.js';
 import { createOrgMetricsMiddleware, getOrgRegistry } from './middleware/org-metrics.js';
 import { startQuotaResetScheduler } from './quota-reset-scheduler.js';
+import { requireSuperadmin } from './middleware/superadmin-auth.js';
 import type { DB } from './db/types.js';
 import { logger } from './utils/logger.js';
 
@@ -70,8 +71,8 @@ export const saasPlugin: AppPlugin = {
       app.use('/test', createTestFixturesNotFoundRouter());
     }
 
-    // Prometheus metrics endpoint for org-level metrics (open/unauthenticated)
-    app.get('/api/saas/metrics', async (_req, res) => {
+    // Prometheus metrics endpoint for org-level metrics
+    app.get('/api/saas/metrics', requireSuperadmin as any, async (_req, res) => {
       try {
         res.set('Content-Type', getOrgRegistry().contentType);
         const metrics = await getOrgRegistry().metrics();

--- a/packages/saas/src/routes/org-settings-import.test.ts
+++ b/packages/saas/src/routes/org-settings-import.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { errorHandler } from 'allo-scrapper-server/dist/middleware/error-handler.js';
+import { validateImage } from 'allo-scrapper-server/dist/utils/image-validator.js';
+
+const updateSettingsMock = vi.fn();
+const getSettingsMock = vi.fn();
+
+vi.mock('../services/org-settings-service.js', () => ({
+  OrgSettingsService: vi.fn(function MockOrgSettingsService() {
+    return {
+      updateSettings: updateSettingsMock,
+      getSettings: getSettingsMock,
+    };
+  }),
+}));
+
+vi.mock('allo-scrapper-server/dist/utils/image-validator.js', () => ({
+  validateImage: vi.fn(),
+}));
+
+vi.mock('allo-scrapper-server/dist/middleware/auth.js', () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (req.headers.authorization === 'Bearer valid-token') {
+      req.user = { id: 1, username: 'admin' };
+      return next();
+    }
+    res.status(401).json({ error: 'Unauthorized' });
+  },
+}));
+
+vi.mock('allo-scrapper-server/dist/middleware/permission.js', () => ({
+  requirePermission: () => (_req: any, _res: any, next: any) => next(),
+}));
+
+describe('POST /api/org/:slug/settings/import', () => {
+  let app: express.Application;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    updateSettingsMock.mockResolvedValue({ id: 1, site_name: 'Updated Org' });
+    getSettingsMock.mockResolvedValue({
+      id: 1,
+      site_name: 'Updated Org',
+      logo_base64: null,
+      favicon_base64: null,
+      color_primary: '#FECC00',
+      color_secondary: '#1F2937',
+      color_accent: '#F59E0B',
+      color_background: '#FFFFFF',
+      color_surface: '#F3F4F6',
+      color_text_primary: '#111827',
+      color_text_secondary: '#6B7280',
+      color_success: '#10B981',
+      color_error: '#EF4444',
+      font_primary: 'Inter',
+      font_secondary: 'Roboto',
+      footer_text: null,
+      footer_links: [{ label: 'Privacy', url: '/privacy' }],
+      email_from_name: 'Acme',
+      email_from_address: 'no-reply@acme.test',
+      scrape_mode: 'weekly',
+      scrape_days: 7,
+      updated_at: '2026-03-01T06:00:00Z',
+      updated_by: 1,
+    });
+    vi.mocked(validateImage).mockResolvedValue({
+      valid: true,
+      compressedBase64: 'data:image/png;base64,compressed',
+    });
+
+    app = express();
+    app.use(express.json());
+    app.use((req: any, _res, next) => {
+      req.dbClient = { query: vi.fn() };
+      req.org = { id: 1, slug: 'acme', name: 'Acme', status: 'active' };
+      next();
+    });
+
+    const router = (await import('./org-settings.js')).default;
+    app.use('/api/org/:slug/settings', router);
+    app.use(errorHandler);
+  });
+
+  it('rejects incompatible import versions', async () => {
+    const response = await request(app)
+      .post('/api/org/acme/settings/import')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ version: '2.0', settings: {} });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toContain('Incompatible version');
+    expect(updateSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects imports missing required canonical fields after legacy normalization', async () => {
+    const response = await request(app)
+      .post('/api/org/acme/settings/import')
+      .set('Authorization', 'Bearer valid-token')
+      .send({
+        version: '1.0',
+        settings: {
+          site_name: 'Legacy only',
+          color_border: '#E5E7EB',
+          color_text: '#111827',
+          font_family_heading: 'Inter',
+          font_family_body: 'Roboto',
+        },
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toContain('Missing required field');
+    expect(updateSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it('normalizes legacy payloads before required-field validation', async () => {
+    const response = await request(app)
+      .post('/api/org/acme/settings/import')
+      .set('Authorization', 'Bearer valid-token')
+      .send({
+        version: '1.0',
+        settings: {
+          site_name: 'Legacy Cinema',
+          logo_base64: 'data:image/png;base64,raw-logo',
+          favicon_base64: 'data:image/png;base64,raw-favicon',
+          color_primary: '#FECC00',
+          color_secondary: '#1F2937',
+          color_accent: '#F59E0B',
+          color_background: '#FFFFFF',
+          color_border: '#F3F4F6',
+          color_text: '#111827',
+          color_text_secondary: '#6B7280',
+          color_success: '#10B981',
+          color_error: '#EF4444',
+          font_family_heading: 'Inter',
+          font_family_body: 'Roboto',
+          email_from_name: 'Acme',
+          email_from_address: 'no-reply@acme.test',
+          footer_links: [{ text: 'Terms', url: '/terms' }],
+        },
+      });
+
+    expect(response.status).toBe(200);
+    expect(validateImage).toHaveBeenNthCalledWith(1, 'data:image/png;base64,raw-logo', 'logo', 200000);
+    expect(validateImage).toHaveBeenNthCalledWith(2, 'data:image/png;base64,raw-favicon', 'favicon', 50000);
+    expect(updateSettingsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        logo_base64: 'data:image/png;base64,compressed',
+        favicon_base64: 'data:image/png;base64,compressed',
+        color_surface: '#F3F4F6',
+        color_text_primary: '#111827',
+        font_primary: 'Inter',
+        font_secondary: 'Roboto',
+        footer_links: [{ label: 'Terms', url: '/terms' }],
+      }),
+      1,
+    );
+  });
+
+  it('rejects invalid imported logo images with the same contract as server settings', async () => {
+    vi.mocked(validateImage).mockResolvedValueOnce({
+      valid: false,
+      error: 'Invalid image data',
+    });
+
+    const response = await request(app)
+      .post('/api/org/acme/settings/import')
+      .set('Authorization', 'Bearer valid-token')
+      .send({
+        version: '1.0',
+        settings: {
+          site_name: 'Legacy Cinema',
+          logo_base64: 'data:image/png;base64,bad-logo',
+          color_primary: '#FECC00',
+          color_secondary: '#1F2937',
+          color_accent: '#F59E0B',
+          color_background: '#FFFFFF',
+          color_surface: '#F3F4F6',
+          color_text_primary: '#111827',
+          color_text_secondary: '#6B7280',
+          color_success: '#10B981',
+          color_error: '#EF4444',
+          font_primary: 'Inter',
+          font_secondary: 'Roboto',
+          email_from_name: 'Acme',
+          email_from_address: 'no-reply@acme.test',
+        },
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toContain('Invalid logo');
+    expect(updateSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid org setting logos on update with the same contract as server settings', async () => {
+    vi.mocked(validateImage).mockResolvedValueOnce({
+      valid: false,
+      error: 'Invalid image data',
+    });
+
+    const response = await request(app)
+      .put('/api/org/acme/settings/admin')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ logo_base64: 'data:image/png;base64,bad-logo' });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toContain('Invalid logo');
+    expect(updateSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it('exports footer_links with legacy text for round-trip compatibility', async () => {
+    getSettingsMock.mockResolvedValue({
+      id: 1,
+      site_name: 'Updated Org',
+      logo_base64: null,
+      favicon_base64: null,
+      color_primary: '#FECC00',
+      color_secondary: '#1F2937',
+      color_accent: '#F59E0B',
+      color_background: '#FFFFFF',
+      color_surface: '#F3F4F6',
+      color_text_primary: '#111827',
+      color_text_secondary: '#6B7280',
+      color_success: '#10B981',
+      color_error: '#EF4444',
+      font_primary: 'Inter',
+      font_secondary: 'Roboto',
+      footer_text: null,
+      footer_links: [{ label: 'Privacy', url: '/privacy' }],
+      email_from_name: 'Acme',
+      email_from_address: 'no-reply@acme.test',
+      scrape_mode: 'weekly',
+      scrape_days: 7,
+      updated_at: '2026-03-01T06:00:00Z',
+      updated_by: 1,
+    });
+
+    const response = await request(app)
+      .post('/api/org/acme/settings/export')
+      .set('Authorization', 'Bearer valid-token')
+      .send();
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.settings.footer_links).toEqual([
+      { label: 'Privacy', text: 'Privacy', url: '/privacy' },
+    ]);
+  });
+});

--- a/packages/saas/src/routes/org-settings.test.ts
+++ b/packages/saas/src/routes/org-settings.test.ts
@@ -34,11 +34,19 @@ describe('normalizeImportSettings', () => {
   it('maps legacy import keys to canonical keys', () => {
     const legacyPayload = {
       site_name: 'Legacy Cinema',
+      color_primary: '#FECC00',
+      color_secondary: '#1F2937',
+      color_accent: '#3B82F6',
+      color_background: '#FFFFFF',
       color_border: '#E5E7EB',
       color_text: '#1F2937',
       color_text_secondary: '#6B7280',
+      color_success: '#10B981',
+      color_error: '#EF4444',
       font_family_heading: 'Playfair Display',
       font_family_body: 'Roboto',
+      email_from_name: 'Legacy',
+      email_from_address: 'legacy@example.com',
       footer_links: [{ text: 'Terms', url: '/terms' }],
     };
 
@@ -50,11 +58,50 @@ describe('normalizeImportSettings', () => {
     expect(result.font_primary).toBe('Playfair Display');
     expect(result.font_secondary).toBe('Roboto');
     expect(result.footer_links).toEqual([
-      { label: 'Terms', text: 'Terms', url: '/terms' },
+      { label: 'Terms', url: '/terms' },
     ]);
     expect(result).not.toHaveProperty('color_border');
     expect(result).not.toHaveProperty('color_text');
     expect(result).not.toHaveProperty('font_family_heading');
     expect(result).not.toHaveProperty('font_family_body');
+  });
+
+  it('preserves null footer_links so validation can reject it explicitly', () => {
+    const result = normalizeImportSettings({ footer_links: null });
+
+    expect(result.footer_links).toBeNull();
+  });
+
+  it('maps incomplete legacy footer links to empty canonical fields for downstream validation', () => {
+    const result = normalizeImportSettings({
+      footer_links: [{ text: 'Terms' }],
+    });
+
+    expect(result.footer_links).toEqual([
+      { label: 'Terms', url: '' },
+    ]);
+  });
+
+  it('keeps canonical import fields required by server-compatible payloads', () => {
+    const result = normalizeImportSettings({
+      site_name: 'Acme Cinema',
+      color_primary: '#FECC00',
+      color_secondary: '#1F2937',
+      color_accent: '#3B82F6',
+      color_background: '#FFFFFF',
+      color_surface: '#F3F4F6',
+      color_text_primary: '#111827',
+      color_text_secondary: '#6B7280',
+      color_success: '#10B981',
+      color_error: '#EF4444',
+      font_primary: 'Inter',
+      font_secondary: 'Roboto',
+      email_from_name: 'Acme',
+      email_from_address: 'no-reply@acme.test',
+    });
+
+    expect(result.site_name).toBe('Acme Cinema');
+    expect(result.email_from_name).toBe('Acme');
+    expect(result.email_from_address).toBe('no-reply@acme.test');
   });
 });

--- a/packages/saas/src/routes/org-settings.ts
+++ b/packages/saas/src/routes/org-settings.ts
@@ -25,6 +25,7 @@ import {
   generateCSSVariables,
   generateGoogleFontsImport,
 } from 'allo-scrapper-server/dist/services/theme-generator.js';
+import { validateImage } from 'allo-scrapper-server/dist/utils/image-validator.js';
 import { requireAuth } from 'allo-scrapper-server/dist/middleware/auth.js';
 import { requirePermission } from 'allo-scrapper-server/dist/middleware/permission.js';
 import type { PermissionName } from 'allo-scrapper-server/dist/types/role.js';
@@ -34,6 +35,8 @@ const router = Router();
 const VALID_SCRAPE_MODES = ['weekly', 'from_today', 'from_today_limited'];
 const SCRAPE_DAYS_MIN = 1;
 const SCRAPE_DAYS_MAX = 14;
+const LOGO_MAX_SIZE = 200000;
+const FAVICON_MAX_SIZE = 50000;
 
 const INPUT_LIMITS = {
   site_name: 100,
@@ -55,6 +58,22 @@ const DEFAULT_THEME_SETTINGS = {
 } as const;
 
 const DEFAULT_PUBLIC_EXPORT_USER = 'org-admin';
+const REQUIRED_IMPORT_FIELDS = [
+  'site_name',
+  'color_primary',
+  'color_secondary',
+  'color_accent',
+  'color_background',
+  'color_surface',
+  'color_text_primary',
+  'color_text_secondary',
+  'color_success',
+  'color_error',
+  'font_primary',
+  'font_secondary',
+  'email_from_name',
+  'email_from_address',
+] as const;
 
 type ExportableOrgSettings = Awaited<ReturnType<OrgSettingsService['getSettings']>>;
 
@@ -70,15 +89,42 @@ type ThemeCssSettings = OrgSettingsPublic & {
 
 function normalizeFooterLinks(
   footerLinks: FooterLink[] | undefined
-): Array<{ label: string; url: string }> {
+): Array<{ label: string; text: string; url: string }> {
   if (!Array.isArray(footerLinks)) {
     return [];
   }
 
-  return footerLinks.map((link) => ({
-    label: link.label ?? link.text ?? '',
-    url: link.url ?? '',
-  }));
+  return footerLinks.map((link) => {
+    const label = link.label ?? link.text ?? '';
+
+    return {
+      label,
+      text: label,
+      url: link.url,
+    };
+  });
+}
+
+function validateImportPayload(importData: { version?: string; settings?: Record<string, unknown> }): string | null {
+  if (!importData.version || !importData.settings || typeof importData.settings !== 'object') {
+    return 'Invalid import data format';
+  }
+
+  if (importData.version !== '1.0') {
+    return `Incompatible version: ${importData.version}. Expected 1.0`;
+  }
+
+  return null;
+}
+
+function validateRequiredImportSettings(updates: OrgSettingsUpdate): string | null {
+  for (const field of REQUIRED_IMPORT_FIELDS) {
+    if (!(field in updates)) {
+      return `Missing required field in import data: ${field}`;
+    }
+  }
+
+  return null;
 }
 
 function toThemeCssSettings(settings: OrgSettingsPublic): ThemeCssSettings {
@@ -119,13 +165,17 @@ export function normalizeImportSettings(rawSettings: Record<string, unknown>): O
           ? (link as Record<string, unknown>)
           : {};
 
+        const label = item.label ?? item.text;
+        const url = item.url;
+
         return {
-          label: String(item.label ?? item.text ?? ''),
-          text: String(item.text ?? item.label ?? ''),
-          url: String(item.url ?? ''),
+          label: typeof label === 'string' ? label : '',
+          url: typeof url === 'string' ? url : '',
         };
       })
-    : undefined;
+    : rawSettings.footer_links === null
+      ? null as never
+      : undefined;
 
   const updates: OrgSettingsUpdate = {
     site_name: typeof rawSettings.site_name === 'string' ? rawSettings.site_name : undefined,
@@ -198,6 +248,28 @@ export function normalizeImportSettings(rawSettings: Record<string, unknown>): O
   ) as OrgSettingsUpdate;
 }
 
+async function validateSettingsImages(res: Response, updates: OrgSettingsUpdate): Promise<boolean> {
+  if (updates.logo_base64) {
+    const logoValidation = await validateImage(updates.logo_base64, 'logo', LOGO_MAX_SIZE);
+    if (!logoValidation.valid) {
+      res.status(400).json({ error: `Invalid logo: ${logoValidation.error}` });
+      return false;
+    }
+    updates.logo_base64 = logoValidation.compressedBase64!;
+  }
+
+  if (updates.favicon_base64) {
+    const faviconValidation = await validateImage(updates.favicon_base64, 'favicon', FAVICON_MAX_SIZE);
+    if (!faviconValidation.valid) {
+      res.status(400).json({ error: `Invalid favicon: ${faviconValidation.error}` });
+      return false;
+    }
+    updates.favicon_base64 = faviconValidation.compressedBase64!;
+  }
+
+  return true;
+}
+
 function validateSettingsUpdate(res: Response, updates: OrgSettingsUpdate): boolean {
   for (const [field, limit] of Object.entries(INPUT_LIMITS)) {
     const value = updates[field as keyof OrgSettingsUpdate];
@@ -245,10 +317,26 @@ function validateSettingsUpdate(res: Response, updates: OrgSettingsUpdate): bool
     return false;
   }
 
-  if (updates.footer_links && Array.isArray(updates.footer_links)) {
+  if (updates.footer_links !== undefined) {
+    if (!Array.isArray(updates.footer_links)) {
+      res.status(400).json({ error: 'footer_links must be an array' });
+      return false;
+    }
+
     for (const link of updates.footer_links) {
-      if (!link.url) {
-        continue;
+      if (!link || typeof link !== 'object') {
+        res.status(400).json({ error: 'Each footer link must be an object with label and url' });
+        return false;
+      }
+
+      if (typeof link.label !== 'string' || link.label.trim() === '') {
+        res.status(400).json({ error: 'Each footer link must include a non-empty label' });
+        return false;
+      }
+
+      if (typeof link.url !== 'string' || link.url.trim() === '') {
+        res.status(400).json({ error: 'Each footer link must include a non-empty url' });
+        return false;
       }
 
       try {
@@ -307,6 +395,10 @@ async function updateSettingsHandler(req: Request, res: Response, next: NextFunc
 
     if (!user) {
       res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+
+    if (!await validateSettingsImages(res, updates)) {
       return;
     }
 
@@ -415,12 +507,23 @@ router.post('/import', ...requireSettingsImport, async (req: Request, res: Respo
       return;
     }
 
-    if (!importData.version || !importData.settings || typeof importData.settings !== 'object') {
-      res.status(400).json({ error: 'Invalid import data format' });
+    const importValidationError = validateImportPayload(importData);
+    if (importValidationError) {
+      res.status(400).json({ error: importValidationError });
       return;
     }
 
-    const updates = normalizeImportSettings(importData.settings);
+    const updates = normalizeImportSettings(importData.settings!);
+    const requiredImportSettingsError = validateRequiredImportSettings(updates);
+    if (requiredImportSettingsError) {
+      res.status(400).json({ error: requiredImportSettingsError });
+      return;
+    }
+
+    if (!await validateSettingsImages(res, updates)) {
+      return;
+    }
+
     if (!validateSettingsUpdate(res, updates)) {
       return;
     }

--- a/packages/saas/src/routes/org.test.ts
+++ b/packages/saas/src/routes/org.test.ts
@@ -339,16 +339,28 @@ describe('POST /api/org/:slug/cinemas — quota guard', () => {
 // ── Films ─────────────────────────────────────────────────────────────────────
 
 describe('GET /api/org/:slug/films', () => {
-  it('returns 200 and queries scoped client', async () => {
-    const jwtUser = {
-      id: 1, username: 'admin', role_name: 'admin',
-      is_system_role: true, permissions: [], org_slug: 'acme',
-    };
-    const { app, dbClient } = buildApp('acme', 'active', [], jwtUser);
+  it('returns 200 without authentication for public tenant film listing', async () => {
+    const { app, dbClient } = buildApp('acme', 'active', []);
     const { createOrgRouter } = await import('./org.js');
     app.use('/api/org/:slug', createOrgRouter());
 
     const res = await request(app).get('/api/org/acme/films');
+    expect(res.status).toBe(200);
+    expect(dbClient.query).toHaveBeenCalled();
+  });
+
+  it('returns 200 and queries scoped client for authenticated org user', async () => {
+    const jwtUser = {
+      id: 1, username: 'admin', role_name: 'admin',
+      is_system_role: true, permissions: [], org_slug: 'acme',
+    };
+    const { app, dbClient, token } = buildApp('acme', 'active', [], jwtUser);
+    const { createOrgRouter } = await import('./org.js');
+    app.use('/api/org/:slug', createOrgRouter());
+
+    const res = await request(app)
+      .get('/api/org/acme/films')
+      .set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(200);
     expect(dbClient.query).toHaveBeenCalled();
   });

--- a/packages/saas/src/services/org-settings-service.test.ts
+++ b/packages/saas/src/services/org-settings-service.test.ts
@@ -85,6 +85,27 @@ describe('OrgSettingsService', () => {
   });
 
   describe('updateSettings', () => {
+    it('rejects footer_links when provided as null', async () => {
+      await expect(service.updateSettings({ footer_links: null as any }, 42)).rejects.toThrow(
+        /footer_links must be an array/i
+      );
+      expect(mockDb.query).not.toHaveBeenCalled();
+    });
+
+    it('rejects footer links missing a label', async () => {
+      await expect(
+        service.updateSettings({ footer_links: [{ url: '/terms' } as any] }, 42)
+      ).rejects.toThrow(/non-empty label/i);
+      expect(mockDb.query).not.toHaveBeenCalled();
+    });
+
+    it('rejects footer links missing a url', async () => {
+      await expect(
+        service.updateSettings({ footer_links: [{ label: 'Terms', text: 'Terms' } as any] }, 42)
+      ).rejects.toThrow(/non-empty url/i);
+      expect(mockDb.query).not.toHaveBeenCalled();
+    });
+
     it('updates settings and returns updated row', async () => {
       const updates = {
         site_name: 'New Name',

--- a/packages/saas/src/services/org-settings-service.ts
+++ b/packages/saas/src/services/org-settings-service.ts
@@ -42,6 +42,47 @@ export interface OrgSettingsRow {
   updated_by: number | null;
 }
 
+function validateFooterLinks(footerLinks: FooterLink[] | undefined): void {
+  if (footerLinks === undefined) {
+    return;
+  }
+
+  if (!Array.isArray(footerLinks)) {
+    throw new Error('footer_links must be an array');
+  }
+
+  for (const link of footerLinks) {
+    if (!link || typeof link !== 'object') {
+      throw new Error('Each footer link must be an object with label and url');
+    }
+
+    if (typeof link.label !== 'string' || link.label.trim() === '') {
+      throw new Error('Each footer link must include a non-empty label');
+    }
+
+    if (typeof link.url !== 'string' || link.url.trim() === '') {
+      throw new Error('Each footer link must include a non-empty url');
+    }
+
+    try {
+      const parsedUrl = new URL(link.url, 'http://dummy.com');
+      if (
+        parsedUrl.protocol !== 'http:'
+        && parsedUrl.protocol !== 'https:'
+        && parsedUrl.protocol !== 'mailto:'
+        && parsedUrl.protocol !== 'tel:'
+      ) {
+        throw new Error(`Invalid URL protocol in footer link: ${link.url}`);
+      }
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith('Invalid URL protocol in footer link:')) {
+        throw error;
+      }
+      throw new Error(`Invalid URL format in footer link: ${link.url}`);
+    }
+  }
+}
+
 export class OrgSettingsService {
   constructor(private db: DB) {}
 
@@ -112,6 +153,8 @@ export class OrgSettingsService {
     updates: OrgSettingsUpdate,
     userId: number
   ): Promise<OrgSettings | undefined> {
+    validateFooterLinks(updates.footer_links);
+
     // Build dynamic UPDATE query
     const fields: string[] = [];
     const values: any[] = [];

--- a/server/src/app.test.ts
+++ b/server/src/app.test.ts
@@ -3,7 +3,8 @@ import request from 'supertest';
 import type { Express } from 'express';
 import type { DB } from './db/client.js';
 import type { Pool } from 'pg';
-import { createApp, applyPlugins, registerFallbackHandlers, type AppPlugin } from './app.js';
+import jwt from 'jsonwebtoken';
+import { createApp, applyPlugins, registerFallbackHandlers, isTrustedInternalMetricsScrape, type AppPlugin } from './app.js';
 import { AuthError } from './utils/errors.js';
 
 // Mock dependencies
@@ -17,6 +18,12 @@ const createMockDb = (queryImpl = vi.fn().mockResolvedValue({ rows: [{ result: 1
   end: vi.fn(),
 } as unknown as DB);
 
+const TEST_JWT_SECRET = 'a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6';
+
+function mintToken(payload: Record<string, unknown>): string {
+  return jwt.sign(payload, TEST_JWT_SECRET, { expiresIn: '1h' });
+}
+
 const loadNonTestAppModule = async () => {
   vi.resetModules();
   return import('./app.js');
@@ -28,6 +35,54 @@ describe('App - Theme Endpoint', () => {
   let originalNodeEnv: string | undefined;
   let originalGeneralMax: string | undefined;
   let originalHealthMax: string | undefined;
+
+  describe('isTrustedInternalMetricsScrape', () => {
+    it('accepts direct docker-network scrapes without forwarded headers', () => {
+      const req = {
+        headers: {},
+        socket: { remoteAddress: '172.18.0.5' },
+      } as any;
+
+      expect(isTrustedInternalMetricsScrape(req)).toBe(true);
+    });
+
+    it('rejects requests that present forwarded headers even from private addresses', () => {
+      const req = {
+        headers: { 'x-forwarded-for': '203.0.113.42' },
+        socket: { remoteAddress: '172.18.0.5' },
+      } as any;
+
+      expect(isTrustedInternalMetricsScrape(req)).toBe(false);
+    });
+
+    it('rejects 10.x and 192.168.x private addresses that are outside the Docker bridge trust boundary', () => {
+      const tenNetReq = {
+        headers: {},
+        socket: { remoteAddress: '10.0.0.5' },
+      } as any;
+      const lanReq = {
+        headers: {},
+        socket: { remoteAddress: '192.168.1.8' },
+      } as any;
+
+      expect(isTrustedInternalMetricsScrape(tenNetReq)).toBe(false);
+      expect(isTrustedInternalMetricsScrape(lanReq)).toBe(false);
+    });
+
+    it('rejects loopback and public addresses', () => {
+      const loopbackReq = {
+        headers: {},
+        socket: { remoteAddress: '127.0.0.1' },
+      } as any;
+      const publicReq = {
+        headers: {},
+        socket: { remoteAddress: '203.0.113.42' },
+      } as any;
+
+      expect(isTrustedInternalMetricsScrape(loopbackReq)).toBe(false);
+      expect(isTrustedInternalMetricsScrape(publicReq)).toBe(false);
+    });
+  });
 
   beforeEach(() => {
     originalNodeEnv = process.env.NODE_ENV;
@@ -292,9 +347,45 @@ describe('App - Theme Endpoint', () => {
   });
 
   describe('GET /metrics', () => {
-    it('should return Prometheus metrics', async () => {
+    it('should return 401 without authentication', async () => {
       const res = await request(app)
         .get('/metrics')
+        .expect(401);
+
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toBe('Authentication required. No token provided.');
+    });
+
+    it('should return 403 for authenticated users without system:health permission', async () => {
+      const token = mintToken({
+        id: 1,
+        username: 'operator',
+        role_name: 'operator',
+        is_system_role: false,
+        permissions: [],
+      });
+
+      const res = await request(app)
+        .get('/metrics')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(403);
+
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toBe('Permission denied');
+    });
+
+    it('should return Prometheus metrics for users with system:health permission', async () => {
+      const token = mintToken({
+        id: 1,
+        username: 'operator',
+        role_name: 'operator',
+        is_system_role: false,
+        permissions: ['system:health'],
+      });
+
+      const res = await request(app)
+        .get('/metrics')
+        .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
       expect(res.headers['content-type']).toContain('text/plain');

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -11,7 +11,7 @@ import type { Pool } from 'pg';
 
 import { getCorsOptions } from './utils/cors-config.js';
 import { logger } from './utils/logger.js';
-import { generalLimiter, healthCheckLimiter } from './middleware/rate-limit.js';
+import { generalLimiter, healthCheckLimiter, protectedLimiter } from './middleware/rate-limit.js';
 import { requireAuth, type AuthRequest } from './middleware/auth.js';
 import { requirePermission } from './middleware/permission.js';
 import { generateThemeCSS } from './services/theme-generator.js';
@@ -294,7 +294,7 @@ export function createApp() {
   });
 
   // Prometheus metrics endpoint
-  app.get('/metrics', requireMetricsAccess, async (_req, res) => {
+  app.get('/metrics', protectedLimiter, requireMetricsAccess, async (_req, res) => {
     try {
       res.set('Content-Type', serverRegistry.contentType);
       res.end(await serverRegistry.metrics());

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import type { Express } from 'express';
+import type { Express, Request, Response, NextFunction } from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import morgan from 'morgan';
@@ -12,6 +12,8 @@ import type { Pool } from 'pg';
 import { getCorsOptions } from './utils/cors-config.js';
 import { logger } from './utils/logger.js';
 import { generalLimiter, healthCheckLimiter } from './middleware/rate-limit.js';
+import { requireAuth, type AuthRequest } from './middleware/auth.js';
+import { requirePermission } from './middleware/permission.js';
 import { generateThemeCSS } from './services/theme-generator.js';
 import { validateInputSize } from "./middleware/input-validation.js";
 import { errorHandler } from './middleware/error-handler.js';
@@ -84,6 +86,45 @@ const __dirname = path.dirname(__filename);
 // ---------------------------------------------------------------------------
 const serverRegistry = new Registry();
 collectDefaultMetrics({ register: serverRegistry, prefix: 'ics_web_' });
+
+function isTrustedDockerBridgeAddress(remoteAddress: string | undefined): boolean {
+  if (!remoteAddress) {
+    return false;
+  }
+
+  const normalized = remoteAddress.replace(/^::ffff:/, '');
+  const octets = normalized.split('.');
+  if (octets.length === 4 && octets.every((segment) => /^\d+$/.test(segment))) {
+    const first = Number(octets[0]);
+    const second = Number(octets[1]);
+    return first === 172 && second >= 16 && second <= 31;
+  }
+
+  return false;
+}
+
+export function isTrustedInternalMetricsScrape(req: Request): boolean {
+  const forwardedFor = req.headers['x-forwarded-for'];
+  if (typeof forwardedFor === 'string' && forwardedFor.trim() !== '') {
+    return false;
+  }
+
+  if (Array.isArray(forwardedFor) && forwardedFor.some((value) => value.trim() !== '')) {
+    return false;
+  }
+
+  return isTrustedDockerBridgeAddress(req.socket.remoteAddress);
+}
+
+function requireMetricsAccess(req: Request, res: Response, next: NextFunction): void | Response {
+  if (isTrustedInternalMetricsScrape(req)) {
+    return next();
+  }
+
+  return requireAuth(req as AuthRequest, res, () =>
+    requirePermission('system:health')(req as AuthRequest, res, next)
+  );
+}
 
 function createAdminScraperAliasRouter() {
   const router = express.Router();
@@ -253,7 +294,7 @@ export function createApp() {
   });
 
   // Prometheus metrics endpoint
-  app.get('/metrics', async (_req, res) => {
+  app.get('/metrics', requireMetricsAccess, async (_req, res) => {
     try {
       res.set('Content-Type', serverRegistry.contentType);
       res.end(await serverRegistry.metrics());

--- a/server/src/db/settings-queries.test.ts
+++ b/server/src/db/settings-queries.test.ts
@@ -207,6 +207,27 @@ describe('Settings Queries', () => {
       expect(result?.favicon_base64).toBeNull();
     });
 
+    it('should reject footer_links when provided as null', async () => {
+      await expect(updateSettings(db, { footer_links: null as any }, 1)).rejects.toThrow(
+        /footer_links must be an array/i
+      );
+      expect(db.query).not.toHaveBeenCalled();
+    });
+
+    it('should reject footer links missing a label', async () => {
+      await expect(
+        updateSettings(db, { footer_links: [{ url: 'https://example.com' } as any] }, 1)
+      ).rejects.toThrow(/non-empty label/i);
+      expect(db.query).not.toHaveBeenCalled();
+    });
+
+    it('should reject footer links missing a url', async () => {
+      await expect(
+        updateSettings(db, { footer_links: [{ label: 'Privacy' } as any] }, 1)
+      ).rejects.toThrow(/non-empty url/i);
+      expect(db.query).not.toHaveBeenCalled();
+    });
+
     it('should handle footer_links array updates', async () => {
       const updates: AppSettingsUpdate = {
         footer_links: [
@@ -389,6 +410,38 @@ describe('Settings Queries', () => {
       } as AppSettingsExport;
 
       await expect(importSettings(db, invalidExport, 1)).rejects.toThrow();
+    });
+
+    it('should reject footer links with unsafe protocols during import', async () => {
+      const invalidExport: AppSettingsExport = {
+        version: '1.0',
+        exported_at: '2026-03-01T05:00:00Z',
+        settings: {
+          site_name: 'Imported Cinema',
+          logo_base64: null,
+          favicon_base64: null,
+          color_primary: '#000000',
+          color_secondary: '#FFFFFF',
+          color_accent: '#FF00FF',
+          color_background: '#FAFAFA',
+          color_surface: '#F0F0F0',
+          color_text_primary: '#000000',
+          color_text_secondary: '#666666',
+          color_success: '#00FF00',
+          color_error: '#FF0000',
+          font_primary: 'Arial',
+          font_secondary: 'Verdana',
+          footer_text: 'Imported footer',
+          footer_links: [{ label: 'Owned', url: 'javascript:alert(1)' }],
+          email_from_name: 'Imported',
+          email_from_address: 'import@test.com',
+        },
+      };
+
+      await expect(importSettings(db, invalidExport, 1)).rejects.toThrow(
+        /invalid url protocol in footer link/i
+      );
+      expect(db.query).not.toHaveBeenCalled();
     });
   });
 });

--- a/server/src/db/settings-queries.ts
+++ b/server/src/db/settings-queries.ts
@@ -62,6 +62,47 @@ function toPublicSettings(settings: AppSettings): AppSettingsPublic {
   return publicFields;
 }
 
+export function validateFooterLinks(footerLinks: FooterLink[] | undefined): void {
+  if (footerLinks === undefined) {
+    return;
+  }
+
+  if (!Array.isArray(footerLinks)) {
+    throw new Error('footer_links must be an array');
+  }
+
+  for (const link of footerLinks) {
+    if (!link || typeof link !== 'object') {
+      throw new Error('Each footer link must be an object with label and url');
+    }
+
+    if (typeof link.label !== 'string' || link.label.trim() === '') {
+      throw new Error('Each footer link must include a non-empty label');
+    }
+
+    if (typeof link.url !== 'string' || link.url.trim() === '') {
+      throw new Error('Each footer link must include a non-empty url');
+    }
+
+    try {
+      const parsedUrl = new URL(link.url, 'http://dummy.com');
+      if (
+        parsedUrl.protocol !== 'http:' &&
+        parsedUrl.protocol !== 'https:' &&
+        parsedUrl.protocol !== 'mailto:' &&
+        parsedUrl.protocol !== 'tel:'
+      ) {
+        throw new Error(`Invalid URL protocol in footer link: ${link.url}`);
+      }
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith('Invalid URL protocol in footer link:')) {
+        throw error;
+      }
+      throw new Error(`Invalid URL format in footer link: ${link.url}`);
+    }
+  }
+}
+
 /**
  * Get full settings (admin only)
  */
@@ -99,6 +140,8 @@ export async function updateSettings(
   updates: AppSettingsUpdate,
   userId: number
 ): Promise<AppSettings | undefined> {
+  validateFooterLinks(updates.footer_links);
+
   // Build dynamic UPDATE query
   const fields: string[] = [];
   const values: any[] = [];

--- a/server/src/routes/settings.test.ts
+++ b/server/src/routes/settings.test.ts
@@ -6,7 +6,18 @@ import { errorHandler } from '../middleware/error-handler.js';
 import type { DB } from '../db/client.js';
 
 // Mock dependencies
-vi.mock('../db/settings-queries.js');
+vi.mock('../db/settings-queries.js', async () => {
+  const actual = await vi.importActual<typeof import('../db/settings-queries.js')>('../db/settings-queries.js');
+  return {
+    ...actual,
+    getSettings: vi.fn(),
+    getPublicSettings: vi.fn(),
+    updateSettings: vi.fn(),
+    resetSettings: vi.fn(),
+    exportSettings: vi.fn(),
+    importSettings: vi.fn(),
+  };
+});
 vi.mock('../utils/image-validator.js');
 vi.mock('../middleware/auth.js', () => ({
   requireAuth: (req: any, res: any, next: any) => {
@@ -248,6 +259,39 @@ describe('Settings Routes', () => {
       expect(settingsQueries.updateSettings).not.toHaveBeenCalled();
     });
 
+    it('should reject footer_links when provided as null', async () => {
+      const response = await request(app)
+        .put('/api/settings')
+        .set('Authorization', 'Bearer valid-token')
+        .send({ footer_links: null });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('footer_links must be an array');
+      expect(settingsQueries.updateSettings).not.toHaveBeenCalled();
+    });
+
+    it('should reject footer links missing a label', async () => {
+      const response = await request(app)
+        .put('/api/settings')
+        .set('Authorization', 'Bearer valid-token')
+        .send({ footer_links: [{ url: 'https://example.com' }] });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('non-empty label');
+      expect(settingsQueries.updateSettings).not.toHaveBeenCalled();
+    });
+
+    it('should reject footer links missing a url', async () => {
+      const response = await request(app)
+        .put('/api/settings')
+        .set('Authorization', 'Bearer valid-token')
+        .send({ footer_links: [{ label: 'Privacy' }] });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('non-empty url');
+      expect(settingsQueries.updateSettings).not.toHaveBeenCalled();
+    });
+
     it('should allow footer links with safe protocols', async () => {
       const updates = {
         footer_links: [
@@ -475,6 +519,102 @@ describe('Settings Routes', () => {
       expect(response.body.success).toBe(true);
     });
 
+    it('should validate imported logo images with the same contract as update', async () => {
+      const validLogo = 'data:image/png;base64,raw-logo';
+      const importData = {
+        version: '1.0',
+        exported_at: '2026-03-01T05:00:00Z',
+        settings: {
+          site_name: 'Imported Cinema',
+          logo_base64: validLogo,
+          favicon_base64: null,
+          color_primary: '#000000',
+          color_secondary: '#FFFFFF',
+          color_accent: '#FF00FF',
+          color_background: '#FAFAFA',
+          color_surface: '#F0F0F0',
+          color_text_primary: '#000000',
+          color_text_secondary: '#666666',
+          color_success: '#00FF00',
+          color_error: '#FF0000',
+          font_primary: 'Arial',
+          font_secondary: 'Verdana',
+          footer_text: null,
+          footer_links: [],
+          email_from_name: 'Imported',
+          email_from_address: 'import@test.com',
+        },
+      };
+
+      vi.mocked(imageValidator.validateImage).mockResolvedValue({
+        valid: true,
+        compressedBase64: 'data:image/png;base64,compressed-logo',
+      });
+      vi.mocked(settingsQueries.importSettings).mockResolvedValue({
+        id: 1,
+        ...importData.settings,
+        logo_base64: 'data:image/png;base64,compressed-logo',
+        updated_at: '2026-03-01T06:00:00Z',
+        updated_by: 1,
+      } as any);
+
+      const response = await request(app)
+        .post('/api/settings/import')
+        .set('Authorization', 'Bearer valid-token')
+        .send(importData);
+
+      expect(response.status).toBe(200);
+      expect(imageValidator.validateImage).toHaveBeenCalledWith(validLogo, 'logo', 200000);
+      expect(settingsQueries.importSettings).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          settings: expect.objectContaining({
+            logo_base64: 'data:image/png;base64,compressed-logo',
+          }),
+        }),
+        1,
+      );
+    });
+
+    it('should reject invalid imported logo images before persistence', async () => {
+      vi.mocked(imageValidator.validateImage).mockResolvedValue({
+        valid: false,
+        error: 'Invalid image data',
+      });
+
+      const response = await request(app)
+        .post('/api/settings/import')
+        .set('Authorization', 'Bearer valid-token')
+        .send({
+          version: '1.0',
+          exported_at: '2026-03-01T05:00:00Z',
+          settings: {
+            site_name: 'Imported Cinema',
+            logo_base64: 'data:image/png;base64,invalid',
+            favicon_base64: null,
+            color_primary: '#000000',
+            color_secondary: '#FFFFFF',
+            color_accent: '#FF00FF',
+            color_background: '#FAFAFA',
+            color_surface: '#F0F0F0',
+            color_text_primary: '#000000',
+            color_text_secondary: '#666666',
+            color_success: '#00FF00',
+            color_error: '#FF0000',
+            font_primary: 'Arial',
+            font_secondary: 'Verdana',
+            footer_text: null,
+            footer_links: [],
+            email_from_name: 'Imported',
+            email_from_address: 'import@test.com',
+          },
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('Invalid logo');
+      expect(settingsQueries.importSettings).not.toHaveBeenCalled();
+    });
+
     it('should reject invalid import data', async () => {
       const invalidData = {
         version: '2.0', // Wrong version
@@ -491,6 +631,45 @@ describe('Settings Routes', () => {
         .send(invalidData);
 
       expect(response.status).toBe(400);
+    });
+
+    it('should reject footer links with unsafe protocols during import', async () => {
+      const invalidData = {
+        version: '1.0',
+        exported_at: '2026-03-01T05:00:00Z',
+        settings: {
+          site_name: 'Imported Cinema',
+          logo_base64: null,
+          favicon_base64: null,
+          color_primary: '#000000',
+          color_secondary: '#FFFFFF',
+          color_accent: '#FF00FF',
+          color_background: '#FAFAFA',
+          color_surface: '#F0F0F0',
+          color_text_primary: '#000000',
+          color_text_secondary: '#666666',
+          color_success: '#00FF00',
+          color_error: '#FF0000',
+          font_primary: 'Arial',
+          font_secondary: 'Verdana',
+          footer_text: null,
+          footer_links: [{ label: 'Owned', url: 'javascript:alert(1)' }],
+          email_from_name: 'Imported',
+          email_from_address: 'import@test.com',
+        },
+      };
+
+      vi.mocked(settingsQueries.importSettings).mockRejectedValue(
+        new Error('Invalid URL protocol in footer link: javascript:alert(1)')
+      );
+
+      const response = await request(app)
+        .post('/api/settings/import')
+        .set('Authorization', 'Bearer valid-token')
+        .send(invalidData);
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toMatch(/invalid url protocol/i);
     });
 
     it('should return 401 without authentication', async () => {

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -7,6 +7,7 @@ import {
   resetSettings,
   exportSettings,
   importSettings,
+  validateFooterLinks,
 } from '../db/settings-queries.js';
 import { validateImage } from '../utils/image-validator.js';
 import type { ApiResponse } from '../types/api.js';
@@ -124,25 +125,11 @@ router.put('/', protectedLimiter, requireAuth, requirePermission('settings:updat
       }
     }
 
-    // Validate footer links to prevent stored XSS via javascript: or data: URIs
-    if (updates.footer_links && Array.isArray(updates.footer_links)) {
-      for (const link of updates.footer_links) {
-        if (link.url) {
-          try {
-            const parsedUrl = new URL(link.url, 'http://dummy.com');
-            if (
-              parsedUrl.protocol !== 'http:' &&
-              parsedUrl.protocol !== 'https:' &&
-              parsedUrl.protocol !== 'mailto:' &&
-              parsedUrl.protocol !== 'tel:'
-            ) {
-              return next(new ValidationError(`Invalid URL protocol in footer link: ${link.url}`));
-            }
-          } catch (e) {
-            return next(new ValidationError(`Invalid URL format in footer link: ${link.url}`));
-          }
-        }
-      }
+    // Validate footer links in the shared server validator
+    try {
+      validateFooterLinks(updates.footer_links);
+    } catch (error) {
+      return next(new ValidationError(error instanceof Error ? error.message : 'Invalid footer_links'));
     }
 
     // Validate scrape_mode if provided
@@ -255,6 +242,22 @@ router.post('/import', protectedLimiter, requireAuth, requirePermission('setting
       if (typeof value === 'string' && value.length > limit) {
         return next(new ValidationError(`${field} exceeds maximum length of ${limit} characters`));
       }
+    }
+
+    if (importData.settings.logo_base64) {
+      const logoValidation = await validateImage(importData.settings.logo_base64, 'logo', LOGO_MAX_SIZE);
+      if (!logoValidation.valid) {
+        return next(new ValidationError(`Invalid logo: ${logoValidation.error}`));
+      }
+      importData.settings.logo_base64 = logoValidation.compressedBase64!;
+    }
+
+    if (importData.settings.favicon_base64) {
+      const faviconValidation = await validateImage(importData.settings.favicon_base64, 'favicon', FAVICON_MAX_SIZE);
+      if (!faviconValidation.valid) {
+        return next(new ValidationError(`Invalid favicon: ${faviconValidation.error}`));
+      }
+      importData.settings.favicon_base64 = faviconValidation.compressedBase64!;
     }
 
     const importedSettings = await importSettings(db, importData, req.user!.id);


### PR DESCRIPTION
## Summary
- harden `/metrics` so anonymous access is no longer allowed outside the trusted Docker bridge scrape path
- protect `/api/saas/metrics` with superadmin authentication and align the README with the real contract
- fix SaaS org-settings import/export compatibility so legacy payloads normalize before validation while preserving the canonical modern settings contract internally
- align footer link and image validation between server settings and SaaS org-settings flows

Closes #990

## Why this matters
This PR closes the critical Sprint A security findings around overly broad metrics exposure, stale operational documentation, and fragile settings import/export behavior across tenant boundaries.

Without these fixes:
- `/metrics` could be read too broadly from private network space
- `/api/saas/metrics` looked open in documentation while being hardened in code
- legacy org-settings imports could fail before canonical normalization
- footer link validation and image validation were inconsistent across server and SaaS paths, increasing XSS/regression risk

## Functional behavior after this change
### Metrics / observability
- `/metrics` now allows either:
  - a direct trusted Docker-bridge scrape with no `X-Forwarded-For`, or
  - an authenticated user with `system:health`
- `/api/saas/metrics` now requires a superadmin token
- README now reflects that `/api/saas/metrics` is authenticated

### Settings import / export
- SaaS import now normalizes legacy fields before required-field validation
- legacy `footer_links[].text` payloads import correctly into canonical `label` form
- export keeps `text` alongside `label` for backward-compatible round-trips
- invalid footer links are rejected consistently in server and SaaS paths
- imported logos/favicons are validated with the same contract as normal settings updates

## Technical changes
- add `requireMetricsAccess()` and `isTrustedInternalMetricsScrape()` in `server/src/app.ts`
- add coverage for authenticated and trusted-scrape metrics access in `server/src/app.test.ts`
- protect `packages/saas` metrics route with `requireSuperadmin`
- add SaaS plugin tests for 401 / 403 / 200 metrics access
- centralize footer link validation in server settings queries and mirror equivalent validation in SaaS org-settings service/router
- reorder SaaS import flow to validate structure -> normalize legacy fields -> enforce canonical required fields -> validate images/business rules
- add/import targeted tests for legacy compatibility, footer link validation, and image validation parity

## Verification
### Build
- `docker run --rm -v /home/debian/agents/hermes/allo-scrapper:/work -w /work node:24 bash -lc 'npm run build --workspace=allo-scrapper-server && npm run build --workspace=@allo-scrapper/saas'`

### Targeted security/settings verification
- `docker run --rm -v /home/debian/agents/hermes/allo-scrapper:/work -w /work/server node:24 bash -lc 'npm run test:run -- src/app.test.ts src/routes/settings.test.ts src/db/settings-queries.test.ts'`
- `docker run --rm -u $(id -u):$(id -g) -v /home/debian/agents/hermes/allo-scrapper:/work -w /work/packages/saas node:24 bash -lc 'npm run test:run -- src/plugin.test.ts src/routes/org-settings.test.ts src/routes/org-settings-import.test.ts src/services/org-settings-service.test.ts src/routes/org.test.ts'`

### Full workspace suites executed during GP
- `docker run --rm -u $(id -u):$(id -g) -v /home/debian/agents/hermes/allo-scrapper:/work -w /work/packages/saas node:24 bash -lc 'npm run test:run'` ✅
- `docker run --rm -v /home/debian/agents/hermes/allo-scrapper:/work -w /work/server node:24 bash -lc 'npm run test:run'` ⚠️ blocked only by Testcontainers-based integration suites in this nested environment (`Could not find a working container runtime strategy`); the touched server unit/integration-lite suites passed

## Reviewer guide
Please focus review on:
1. the narrowed trust boundary for `/metrics`
2. the superadmin protection and documentation alignment for `/api/saas/metrics`
3. the SaaS import order: normalization before required-field validation
4. the legacy/canonical `footer_links` round-trip behavior
5. the parity of footer-link and image validation between server and SaaS flows

## Residual risk
`/metrics` still uses a network-trust exception for the current Docker bridge topology rather than explicit Prometheus identity. That is intentionally narrower than the previous behavior and works with the repo’s current compose/prometheus setup, but if deployment topology changes the route should move to explicit authenticated scraping.
