### PR TITLE
fix(security): Sprint D — hardening structurel API/auth (#993)

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -174,9 +174,18 @@ export function createApp() {
   );
   app.use(cors(getCorsOptions()));
   app.use(morgan('combined'));
+
+  // Additional security headers beyond Helmet defaults
+  app.use((_req, res, next) => {
+    res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+    res.setHeader('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+    res.setHeader('X-DNS-Prefetch-Control', 'off');
+    next();
+  });
+
   app.use(validateInputSize());
-  app.use(express.json());
-  app.use(express.urlencoded({ extended: true }));
+  app.use(express.json({ limit: '100kb' }));
+  app.use(express.urlencoded({ limit: '100kb', extended: true }));
 
   // Health check endpoint with database connectivity check
   // Cached for 5 seconds to prevent database connection pool exhaustion

--- a/server/src/utils/security.ts
+++ b/server/src/utils/security.ts
@@ -1,4 +1,5 @@
 export const PASSWORD_MIN_LENGTH = 8;
+export const PASSWORD_MAX_LENGTH = 72; // bcrypt silently truncates beyond 72 bytes
 
 /** Username format: alphanumeric, 3-15 characters. Shared across core server and SaaS. */
 export const USERNAME_REGEX = /^[a-zA-Z0-9]{3,15}$/;
@@ -16,6 +17,9 @@ export function validateUsername(username: string): string | null {
 export function validatePasswordStrength(password: string): string | null {
   if (password.length < PASSWORD_MIN_LENGTH) {
     return `Password must be at least ${PASSWORD_MIN_LENGTH} characters`;
+  }
+  if (password.length > PASSWORD_MAX_LENGTH) {
+    return `Password must be at most ${PASSWORD_MAX_LENGTH} characters`;
   }
   if (!/[A-Z]/.test(password)) {
     return 'Password must contain at least one uppercase letter';


### PR DESCRIPTION
## Sprint D — Hardening structurel API/auth

3 correctifs backend regroupés :

### #632 — Body size limits
Ajout de `limit: '100kb'` à `express.json()` et `express.urlencoded()` — défense en profondeur, cohérent avec `validateInputSize()` (100KB).

### #636 — Security headers
Ajout de 3 headers non couverts par Helmet :
| Header | Valeur |
|---|---|
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` |
| `X-DNS-Prefetch-Control` | `off` |

### #635 — Password max length
Ajout de `PASSWORD_MAX_LENGTH = 72` (limite bcrypt) dans `validatePasswordStrength()`. La validation de complexité (majuscule, minuscule, chiffre, spécial) était déjà en place et déjà appelée depuis `register()` et `changePassword()`.

## Fichiers modifiés
- `server/src/app.ts` (+11/−2)
- `server/src/utils/security.ts` (+4)

## Vérification
```bash
cd server && npm run test:run
```