### PR TITLE
fix(security): add missing security headers (#636)

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -174,6 +174,14 @@ export function createApp() {
   );
   app.use(cors(getCorsOptions()));
   app.use(morgan('combined'));
+
+  // Additional security headers beyond Helmet defaults
+  app.use((_req, res, next) => {
+    res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+    res.setHeader('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+    res.setHeader('X-DNS-Prefetch-Control', 'off');
+    next();
+  });
   app.use(validateInputSize());
   app.use(express.json());
   app.use(express.urlencoded({ extended: true }));


### PR DESCRIPTION
## Problème

Plusieurs headers de sécurité recommandés étaient absents malgré l'utilisation de Helmet :

Closes #636

## Headers ajoutés

| Header | Valeur | Rôle |
|---|---|---|
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Contrôle les fuites d'URL dans le header Referer |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | Désactive les APIs navigateur non utilisées |
| `X-DNS-Prefetch-Control` | `off` | Empêche le DNS prefetching |

Ces headers s'ajoutent à la CSP déjà configurée via Helmet.

## Vérification

```bash
cd server && npm run test:run
```