### PR TITLE
fix: Sprint B — robustesse settings et cohérence validation (#991)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,48 @@ Operational guide for contributors and agents in this monorepo. Prefer BMAD work
 - Auth and superadmin scope truth: `server/src/services/auth-service.ts`
 - DB init + one-time cinema bootstrap seed: `server/src/db/schema.ts`
 
+## Gotcha: `app_settings` Row Requirement
+
+### Problem
+
+The homepage becomes inaccessible when the `app_settings` table exists but the required singleton row (`id = 1`) is missing. Symptoms:
+
+- `GET /api/settings/public` returns `404`
+- Frontend `SettingsProvider` sets `publicSettings = null`
+- UI components crash or render without theme data
+
+### Root Cause
+
+Migration `004_add_app_settings.sql` creates the table and inserts the default row with `ON CONFLICT (id) DO NOTHING`. The INSERT can fail silently in edge cases (transaction rollbacks, race conditions during multi-migration runs), leaving an empty table.
+
+### Diagnostics
+
+```sql
+-- Check if the row exists
+SELECT * FROM app_settings WHERE id = 1;
+```
+
+If the query returns 0 rows, the row is missing.
+
+### Immediate Fix
+
+```sql
+INSERT INTO app_settings (id) VALUES (1) ON CONFLICT (id) DO NOTHING;
+```
+
+All columns will fall back to their `DEFAULT` values (matching the migration schema). No need to specify all 20+ columns manually.
+
+### Prevention (Implemented)
+
+1. **Startup guard** (`server/src/db/schema.ts`): `seedSettingsIfEmpty()` runs on every server startup, checking for and repairing the missing row.
+2. **Frontend fallback** (`client/src/contexts/SettingsProvider.tsx`): `DEFAULT_PUBLIC_SETTINGS` provides sane defaults when the backend returns nothing.
+3. **AGENTS.md** (this section): Documents the gotcha for future contributors.
+
+### Verification
+
+1. **Backend guard**: `docker compose exec -T ics-db psql -U postgres -d ics -c "DELETE FROM app_settings WHERE id = 1"` then restart — server logs should show `Seeded missing app_settings row`.
+2. **Frontend fallback**: Stop the backend, load the frontend — site name should show "Allo-Scrapper" with default theme instead of crashing.
+
 ## Automated Versioning / Releases
 
 - PRs merged to `main` feed the version/release workflow in `.github/workflows/version-tag.yml`.

--- a/client/src/contexts/SettingsProvider.tsx
+++ b/client/src/contexts/SettingsProvider.tsx
@@ -2,6 +2,30 @@ import React, { useState, useEffect, useCallback, type ReactNode } from 'react';
 import { SettingsContext } from './SettingsContext';
 import { getPublicSettings, getAdminSettings, updateSettings as apiUpdateSettings, toPublicSettings, type AppSettings, type AppSettingsPublic, type AppSettingsUpdate } from '../api/settings';
 
+/**
+ * Default public settings used as fallback when the backend fails to return
+ * the app_settings row (e.g. missing row after silent migration failure).
+ * Values match the DEFAULTs defined in migration 004_add_app_settings.sql.
+ */
+export const DEFAULT_PUBLIC_SETTINGS: AppSettingsPublic = {
+  site_name: 'Allo-Scrapper',
+  logo_base64: null,
+  favicon_base64: null,
+  color_primary: '#FECC00',
+  color_secondary: '#1F2937',
+  color_accent: '#F59E0B',
+  color_background: '#FFFFFF',
+  color_surface: '#F3F4F6',
+  color_text_primary: '#111827',
+  color_text_secondary: '#6B7280',
+  color_success: '#10B981',
+  color_error: '#EF4444',
+  font_primary: 'Inter',
+  font_secondary: 'Roboto',
+  footer_text: null,
+  footer_links: [],
+};
+
 interface SettingsProviderProps {
     children: ReactNode;
 }
@@ -69,7 +93,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children }) 
     return (
         <SettingsContext.Provider
             value={{
-                publicSettings,
+                publicSettings: publicSettings ?? DEFAULT_PUBLIC_SETTINGS,
                 adminSettings,
                 isLoading,
                 isLoadingPublic,

--- a/packages/saas/src/routes/org.ts
+++ b/packages/saas/src/routes/org.ts
@@ -34,10 +34,9 @@ import { optionalAuth, requireAuth } from 'allo-scrapper-server/dist/middleware/
 import { requirePermission } from 'allo-scrapper-server/dist/middleware/permission.js';
 import { protectedLimiter } from 'allo-scrapper-server/dist/middleware/rate-limit.js';
 import { ValidationError, NotFoundError, AuthError } from 'allo-scrapper-server/dist/utils/errors.js';
-import { validatePasswordStrength } from 'allo-scrapper-server/dist/utils/security.js';
+import { validatePasswordStrength, validateUsername } from 'allo-scrapper-server/dist/utils/security.js';
 
 // ── Inline org-specific helpers ─────────────────────────────────────────────
-const USERNAME_REGEX = /^[a-zA-Z0-9]{3,15}$/;
 
 /**
  * Validates that the JWT org_slug claim (if present) matches the :slug route param.
@@ -180,9 +179,8 @@ export function createOrgRouter(): Router {
         if (!username || !password) {
           return next(new ValidationError('username and password are required'));
         }
-        if (!USERNAME_REGEX.test(username)) {
-          return next(new ValidationError('Username must be alphanumeric and 3-15 characters long'));
-        }
+        const usernameError = validateUsername(username);
+        if (usernameError) return next(new ValidationError(usernameError));
         const passwordError = validatePasswordStrength(password);
         if (passwordError) return next(new ValidationError(passwordError));
 

--- a/scraper/src/scraper/film-parser.test.ts
+++ b/scraper/src/scraper/film-parser.test.ts
@@ -65,4 +65,44 @@ describe('parseFilmPage', () => {
       'https://www.allocine.fr/video/player_gen_cmedia=19600934&cfilm=296168.html'
     );
   });
+
+  it('parses minutes-only duration for short films (< 1h)', () => {
+    const html = `
+      <div class="meta-body-info">45min</div>
+    `;
+
+    const result = parseFilmPage(html);
+
+    expect(result.duration_minutes).toBe(45);
+  });
+
+  it('parses duration with only hours (no minutes)', () => {
+    const html = `
+      <div class="meta-body-info">2h</div>
+    `;
+
+    const result = parseFilmPage(html);
+
+    expect(result.duration_minutes).toBe(120);
+  });
+
+  it('parses duration with hours and minutes without "min" suffix', () => {
+    const html = `
+      <div class="meta-body-info">2h 30</div>
+    `;
+
+    const result = parseFilmPage(html);
+
+    expect(result.duration_minutes).toBe(150);
+  });
+
+  it('parses zero duration gracefully', () => {
+    const html = `
+      <div class="meta-body-info">0min</div>
+    `;
+
+    const result = parseFilmPage(html);
+
+    expect(result.duration_minutes).toBe(0);
+  });
 });

--- a/scraper/src/scraper/film-parser.ts
+++ b/scraper/src/scraper/film-parser.ts
@@ -126,17 +126,13 @@ export function parseFilmPage(html: string): FilmPageData {
   let durationMinutes: number | undefined;
 
   const metaText = metaInfo.text();
-  const durationMatch = metaText.match(/(\d+)h\s*(\d+)min/);
+  // Match "Xh Ymin", "Xh Y" (min suffix optional), "Xh", or "Ymin"
+  const durationMatch = metaText.match(/(?:(\d+)h)?\s*(?:(\d+)(?:min)?)?/);
 
-  if (durationMatch) {
-    const hours = parseInt(durationMatch[1], 10);
-    const minutes = parseInt(durationMatch[2], 10);
+  if (durationMatch && (durationMatch[1] || durationMatch[2])) {
+    const hours = durationMatch[1] ? parseInt(durationMatch[1], 10) : 0;
+    const minutes = durationMatch[2] ? parseInt(durationMatch[2], 10) : 0;
     durationMinutes = hours * 60 + minutes;
-  } else {
-    const hoursOnlyMatch = metaText.match(/(\d+)h/);
-    if (hoursOnlyMatch) {
-      durationMinutes = parseInt(hoursOnlyMatch[1], 10) * 60;
-    }
   }
 
   let trailerUrl: string | undefined;

--- a/server/src/db/schema.test.ts
+++ b/server/src/db/schema.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockQuery } = vi.hoisted(() => ({
+  mockQuery: vi.fn(),
+}));
+
+vi.mock('./client.js', () => ({
+  db: {
+    query: mockQuery,
+  },
+  pool: {},
+}));
+
+vi.mock('./migrations.js', () => ({
+  runMigrations: vi.fn(),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { seedSettingsIfEmpty } from './schema.js';
+
+describe('seedSettingsIfEmpty', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Default: row exists (happy path)
+    mockQuery.mockResolvedValue({ rows: [{ id: 1 }] });
+  });
+
+  it('skips insert when app_settings row already exists', async () => {
+    await seedSettingsIfEmpty();
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(mockQuery).toHaveBeenCalledWith(
+      'SELECT id FROM app_settings WHERE id = 1'
+    );
+  });
+
+  it('inserts default row when app_settings is missing', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] });
+
+    await seedSettingsIfEmpty();
+
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    expect(mockQuery).toHaveBeenNthCalledWith(1, 'SELECT id FROM app_settings WHERE id = 1');
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('INSERT INTO app_settings (id)')
+    );
+  });
+
+  it('is idempotent — safe to call multiple times', async () => {
+    await seedSettingsIfEmpty();
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+
+    vi.resetAllMocks();
+    mockQuery.mockResolvedValue({ rows: [{ id: 1 }] });
+
+    await seedSettingsIfEmpty();
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles database errors gracefully (non-fatal)', async () => {
+    mockQuery.mockRejectedValue(new Error('connection refused'));
+
+    await expect(seedSettingsIfEmpty()).resolves.toBeUndefined();
+  });
+});

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -43,6 +43,40 @@ export async function initializeDatabase(extraMigrationDirs: string[] = []) {
 
   // Seed cinemas from cinemas.json if DB is empty
   await seedCinemasIfEmpty();
+
+  // Seed app_settings row if missing (defense-in-depth against silent migration failures)
+  await seedSettingsIfEmpty();
+}
+
+/**
+ * Ensures the required app_settings singleton row (id=1) exists.
+ * Idempotent — safe to call on every startup.
+ *
+ * Background: Migration 004 creates the table and inserts the default row with
+ * ON CONFLICT DO NOTHING, but the INSERT can fail silently in edge cases
+ * (transaction rollbacks, race conditions during multi-migration runs).
+ * This startup guard detects and repairs the missing row.
+ */
+export async function seedSettingsIfEmpty(): Promise<void> {
+  try {
+    const result = await db.query('SELECT id FROM app_settings WHERE id = 1');
+    if (result.rows.length > 0) {
+      logger.info('ℹ️  app_settings row exists. Skipping seed.');
+      return;
+    }
+
+    await db.query(`
+      INSERT INTO app_settings (id)
+      VALUES (1)
+      ON CONFLICT (id) DO NOTHING
+    `);
+
+    logger.info('🌱 Seeded missing app_settings row (id=1)');
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    logger.error('⚠️  Warning: Could not seed app_settings:', errorMessage);
+    // Non-fatal: server can still start (frontend has fallback defaults)
+  }
 }
 
 async function seedCinemasIfEmpty(): Promise<void> {

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -70,7 +70,7 @@ router.post('/register', registerLimiter, requireAuth, requirePermission('users:
 
         res.status(201).json(response);
     } catch (error: any) {
-        if (error.message === 'Username and password are required' || error.message.includes('Password must')) {
+        if (error.message === 'Username and password are required' || error.message.includes('Password must') || error.message.includes('Username must')) {
             return next(new ValidationError(error.message));
         }
         if (error.message === 'Username already exists') {

--- a/server/src/services/auth-service.test.ts
+++ b/server/src/services/auth-service.test.ts
@@ -13,6 +13,8 @@ vi.mock('bcryptjs');
 vi.mock('jsonwebtoken');
 vi.mock('../utils/security.js', () => ({
   validatePasswordStrength: vi.fn(() => null),
+  validateUsername: vi.fn(() => null),
+  USERNAME_REGEX: /^[a-zA-Z0-9]{3,15}$/,
 }));
 
 describe('AuthService', () => {
@@ -301,6 +303,20 @@ describe('AuthService', () => {
       vi.mocked(userQueries.getTenantUserByUsername).mockResolvedValue({ id: 9, org_slug: 'acme' } as any);
 
       await expect(authService.register('shareduser', 'password')).rejects.toThrow('Username already exists');
+    });
+
+    it('should throw error if username format is invalid', async () => {
+      const { validateUsername } = await import('../utils/security.js');
+      vi.mocked(validateUsername).mockReturnValue('Username must be alphanumeric and 3-15 characters long');
+      
+      await expect(authService.register('ab', 'ValidPass123!')).rejects.toThrow('Username must be alphanumeric and 3-15 characters long');
+    });
+
+    it('should throw error if username contains special characters', async () => {
+      const { validateUsername } = await import('../utils/security.js');
+      vi.mocked(validateUsername).mockReturnValue('Username must be alphanumeric and 3-15 characters long');
+      
+      await expect(authService.register('user@name', 'ValidPass123!')).rejects.toThrow('Username must be alphanumeric and 3-15 characters long');
     });
 
     it('should return created user on success', async () => {

--- a/server/src/services/auth-service.ts
+++ b/server/src/services/auth-service.ts
@@ -3,7 +3,7 @@ import jwt from 'jsonwebtoken';
 import { getUserByUsername, getTenantUserByUsername, hasTenantUserWithUsername, createUser, updateUserPassword } from '../db/user-queries.js';
 import { getPermissionNamesByRoleId } from '../db/role-queries.js';
 import type { DB } from '../db/client.js';
-import { validatePasswordStrength } from '../utils/security.js';
+import { validatePasswordStrength, validateUsername } from '../utils/security.js';
 import { logger } from '../utils/logger.js';
 import { parseJwtExpiration } from '../utils/jwt-config.js';
 import type { PermissionName } from '../types/role.js';
@@ -82,6 +82,11 @@ export class AuthService {
   async register(username?: string, password?: string) {
     if (!username || !password) {
       throw new Error('Username and password are required');
+    }
+
+    const usernameError = validateUsername(username);
+    if (usernameError) {
+      throw new Error(usernameError);
     }
 
     const passwordError = validatePasswordStrength(password);

--- a/server/src/utils/security.test.ts
+++ b/server/src/utils/security.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { validateUsername, USERNAME_REGEX, validatePasswordStrength } from './security.js';
+
+describe('validateUsername', () => {
+  it('accepts valid alphanumeric usernames (3-15 chars)', () => {
+    expect(validateUsername('abc')).toBeNull();
+    expect(validateUsername('testuser')).toBeNull();
+    expect(validateUsername('Test123')).toBeNull();
+    expect(validateUsername('ABC')).toBeNull();
+    expect(validateUsername('12345')).toBeNull();
+    expect(validateUsername('a'.repeat(15))).toBeNull();
+  });
+
+  it('rejects usernames shorter than 3 characters', () => {
+    const error = validateUsername('ab');
+    expect(error).toBe('Username must be alphanumeric and 3-15 characters long');
+  });
+
+  it('rejects usernames longer than 15 characters', () => {
+    const error = validateUsername('a'.repeat(16));
+    expect(error).toBe('Username must be alphanumeric and 3-15 characters long');
+  });
+
+  it('rejects usernames with special characters', () => {
+    expect(validateUsername('user@name')).not.toBeNull();
+    expect(validateUsername('user name')).not.toBeNull();
+    expect(validateUsername('user-name')).not.toBeNull();
+    expect(validateUsername('user_name')).not.toBeNull();
+    expect(validateUsername('user.name')).not.toBeNull();
+  });
+
+  it('rejects empty username', () => {
+    const error = validateUsername('');
+    expect(error).toBe('Username is required');
+  });
+});
+
+describe('USERNAME_REGEX', () => {
+  it('matches valid usernames', () => {
+    expect(USERNAME_REGEX.test('abc')).toBe(true);
+    expect(USERNAME_REGEX.test('TestUser')).toBe(true);
+    expect(USERNAME_REGEX.test('user123')).toBe(true);
+    expect(USERNAME_REGEX.test('ABC123')).toBe(true);
+  });
+
+  it('rejects invalid usernames', () => {
+    expect(USERNAME_REGEX.test('ab')).toBe(false);
+    expect(USERNAME_REGEX.test('user@name')).toBe(false);
+    expect(USERNAME_REGEX.test('user name')).toBe(false);
+    expect(USERNAME_REGEX.test('user-name')).toBe(false);
+    expect(USERNAME_REGEX.test('verylongusername12345')).toBe(false);
+  });
+});
+
+describe('validatePasswordStrength', () => {
+  it('accepts strong passwords', () => {
+    expect(validatePasswordStrength('ValidP@ss1')).toBeNull();
+  });
+
+  it('rejects short passwords', () => {
+    expect(validatePasswordStrength('Ab1!')).toContain('at least');
+  });
+
+  it('rejects passwords without uppercase', () => {
+    expect(validatePasswordStrength('nouppercase1!')).toBe(
+      'Password must contain at least one uppercase letter'
+    );
+  });
+});

--- a/server/src/utils/security.ts
+++ b/server/src/utils/security.ts
@@ -1,5 +1,18 @@
 export const PASSWORD_MIN_LENGTH = 8;
 
+/** Username format: alphanumeric, 3-15 characters. Shared across core server and SaaS. */
+export const USERNAME_REGEX = /^[a-zA-Z0-9]{3,15}$/;
+
+export function validateUsername(username: string): string | null {
+  if (!username || typeof username !== 'string') {
+    return 'Username is required';
+  }
+  if (!USERNAME_REGEX.test(username)) {
+    return 'Username must be alphanumeric and 3-15 characters long';
+  }
+  return null;
+}
+
 export function validatePasswordStrength(password: string): string | null {
   if (password.length < PASSWORD_MIN_LENGTH) {
     return `Password must be at least ${PASSWORD_MIN_LENGTH} characters`;


### PR DESCRIPTION
## Sprint B — Robustesse settings & cohérence validation

Closes #991

### Sous-issues résolues

| Issue | Description | Commit |
|-------|-------------|--------|
| #803 | Durées films < 1h non parsées (`45min`) | `f28d0be` |
| #804 | Validation username incohérente server/SaaS | `9bbc898` |
| #682 | `seedSettingsIfEmpty()` garde-fou startup | `6643dd5` |
| #683 | Fallback frontend `DEFAULT_PUBLIC_SETTINGS` | `d644051` |
| #684 | Documentation gotcha `app_settings` | `5edccae` |

### Modifications

- **10 fichiers**, +329 / −17 lignes
- **3 nouveaux fichiers** : `security.test.ts`, `schema.test.ts`, `security.test.ts`
- **3 packages** : `scraper`, `server`, `client` + `packages/saas`

### Tests exécutés

```bash
# Scraper (7 tests)
docker run --rm -v "$PWD:/app" -w /app node:20-alpine sh -lc \
  'npm ci --legacy-peer-deps --workspace=allo-scrapper-scraper --include-workspace-root && 
   npx vitest run src/scraper/film-parser.test.ts'
# ✅ 7 passed

# Server (36 tests)
docker run --rm -v "$PWD:/app" -w /app node:20-alpine sh -lc \
  'npm ci --legacy-peer-deps --workspace=allo-scrapper-server --include-workspace-root && 
   npx vitest run src/services/auth-service.test.ts src/utils/security.test.ts src/db/schema.test.ts'
# ✅ 36 passed
```

### CR BMAD

- **Blind Hunter** + **Edge Case Hunter** exécutés en parallèle
- 2 PATCH appliqués (regex `2h 30` sans suffixe + duplication validation org.ts)
- 7 DEFER (patterns pré-existants ou hors scope)
