### PR TITLE
fix(security): add explicit Express body size limits (#632)

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -175,8 +175,8 @@ export function createApp() {
   app.use(cors(getCorsOptions()));
   app.use(morgan('combined'));
   app.use(validateInputSize());
-  app.use(express.json());
-  app.use(express.urlencoded({ extended: true }));
+  app.use(express.json({ limit: '100kb' }));
+  app.use(express.urlencoded({ limit: '100kb', extended: true }));
 
   // Health check endpoint with database connectivity check
   // Cached for 5 seconds to prevent database connection pool exhaustion


### PR DESCRIPTION
## Problème

Express body parsers (`express.json()`, `express.urlencoded()`) étaient utilisés sans paramètre `limit` explicite, pouvant permettre l'épuisement de ressources via des payloads volumineux avant que la validation applicative (`validateInputSize`) n'intervienne.

Closes #632

## Solution

Ajout de `limit: '100kb'` aux deux middlewares Express natifs, en cohérence avec le `maxTotalSize: 100KB` déjà imposé par `validateInputSize()`.

## Vérification

```bash
cd server && npm run test:run
```