### PR TITLE
fix(security): migrate JWT from localStorage to httpOnly cookies (#633)

### DIFF
--- a/.hermes/plans/2026-05-03-630-cr-gp.md
+++ b/.hermes/plans/2026-05-03-630-cr-gp.md
@@ -1,0 +1,52 @@
+# GP — issue #630 après CR local
+
+Date: 2026-05-03
+Branche: `fix/630-sse-progress-connection-limit`
+Périmètre: `server/src/services/scraper-service.ts`, `server/src/services/scraper-service.test.ts`, `server/src/routes/scraper.test.ts`
+
+## Contexte
+Le patch DS ajoute une limite locale de 3 connexions SSE concurrentes par utilisateur sur `GET /api/scraper/progress`.
+Les tests ciblés passent en Docker.
+
+## Verdict CR
+CR **non validée en l’état**. Deux findings matériels ont été confirmés.
+
+### Finding 1 — collision cross-tenant sur la clé utilisateur
+- Gravité: moyenne
+- Observation: la clé de quota utilise uniquement `user.id`
+- Preuve:
+  - `server/src/services/scraper-service.ts` → `getProgressConnectionUserKey()` retourne `String(context.user.id)`
+  - `packages/saas/src/routes/org.ts` monte le même `scraperRouter` sous `/org/:slug/...`
+  - `server/src/db/user-queries.ts` lit des utilisateurs depuis des schémas tenant distincts, donc des `id` locaux peuvent se recroiser entre orgs
+- Risque: un utilisateur `id=7` de l’org A peut consommer le quota du `id=7` de l’org B sur le même process serveur
+
+### Finding 2 — fuite potentielle du compteur si l’abonnement meurt pendant le replay initial
+- Gravité: moyenne
+- Observation: la réservation se fait avant `progressTracker.addListener()`, mais `progressTracker.sendToListener()` avale les erreurs d’écriture et retire seulement le listener interne
+- Preuve:
+  - `server/src/services/scraper-service.ts` réserve avant `addListener`
+  - `server/src/services/progress-tracker.ts` fait du replay synchrone dans `addListener()`
+  - `sendToListener()` appelle `this.removeListener(res)` sur erreur sans rappeler le cleanup de `ScraperService`
+- Risque: sur déconnexion / write failure précoce pendant le replay, le listener tracker disparaît mais le compteur par user peut rester incrémenté à tort
+
+## Plan correctif minimal
+1. Changer la clé de quota pour inclure le scope tenant
+   - forme proposée: `${org_slug ?? 'system'}:${user.id}``
+   - fallback possible sur `org_id` si `org_slug` absent mais `org_id` présent
+2. Éviter la fuite de compteur au handshake/replay initial
+   - idéalement faire porter le compteur à `ProgressTracker` via un callback de suppression/close
+   - solution minimale acceptable: faire retourner à `addListener()` une information/callback de retrait, ou brancher une stratégie où toute suppression côté tracker déclenche la libération côté service
+3. Ajouter/adapter les tests ciblés
+   - prouver que deux orgs avec le même `user.id` n’entrent plus en collision
+   - prouver qu’un échec d’écriture/replay initial libère bien le slot
+4. Rejouer la vérification ciblée Docker
+
+## Commande de vérification à rejouer
+```bash
+docker compose -f docker-compose.dev.yml run --rm server sh -lc "npm install --legacy-peer-deps >/tmp/npm-install.log 2>&1 && cd server && npm run test:run -- src/services/scraper-service.test.ts src/routes/scraper.test.ts"
+```
+
+## État BMAD
+- CR terminée (read-only)
+- GP rédigé
+- En attente d’un ordre explicite du Maitre pour appliquer les correctifs

--- a/.hermes/plans/2026-05-03-agents-md-cr-fixes.md
+++ b/.hermes/plans/2026-05-03-agents-md-cr-fixes.md
@@ -1,0 +1,213 @@
+# AGENTS.md CR Findings Remediation Plan
+
+> **For Hermes:** Execute via `majordome-subagent-dev-loop`. This document is a **post-CR GP** only. Do not edit files during review. Apply changes only after an explicit DS/implementation order. After the next `CR`, the mandatory next BMAD step is `GP`, then **WAIT**.
+
+**Goal:** Adjust `AGENTS.md` so the local CR passes by restoring the critical runtime truths and plan-required structure that were lost in the first rewrite, while keeping the file dense and operator-first.
+
+**Architecture:** Keep `AGENTS.md` as a compact operational index, but restore the minimum set of repo truths that the CR identified as too expensive to rediscover. Fix only the documented findings in `AGENTS.md`; do not widen scope into README or adjacent docs during this pass.
+
+**Tech Stack:** Markdown, npm workspaces, Docker Compose, Playwright, Express/TypeScript server, BMAD workflow docs.
+
+---
+
+## Canonical Direction
+
+The corrected `AGENTS.md` must remain **operator-first and compact**, but it must also restore the truths explicitly required by the original optimization plan and flagged by CR:
+
+1. restore **service ownership** in `Repo Topology`
+2. restore a distinct **Fast Start / What To Run** section
+3. restore **dynamic SaaS loading** in runtime truths
+4. restore the **scraper RUN_MODE** / production topology guardrail
+5. restore the **Testcontainers / CI integration-test** guardrail
+6. restore the **CI branch-prefix** guardrail
+7. narrow the **post-GP** wording back to the precise repo contract
+8. make the auth/superadmin bullet exact enough to avoid overclaiming
+
+This is a repair pass, not a second redesign.
+
+---
+
+## Biggest Remaining Risk
+
+**Risk:** over-correcting the CR findings could bloat `AGENTS.md` back into a long fact dump and undo the useful scanability gained in the rewrite.
+
+So the implementation must restore only the findings-backed truths, in the shortest wording that remains precise.
+
+---
+
+## Scope
+
+### Modify
+- `/home/debian/agents/hermes/allo-scrapper/AGENTS.md`
+
+### Read/verify while editing
+- `/home/debian/agents/hermes/allo-scrapper/package.json`
+- `/home/debian/agents/hermes/allo-scrapper/docker-compose.dev.yml`
+- `/home/debian/agents/hermes/allo-scrapper/docker-compose.yml`
+- `/home/debian/agents/hermes/allo-scrapper/playwright.config.ts`
+- `/home/debian/agents/hermes/allo-scrapper/client/vite.config.ts`
+- `/home/debian/agents/hermes/allo-scrapper/scripts/install-hooks.sh`
+- `/home/debian/agents/hermes/allo-scrapper/scripts/hooks/pre-push`
+- `/home/debian/agents/hermes/allo-scrapper/server/src/index.ts`
+- `/home/debian/agents/hermes/allo-scrapper/server/src/services/auth-service.ts`
+- `/home/debian/agents/hermes/allo-scrapper/server/src/db/schema.ts`
+- `/home/debian/agents/hermes/allo-scrapper/.github/workflows/ci.yml`
+- `/home/debian/agents/hermes/allo-scrapper/.github/workflows/version-tag.yml`
+- `/home/debian/agents/hermes/allo-scrapper/scraper/src/index.ts`
+
+### Explicitly out of scope for this pass
+- `README.md`
+- `docs/guides/development/*`
+- `docs/project/*`
+- workflow YAML changes
+
+Those docs may remain inconsistent after this pass; the immediate target is only to make the `AGENTS.md` CR pass.
+
+---
+
+## Acceptance Target
+
+The next CR should be able to verify all of the following from `AGENTS.md` alone:
+
+- `Repo Topology` tells what `server` and `scraper` actually own/do
+- `Fast Start / What To Run` exists as a distinct section
+- `Verification Shortcuts` distinguishes quick checks vs CI-like checks clearly enough
+- `Runtime Truths That Drift Easily` includes the dynamic SaaS loading truth
+- `Runtime Truths` keeps `/api/auth/login` and the exact-enough `superadmin` scope rule
+- `Testing / E2E Traps` or verification text preserves the Testcontainers/CI integration-test guardrail
+- `Workflow Gates` explicitly preserves the CI branch-prefix guardrail
+- post-`GP` wording is narrowed back to the repo-specific lock (`CS`, `DS`, `push-flow`, merge-related actions), not a broad ban on all execution
+- the file remains compact and obviously more scanable than the old version
+
+---
+
+## Bite-Sized Execution Tasks
+
+### Task 1: Restore service ownership in Repo Topology
+
+**Objective:** Reintroduce the minimum high-value runtime ownership facts for `server` and `scraper`.
+
+**Files:**
+- Modify: `/home/debian/agents/hermes/allo-scrapper/AGENTS.md`
+- Read: `/home/debian/agents/hermes/allo-scrapper/server/src/index.ts`
+- Read: `/home/debian/agents/hermes/allo-scrapper/scraper/src/index.ts`
+- Read: `/home/debian/agents/hermes/allo-scrapper/docker-compose.yml`
+
+**Step 1:** Add back a concise `server` bullet saying it initializes DB, subscribes to Redis progress, and conditionally loads SaaS.
+
+**Step 2:** Add back a concise `scraper` bullet saying it is a separate service with `RUN_MODE` support (`oneshot`, `consumer`, `cron`, `direct`).
+
+**Step 3:** If space allows, keep the production `consumer`/`cron` split in the same bullet; otherwise mention it in the shortest possible clause.
+
+**Verification checkpoint:** `Repo Topology` again answers “what owns what?” instead of only “what command runs what?”.
+
+---
+
+### Task 2: Recreate a distinct Fast Start / What To Run section
+
+**Objective:** Match the plan structure and isolate startup decisions from topology facts.
+
+**Files:**
+- Modify: `/home/debian/agents/hermes/allo-scrapper/AGENTS.md`
+- Read: `/home/debian/agents/hermes/allo-scrapper/package.json`
+- Read: `/home/debian/agents/hermes/allo-scrapper/docker-compose.dev.yml`
+
+**Step 1:** Move startup commands out of `Repo Topology` into a separate section named exactly `Fast Start / What To Run`.
+
+**Step 2:** Keep only:
+- root `npm run dev`
+- what dev compose starts
+- what it does not start
+- how to run scraper separately
+- root `npm run build` vs full workspace build if still helpful here
+
+**Step 3:** Keep wording short; no new theory.
+
+**Verification checkpoint:** the section exists as a standalone decision aid and satisfies the original plan structure.
+
+---
+
+### Task 3: Tighten Verification Shortcuts into quick vs CI-like checks
+
+**Objective:** Make validation choices more explicit without adding verbosity.
+
+**Files:**
+- Modify: `/home/debian/agents/hermes/allo-scrapper/AGENTS.md`
+- Read: `/home/debian/agents/hermes/allo-scrapper/scripts/hooks/pre-push`
+- Read: `/home/debian/agents/hermes/allo-scrapper/.github/workflows/ci.yml`
+
+**Step 1:** Split or label the bullets so a reader can distinguish:
+- fast local checks
+- CI-like checks
+
+**Step 2:** Reintroduce the Testcontainers note in the smallest honest wording, e.g. server integration tests rely on Testcontainers; CI does not provision Redis separately.
+
+**Step 3:** Keep the real pre-push gate visible.
+
+**Verification checkpoint:** a reviewer can see both the quick path and the CI-like path, plus the Testcontainers guardrail.
+
+---
+
+### Task 4: Repair runtime truths without overclaiming
+
+**Objective:** Restore missing runtime truths and remove over-broad formulations.
+
+**Files:**
+- Modify: `/home/debian/agents/hermes/allo-scrapper/AGENTS.md`
+- Read: `/home/debian/agents/hermes/allo-scrapper/server/src/index.ts`
+- Read: `/home/debian/agents/hermes/allo-scrapper/server/src/services/auth-service.ts`
+- Read: `/home/debian/agents/hermes/allo-scrapper/server/src/db/schema.ts`
+
+**Step 1:** Add back the dynamic SaaS loading truth explicitly.
+
+**Step 2:** Refine the superadmin bullet so it does not overstate the condition. It must reflect that the JWT scope is granted for system-role admins with no `org_slug`, specifically on the admin role path.
+
+**Step 3:** Keep the cinema seed bullet precise enough to avoid “table empty” oversimplification if concise wording can preserve truth better.
+
+**Verification checkpoint:** no runtime bullet is materially broader than the code.
+
+---
+
+### Task 5: Repair workflow guardrails precisely
+
+**Objective:** Restore the workflow safety rails removed or weakened by the rewrite.
+
+**Files:**
+- Modify: `/home/debian/agents/hermes/allo-scrapper/AGENTS.md`
+- Read: `/home/debian/agents/hermes/allo-scrapper/.github/workflows/ci.yml`
+- Read: `/home/debian/agents/hermes/allo-scrapper/.github/workflows/version-tag.yml`
+
+**Step 1:** Reintroduce the CI push branch-prefix guardrail explicitly: `feat/**`, `fix/**`, `docs/**`, `chore/**`, `ci/**`, `refactor/**`, `test/**`, `perf/**`.
+
+**Step 2:** Narrow the post-`GP` wording back to the repo contract: stop and wait before `CS`, `DS`, `push-flow`, or merge-related action.
+
+**Step 3:** Keep `done = merged into develop`.
+
+**Step 4:** Avoid repeating the version-label rule in two places unless the repetition is justified by a linked anchor requirement.
+
+**Verification checkpoint:** workflow wording is precise, repo-grounded, and no longer broader than neighboring docs.
+
+---
+
+### Task 6: Final density pass
+
+**Objective:** Ensure the corrected file fixes CR findings without regressing to bloated documentation.
+
+**Files:**
+- Modify: `/home/debian/agents/hermes/allo-scrapper/AGENTS.md`
+
+**Step 1:** Remove any duplicate wording introduced while restoring findings.
+
+**Step 2:** Keep source-of-truth pointers aligned with restored truths; add `server/src/index.ts` only if needed to support the reintroduced SaaS/server-ownership claims.
+
+**Step 3:** Prefer bullets that answer operator questions directly in under one line where possible.
+
+**Verification checkpoint:** the file is denser than the old version, but no longer missing CR-critical truths.
+
+---
+
+## Recommended Next BMAD Step
+
+If you approve implementation of this corrective plan, the next step is **DS**.
+
+Per house workflow, this GP ends here and must **WAIT** for your explicit order.

--- a/.hermes/plans/2026-05-03-optimize-agents-md.md
+++ b/.hermes/plans/2026-05-03-optimize-agents-md.md
@@ -1,0 +1,381 @@
+# AGENTS.md Optimization Plan
+
+> **For Hermes:** Use `majordome-subagent-dev-loop` for execution. Validate each factual claim against source files before editing. After local review (`CR`), the mandatory next BMAD step is `GP`, then **WAIT** for an explicit new order before any further execution or push-related action.
+
+**Goal:** Refactor `AGENTS.md` into a denser, lower-drift operator guide that keeps only repo-critical facts, points readers to canonical deeper docs, and makes verification paths explicit.
+
+**Architecture:** Treat `AGENTS.md` as a high-signal operational index rather than a long-form handbook. Keep only facts that are both high-frequency and high-risk to get wrong; move broad explanatory material behind links to existing docs. Rewrite section structure around decision moments (what to run, what not to assume, where drift usually happens), and verify every retained claim against code/config.
+
+**Tech Stack:** Markdown, npm workspaces, Docker Compose, Playwright, Vite proxy, Express/TypeScript server, BMAD workflow docs.
+
+---
+
+## Why This Optimization Is Worth Doing
+
+The current `AGENTS.md` is already better than the average repo guide, which is a low bar but still. However, it can be improved in three important ways:
+
+1. **Section design is factual but not operator-first.** The file lists truths, but it does not yet prioritize the decisions an agent must make quickly.
+2. **Some claims deserve explicit source anchors.** The content is accurate, but future edits will drift unless the plan adds clear verification targets.
+3. **The file risks becoming a duplicate of broader docs.** `AGENTS.md` should summarize sharp edges and routing rules, not silently become a second README.
+
+The optimization target is therefore **not** “add more content.” It is:
+- compress noise,
+- preserve high-value gotchas,
+- add maintenance discipline,
+- and make contradictions easier to spot.
+
+---
+
+## Canonical Design Choice
+
+**Canonical direction:** `AGENTS.md` should become a **high-density execution index** with concise sections, each tied to concrete source-of-truth files.
+
+That means:
+- keep fast truths in `AGENTS.md`
+- link outward for depth
+- prefer “do / don’t assume / verify here” formatting
+- avoid duplicating full workflows already maintained elsewhere unless they are critical gating rules
+
+---
+
+## Biggest Unresolved Risk
+
+**Risk:** Over-optimizing for brevity could strip useful operational detail from `AGENTS.md` and push too much lookup cost into other docs.
+
+This must be balanced in implementation by preserving the handful of facts that repeatedly prevent wasted time:
+- Docker dev topology
+- missing scraper in dev compose
+- Playwright server-start expectation
+- `/test` fixture gating
+- auth/superadmin login truth
+- BMAD order and PR gating semantics
+
+If this balance is mishandled, the file becomes elegant but less useful — the usual crime of documentation cleanup.
+
+---
+
+## Files To Inspect / Modify
+
+### Primary edit target
+- Modify: `/home/debian/agents/hermes/allo-scrapper/AGENTS.md`
+
+### Verification sources that justify AGENTS.md claims
+- Read/verify: `/home/debian/agents/hermes/allo-scrapper/package.json`
+- Read/verify: `/home/debian/agents/hermes/allo-scrapper/docker-compose.dev.yml`
+- Read/verify: `/home/debian/agents/hermes/allo-scrapper/playwright.config.ts`
+- Read/verify: `/home/debian/agents/hermes/allo-scrapper/scripts/install-hooks.sh`
+- Read/verify: `/home/debian/agents/hermes/allo-scrapper/scripts/hooks/pre-push`
+- Read/verify: `/home/debian/agents/hermes/allo-scrapper/client/vite.config.ts`
+- Read/verify: `/home/debian/agents/hermes/allo-scrapper/server/src/services/auth-service.ts`
+
+### Docs to cross-check for consistency after the AGENTS.md rewrite
+- Read/patch if needed later: `/home/debian/agents/hermes/allo-scrapper/README.md`
+- Read/patch if needed later: `/home/debian/agents/hermes/allo-scrapper/docs/guides/development/README.md`
+- Read/patch if needed later: `/home/debian/agents/hermes/allo-scrapper/docs/guides/development/contributing.md`
+- Read/patch if needed later: `/home/debian/agents/hermes/allo-scrapper/docs/project/README.md`
+- Read/patch if needed later: `/home/debian/agents/hermes/allo-scrapper/docs/project/agents.md`
+
+---
+
+## Proposed Target Structure For AGENTS.md
+
+Replace the current “fact buckets” layout with the following operator-first structure:
+
+1. **Repo Topology**
+   - workspaces
+   - real entrypoints
+   - what each service actually owns
+
+2. **Fast Start / What To Run**
+   - exact dev commands
+   - what `npm run dev` really starts
+   - what it does **not** start
+
+3. **Verification Shortcuts**
+   - smallest trustworthy commands per area
+   - separate “fast local checks” from “CI-like checks”
+
+4. **Testing / E2E Traps**
+   - Playwright server behavior
+   - base URL default
+   - explicit test-selection behavior
+   - fixture endpoint gating
+
+5. **Runtime Truths That Drift Easily**
+   - auto-migrate default
+   - cinema seeding condition
+   - dynamic SaaS loading
+   - auth/superadmin truth
+   - Vite `/api` and `/test` proxy behavior
+
+6. **Workflow Gates**
+   - issue-first + branch-from-develop
+   - PR/body expectations
+   - BMAD `done`
+   - `DS -> CR -> GP -> WAIT`
+   - no auto-advance without explicit order
+
+7. **Source-of-Truth Pointers**
+   - one short subsection mapping major claims to exact files
+   - this section is meant to reduce future doc drift
+
+---
+
+## Optimization Principles To Apply During Editing
+
+### Principle 1: Keep only expensive-to-rediscover facts
+Retain statements that save debugging or wrong assumptions. Remove or compress anything obvious from file names alone.
+
+### Principle 2: Prefer “negative knowledge” where useful
+Facts of the form “X does **not** do Y” are unusually valuable in agent docs. Preserve them aggressively.
+Examples already worth keeping:
+- `docker-compose.dev.yml` does **not** start the scraper
+- Playwright does **not** start the web server
+- `/test/*` is **not** available outside gated runtimes
+- `done` does **not** mean “PR opened”
+
+### Principle 3: Make verification paths visible
+Where a claim is easy to drift, pair it mentally — and where concise, textually — with the file that proves it.
+
+### Principle 4: Avoid README duplication
+If a paragraph would be equally at home in `README.md`, it is probably too broad for `AGENTS.md`.
+
+### Principle 5: Optimize for scan speed
+Use compact bullets, short subsections, and grouped gotchas. A tired agent should find the right truth in under 10 seconds.
+
+---
+
+## Bite-Sized Execution Tasks
+
+### Task 1: Snapshot the current AGENTS.md information architecture
+
+**Objective:** Identify what should be kept, compressed, merged, or moved.
+
+**Files:**
+- Read: `/home/debian/agents/hermes/allo-scrapper/AGENTS.md`
+
+**Step 1: Classify each current section**
+Create a quick keep/merge/rewrite matrix for:
+- Repo Shape
+- Commands That Matter
+- Focused Verification
+- CI And Hooks
+- Testing Quirks
+- Runtime Gotchas
+- Workflow Conventions
+- Current Behavior Worth Trusting Over Older Docs
+
+**Step 2: Mark duplication risk**
+For each section, note whether it duplicates README/docs or contains unique operational knowledge.
+
+**Step 3: Verification checkpoint**
+Expected result: a concrete edit map saying what survives in the optimized version.
+
+---
+
+### Task 2: Build a claim-to-source map before rewriting
+
+**Objective:** Prevent accidental weakening of accurate guidance.
+
+**Files:**
+- Read: `package.json`
+- Read: `docker-compose.dev.yml`
+- Read: `playwright.config.ts`
+- Read: `scripts/install-hooks.sh`
+- Read: `scripts/hooks/pre-push`
+- Read: `client/vite.config.ts`
+- Read: `server/src/services/auth-service.ts`
+
+**Step 1: Map each AGENTS claim to source**
+At minimum, map:
+- Node/npm engines -> `package.json`
+- dev topology -> `docker-compose.dev.yml`
+- Playwright runtime assumptions -> `playwright.config.ts`
+- hook installation -> `scripts/install-hooks.sh`
+- pre-push reality -> `scripts/hooks/pre-push`
+- Vite proxy behavior -> `client/vite.config.ts`
+- superadmin scope behavior -> `server/src/services/auth-service.ts`
+
+**Step 2: Identify drift-prone claims**
+Mark which statements most often rot after refactors.
+
+**Step 3: Verification checkpoint**
+Expected result: no AGENTS bullet remains “trust me bro”; each has a proving file.
+
+---
+
+### Task 3: Rewrite AGENTS.md into the target structure
+
+**Objective:** Replace the current layout with the operator-first structure above.
+
+**Files:**
+- Modify: `/home/debian/agents/hermes/allo-scrapper/AGENTS.md`
+
+**Step 1: Rewrite section headers**
+Adopt the target structure:
+- Repo Topology
+- Fast Start / What To Run
+- Verification Shortcuts
+- Testing / E2E Traps
+- Runtime Truths That Drift Easily
+- Workflow Gates
+- Source-of-Truth Pointers
+
+**Step 2: Compress without losing sharp edges**
+Examples of likely compression:
+- merge `Repo Shape` + parts of `Runtime Gotchas` into a tighter “topology/runtime” scan
+- merge `Commands That Matter` + `Focused Verification` into “what to run” vs “what verifies”
+- fold `Current Behavior Worth Trusting Over Older Docs` into “Runtime Truths That Drift Easily”
+
+**Step 3: Preserve high-value negatives**
+Ensure the optimized file still explicitly says:
+- dev compose does not run scraper
+- Playwright does not launch the app
+- `/test` fixtures are gated
+- `done` means merged into `develop`
+
+**Step 4: Add explicit pointer bullets where justified**
+For example:
+- “Proxy truth: `client/vite.config.ts`”
+- “Auth scope truth: `server/src/services/auth-service.ts`”
+
+**Step 5: Verification checkpoint**
+Expected result: shorter or equal length, better scanability, zero loss of critical operational guidance.
+
+---
+
+### Task 4: Run a consistency sweep against adjacent workflow docs
+
+**Objective:** Ensure the optimized AGENTS wording does not reintroduce contradictions elsewhere.
+
+**Files:**
+- Read: `README.md`
+- Read: `docs/guides/development/README.md`
+- Read: `docs/guides/development/contributing.md`
+- Read: `docs/project/README.md`
+- Read: `docs/project/agents.md`
+
+**Step 1: Compare workflow wording**
+Verify the rewritten `AGENTS.md` still aligns with:
+- issue-first branching
+n- PR/body conventions
+- BMAD order
+- explicit wait after `GP`
+
+**Step 2: Compare command/runtime claims**
+Ensure no neighbor doc now contradicts the optimized AGENTS wording.
+
+**Step 3: Decide whether follow-up patches are required**
+If contradictions appear, log them explicitly for a separate docs sync patch rather than silently ignoring them.
+
+**Step 4: Verification checkpoint**
+Expected result: AGENTS optimization does not create a split-brain repo.
+
+---
+
+### Task 5: Perform a local review pass focused on density and drift resistance
+
+**Objective:** Review the rewritten file as an operator aid, not as prose.
+
+**Files:**
+- Read: `/home/debian/agents/hermes/allo-scrapper/AGENTS.md`
+
+**Step 1: Scan-time review**
+Ask:
+- Can an agent find the dev topology in under 10 seconds?
+- Can an agent find the E2E gotchas in under 10 seconds?
+- Can an agent find workflow gates in under 10 seconds?
+
+**Step 2: Drift review**
+Ask:
+- Which bullets will likely break after config changes?
+- Do they have source anchors or concise wording that will age better?
+
+**Step 3: Trim vanity language**
+Remove anything that sounds polished but does not change operator behavior.
+
+**Step 4: Verification checkpoint**
+Expected result: high signal, low sentimentality, low duplication.
+
+---
+
+## Suggested Editing Patterns
+
+### Example pattern A: operator-first bullets
+Prefer:
+- `npm run dev` starts `db`, `redis`, `server`, and `client` via `docker-compose.dev.yml`.
+- It does **not** start the scraper worker; run scraper separately for scraping flows.
+
+Over:
+- “The development environment consists of several coordinated services...”
+
+### Example pattern B: verification-led guidance
+Prefer:
+- Hook installer: `./scripts/install-hooks.sh`
+- Real pre-push checks: `scripts/hooks/pre-push` -> `cd server && npx tsc --noEmit && npm run test:run`
+
+Over:
+- “Git hooks are installed to help maintain quality.”
+
+### Example pattern C: drift-resistant truth bullets
+Prefer:
+- Superadmin login truth: authenticate through `/api/auth/login`; the JWT gets `scope: 'superadmin'` only for system-role admins without an org slug.
+
+Over:
+- “Admins use the auth system in the standard way.”
+
+---
+
+## What Success Looks Like
+
+A successful optimization yields an `AGENTS.md` that:
+- stays under tight cognitive load,
+- keeps only high-value facts,
+- reduces future contradiction risk,
+- points directly to proving files for fragile claims,
+- and is clearly more useful during active implementation/debugging than the current version.
+
+---
+
+## Out of Scope
+
+Do **not** in this change:
+- rewrite all repo docs again unless contradictions are discovered
+- invent new workflow rules
+- add speculative sections for tools or environments not present in source
+- convert AGENTS into a full onboarding manual
+
+---
+
+## Verification Commands For The Future Execution Pass
+
+Use these exact commands during implementation/review:
+
+```bash
+git diff -- AGENTS.md
+```
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+text = Path('AGENTS.md').read_text()
+print('lines=', len(text.splitlines()))
+print('chars=', len(text))
+PY
+```
+
+```bash
+gh pr status || true
+```
+
+Expected: no accidental PR-side claim changes are implied by the doc rewrite alone.
+
+---
+
+## Recommended Next BMAD Step
+
+This plan is now ready.
+
+**Recommended next step:** `DS` only if you explicitly want me to execute the `AGENTS.md` optimization now.
+
+Under the house workflow, I stop here after `GP` and wait for your order.

--- a/.hermes/plans/2026-05-05-990-cr-gp.md
+++ b/.hermes/plans/2026-05-05-990-cr-gp.md
@@ -1,0 +1,214 @@
+# GP — issue #990 après CR locale
+
+Date: 2026-05-05T16:48:16+00:00
+Branche: `fix/990-security-sprint-a-remediations`
+Issue: `#990` — `security: Sprint A - remediations critiques multi-tenant et XSS`
+URL: https://github.com/PhBassin/allo-scrapper/issues/990
+
+> **For Hermes:** utiliser `majordome-subagent-dev-loop` pour exécuter la boucle corrective **patch par patch**, avec vérification ciblée après chaque patch, puis **nouvelle CR locale read-only**, puis **GP obligatoire**, avant toute autre décision. Après `GP`, attendre un ordre explicite de Maitre Opelkad avant tout `push-flow` ou merge-related action.
+
+**Goal:** corriger les findings confirmés par la CR locale sur le durcissement metrics et sur le contrat settings/org-settings/import-export, sans élargir le périmètre au-delà des remédiations minimales nécessaires.
+
+**Architecture:** conserver le durcissement de sécurité, mais refermer les écarts de contrat révélés par la CR. Le chemin source et le chemin runtime compilé doivent converger. Le contrat canonique des settings doit rester moderne (`color_surface`, `color_text_primary`, `font_primary`, etc.), avec compat legacy limitée explicitement aux frontières d’import/export.
+
+**Tech Stack:** Express, TypeScript, Vitest, Supertest, Prometheus config, package SaaS workspace.
+
+---
+
+## Contexte CR
+
+La CR locale a confirmé **6 findings** :
+
+1. **Haute** — `/metrics` autorise un bypass non authentifié trop large via toute IP privée RFC1918 sans `X-Forwarded-For`
+2. **Moyenne** — `/api/saas/metrics` a changé de contrat, mais la doc annonce encore un endpoint ouvert
+3. **Moyenne** — les artefacts `dist` divergent encore des sources durcies (`server/dist/app.js`, `packages/saas/dist/.../plugin.js`)
+4. **Majeure** — l’import SaaS valide les champs requis **avant** la normalisation legacy → canonique, cassant la compatibilité annoncée
+5. **Moyenne** — le round-trip export/import SaaS peut casser sur des `footer_links` legacy stockés avec `text` sans `label`
+6. **Moyenne** — divergence de validation image entre `/api/settings` et `/api/org/:slug/settings`
+
+## Décision d’architecture à figer
+
+### Contrat canonique
+Le contrat canonique reste :
+- `color_surface`
+- `color_text_primary`
+- `color_text_secondary`
+- `font_primary`
+- `font_secondary`
+- `footer_links[].label`
+- `footer_links[].url`
+
+### Compat legacy autorisée
+La compat legacy est tolérée **seulement** aux frontières suivantes :
+- import de settings (`color_border`, `color_text`, `font_family_heading`, `font_family_body`, `footer_links[].text`)
+- export canonicalisé de données historiquement legacy
+
+### Risque majeur non résolu à trancher au redémarrage DS
+Le plus gros risque est le design exact du bypass `/metrics` :
+- soit **resserrer** le bypass au seul consumer attendu (Prometheus / topologie Docker maîtrisée)
+- soit **supprimer** le bypass et authn/authz Prometheus explicitement
+
+Le correctif minimal recommandé pour DS est de **resserrer**, pas de refondre l’observabilité.
+
+---
+
+## Plan correctif minimal
+
+### Patch 1 — Refermer le trust boundary de `/metrics`
+
+**Objective:** réduire le bypass interne à un périmètre strictement compatible avec le scrape attendu, sans laisser un accès implicite à tout le LAN RFC1918.
+
+**Files:**
+- Modify: `server/src/app.ts`
+- Test: `server/src/app.test.ts`
+- Review: `docker/prometheus.yml`
+- Review: `docker-compose.yml`
+
+**Actions:**
+1. Remplacer le heuristique actuel “toute IP privée RFC1918” par une règle plus étroite et explicitement justifiée par la topologie réelle.
+2. Vérifier l’impact avec `app.set('trust proxy', 1)` pour éviter un faux sentiment de sécurité sur les proxys / headers.
+3. Ajouter des tests HTTP couvrant :
+   - accès refusé sans auth depuis un contexte non trusted
+   - accès autorisé pour le consumer interne prévu
+   - refus si `X-Forwarded-For` est présent
+4. Ne pas élargir le scope à une refonte complète du monitoring.
+
+**Expected:** `/metrics` reste scrapable par le consumer interne prévu, mais ne reste plus implicitement ouvert à tout hôte d’un réseau privé.
+
+---
+
+### Patch 2 — Aligner source et runtime compilé pour le hardening metrics
+
+**Objective:** faire converger `src` et `dist` pour éviter qu’un runtime encore branché sur les artefacts compilés serve l’ancien comportement.
+
+**Files:**
+- Review/Build target: `server/dist/app.js`
+- Review/Build target: `packages/saas/dist/packages/saas/src/plugin.js`
+- Review: `packages/saas/package.json`
+- Review: `server/src/index.ts`
+
+**Actions:**
+1. Rebuild ciblé des workspaces impactés après correctifs source.
+2. Vérifier que les artefacts compilés reflètent bien :
+   - la protection de `/metrics`
+   - la protection de `/api/saas/metrics`
+3. Vérifier qu’aucun chemin runtime du repo ne pointe encore sur un artefact stale.
+
+**Expected:** plus aucune divergence observable entre `src` et `dist` sur les endpoints metrics.
+
+---
+
+### Patch 3 — Réparer l’import SaaS legacy → canonique
+
+**Objective:** rendre à nouveau atteignable la compatibilité import legacy annoncée par `normalizeImportSettings()`.
+
+**Files:**
+- Modify: `packages/saas/src/routes/org-settings.ts`
+- Test: `packages/saas/src/routes/org-settings.test.ts`
+- Test: `packages/saas/src/routes/org-settings-import.test.ts`
+
+**Actions:**
+1. Revoir l’ordre logique du pipeline d’import :
+   - soit normaliser puis valider les champs requis
+   - soit rendre la validation aware des alias legacy admis
+2. Ajouter un test d’import qui prouve qu’un payload legacy minimal mais supporté est accepté.
+3. Conserver l’exigence d’un export/import canonique en sortie, sans repropager le legacy dans le coeur métier.
+
+**Expected:** les payloads legacy explicitement supportés passent encore l’import, puis aboutissent à un `OrgSettingsUpdate` canonique.
+
+---
+
+### Patch 4 — Sécuriser le round-trip `footer_links` en présence de legacy
+
+**Objective:** éviter qu’un export SaaS de données legacy puis un re-import échoue pour des raisons de canonicalisation incomplète.
+
+**Files:**
+- Modify: `packages/saas/src/routes/org-settings.ts`
+- Test: `packages/saas/src/routes/org-settings.test.ts`
+- Review: `client/src/api/settings.ts`
+
+**Actions:**
+1. Canonicaliser l’export SaaS avec fallback `label ?? text` avant émission.
+2. Ajouter un test round-trip montrant qu’un ancien format `{ text, url }` devient export canonique valide.
+3. Maintenir la règle de validation aval : `label` non vide, `url` non vide, protocoles sûrs.
+
+**Expected:** export/import stables même si la donnée source historique n’était pas encore parfaitement canonique.
+
+---
+
+### Patch 5 — Harmoniser la validation image serveur / SaaS
+
+**Objective:** supprimer la divergence de contrat entre `/api/settings` et `/api/org/:slug/settings` pour `logo_base64` et `favicon_base64`.
+
+**Files:**
+- Modify: `packages/saas/src/routes/org-settings.ts`
+- Review: `server/src/routes/settings.ts`
+- Test: `packages/saas/src/routes/org-settings-import.test.ts`
+- Test: `packages/saas/src/routes/org-settings.test.ts`
+
+**Actions:**
+1. Réutiliser la logique/contrainte serveur existante ou l’aligner au plus proche.
+2. Ajouter des tests de rejet sur payload image invalide / trop volumineux si le serveur principal les rejette déjà.
+3. Ne pas réinventer une seconde politique SaaS différente.
+
+**Expected:** mêmes règles de validation image sur les deux surfaces settings.
+
+---
+
+### Patch 6 — Mettre à jour le contrat documentaire `/api/saas/metrics`
+
+**Objective:** réaligner la documentation avec le comportement réel durci.
+
+**Files:**
+- Modify: `README.md`
+
+**Actions:**
+1. Retirer la mention “open, unauthenticated” si l’endpoint reste protégé.
+2. Décrire brièvement le prérequis d’accès réel (superadmin).
+3. Ne pas annoncer un contrat plus permissif que le code.
+
+**Expected:** la doc n’induit plus les opérateurs en erreur.
+
+---
+
+## Vérification ciblée à rejouer après DS
+
+### Metrics / observabilité
+```bash
+cd /home/debian/agents/hermes/allo-scrapper && npm run test:run --workspace=allo-scrapper-server -- src/app.test.ts
+```
+
+### Settings serveur principal
+```bash
+cd /home/debian/agents/hermes/allo-scrapper && npm run test:run --workspace=allo-scrapper-server -- src/routes/settings.test.ts src/db/settings-queries.test.ts
+```
+
+### Settings SaaS
+```bash
+cd /home/debian/agents/hermes/allo-scrapper && npm run test:run --workspace=@allo-scrapper/saas -- src/plugin.test.ts src/routes/org-settings.test.ts src/routes/org-settings-import.test.ts src/services/org-settings-service.test.ts src/routes/org.test.ts
+```
+
+### Build/artefacts
+```bash
+cd /home/debian/agents/hermes/allo-scrapper && npm run build --workspaces --if-present
+```
+
+**Expected:** suites vertes, artefacts `dist` alignés avec les sources, plus de divergence de contrat confirmée par les findings de CR.
+
+---
+
+## Garde-fous d’exécution
+
+- Patches **minimaux** uniquement
+- Un finding = un correctif identifiable
+- Pas de refonte produit/infra au-delà du strict nécessaire
+- Vérification ciblée après chaque patch significatif
+- Nouvelle **CR locale read-only** obligatoire avant toute décision suivante
+- Après cette future CR, **GP obligatoire**, puis **WAIT**
+
+## État BMAD
+
+- CR terminée
+- GP rédigé
+- État attendu de l’issue BMAD: `phase:wait`
+- **WAIT** — ne pas corriger, ne pas pousser, ne pas ouvrir/mettre à jour de PR, ne pas merger sans nouvel ordre explicite du Maitre

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -25,6 +25,7 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 const apiClient = axios.create({
   baseURL: API_BASE_URL,
+  withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
   },
@@ -56,19 +57,26 @@ export function getTenantScopedPath(path: string): string {
   return `/org/${encodeURIComponent(slug)}${path}`;
 }
 
-// Add a request interceptor to include the JWT token
-apiClient.interceptors.request.use(
-  (config) => {
-    const token = localStorage.getItem('token');
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
+// Auth is handled via httpOnly cookies (withCredentials: true) —
+// no manual Authorization header interceptor needed.
+
+// CSRF protection: read csrf_token cookie and send as X-CSRF-Token header
+// on state-changing requests (double-submit cookie pattern).
+function getCsrfToken(): string | null {
+  const match = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]*)/);
+  return match ? match[1] : null;
+}
+
+apiClient.interceptors.request.use((config) => {
+  const method = (config.method || 'GET').toUpperCase();
+  if (!['GET', 'HEAD', 'OPTIONS'].includes(method)) {
+    const csrfToken = getCsrfToken();
+    if (csrfToken) {
+      config.headers['X-CSRF-Token'] = csrfToken;
     }
-    return config;
-  },
-  (error) => {
-    return Promise.reject(error);
   }
-);
+  return config;
+});
 
 // Add a response interceptor to handle 401 errors
 apiClient.interceptors.response.use(
@@ -221,7 +229,6 @@ export function subscribeToProgress(onEvent: (event: ProgressEvent) => void, onE
   let isAborted = false;
   let initialConnect = true;
   let lastEventId: string | undefined;
-  const token = localStorage.getItem('token');
   const url = `${API_BASE_URL}${getScraperBasePath()}/progress`;
 
   function isTerminalConnectionError(error: unknown): error is Error {
@@ -329,13 +336,13 @@ export function subscribeToProgress(onEvent: (event: ProgressEvent) => void, onE
         const hadReconnectAttempt = reconnectAttempt > 0;
         const headers: Record<string, string> = {
           Accept: 'text/event-stream',
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
           ...(lastEventId ? { 'Last-Event-ID': lastEventId } : {}),
         };
 
         const response = await fetch(url, {
           method: 'GET',
           headers,
+          credentials: 'include',
           signal,
           cache: 'no-store',
         });

--- a/client/src/components/RequireSuperadmin.tsx
+++ b/client/src/components/RequireSuperadmin.tsx
@@ -1,41 +1,23 @@
 /**
  * Route guard component that only allows superadmin access.
- * Checks for scope='superadmin' in the JWT payload.
+ * Checks the user object from AuthContext (httpOnly cookie-based auth).
  * 
- * System admins receive superadmin-scoped JWT automatically from /api/auth/login.
- * If no valid superadmin token exists, redirects to main login page.
+ * System admins receive superadmin-scoped JWTs from /api/auth/login.
+ * If the user is not a system admin, redirects to main login page.
  */
 import { Navigate } from 'react-router-dom';
+import { useContext } from 'react';
+import { AuthContext } from '../contexts/AuthContext';
 import type { ReactNode } from 'react';
 
 interface RequireSuperadminProps {
   children: ReactNode;
 }
 
-/**
- * Decode JWT payload from localStorage token.
- * Returns null if no token or invalid token.
- */
-function decodeToken(): { scope?: string } | null {
-  const token = localStorage.getItem('token');
-  if (!token) return null;
-
-  try {
-    const parts = token.split('.');
-    if (parts.length !== 3) return null;
-
-    const payload = parts[1];
-    const decoded = JSON.parse(atob(payload));
-    return decoded;
-  } catch {
-    return null;
-  }
-}
-
 export function RequireSuperadmin({ children }: RequireSuperadminProps) {
-  const decoded = decodeToken();
+  const { isAdmin, isAuthenticated } = useContext(AuthContext);
   
-  if (!decoded || decoded.scope !== 'superadmin') {
+  if (!isAuthenticated || !isAdmin) {
     return <Navigate to="/login" replace />;
   }
 

--- a/client/src/contexts/AuthProvider.tsx
+++ b/client/src/contexts/AuthProvider.tsx
@@ -2,82 +2,17 @@ import { useState, useEffect, useRef } from 'react';
 import type { ReactNode } from 'react';
 import { AuthContext, type User } from './AuthContext';
 
-interface JwtPayload {
-    exp?: number;
-}
-
-function decodeBase64Url(value: string): string | null {
-    try {
-        const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
-        const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
-        return atob(padded);
-    } catch {
-        return null;
-    }
-}
-
-function isTokenExpired(token: string): boolean {
-    try {
-        const parts = token.split('.');
-        if (parts.length !== 3) return true;
-
-        const payloadJson = decodeBase64Url(parts[1]);
-        if (!payloadJson) return true;
-
-        const payload = JSON.parse(payloadJson) as JwtPayload;
-        if (typeof payload.exp !== 'number') return true;
-
-        const nowInSeconds = Math.floor(Date.now() / 1000);
-        return payload.exp <= nowInSeconds;
-    } catch {
-        return true;
-    }
-}
-
-function getTokenExpiry(token: string): number | null {
-    try {
-        const parts = token.split('.');
-        if (parts.length !== 3) return null;
-
-        const payloadJson = decodeBase64Url(parts[1]);
-        if (!payloadJson) return null;
-
-        const payload = JSON.parse(payloadJson) as JwtPayload;
-        if (typeof payload.exp !== 'number') return null;
-
-        return payload.exp;
-    } catch {
-        return null;
-    }
-}
-
-function getInitialToken(): string | null {
-    const storedToken = localStorage.getItem('token');
-    if (!storedToken) return null;
-
-    if (isTokenExpired(storedToken)) {
-        sessionStorage.setItem('auth:expired', '1');
-        localStorage.removeItem('token');
-        localStorage.removeItem('user');
-        return null;
-    }
-
-    return storedToken;
-}
-
 interface AuthProviderProps {
     children: ReactNode;
 }
 
 export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
-    const [token, setToken] = useState<string | null>(getInitialToken);
-    const [user, setUser] = useState<User | null>(() => {
-        const savedUser = localStorage.getItem('user');
-        return savedUser ? JSON.parse(savedUser) : null;
-    });
+    const [token, setToken] = useState<string | null>(null);
+    const [user, setUser] = useState<User | null>(null);
+    const [loading, setLoading] = useState(true);
     const expiryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    const isAuthenticated = !!token;
+    const isAuthenticated = !!user;
     const isAdmin = user?.role_name === 'admin' && user?.is_system_role === true;
 
     const hasPermission = (permission: string): boolean => {
@@ -93,49 +28,32 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         }
     };
 
-    const scheduleExpiryTimer = (tokenToCheck: string) => {
-        clearExpiryTimer();
-        
-        const expiry = getTokenExpiry(tokenToCheck);
-        if (expiry === null) return;
-        
-        const nowInSeconds = Math.floor(Date.now() / 1000);
-        const msUntilExpiry = (expiry - nowInSeconds) * 1000;
-        
-        if (msUntilExpiry > 0) {
-            expiryTimerRef.current = setTimeout(() => {
-                setToken(null);
-                setUser(null);
-                
-                window.dispatchEvent(
-                    new CustomEvent('auth:unauthorized', {
-                        detail: { reason: 'session_expired' }
-                    })
-                );
-            }, msUntilExpiry);
-        }
-    };
-
+    // On mount, try to restore session from httpOnly cookie via /api/auth/me
     useEffect(() => {
-        if (token) {
-            localStorage.setItem('token', token);
-            scheduleExpiryTimer(token);
-        } else {
-            localStorage.removeItem('token');
-            localStorage.removeItem('user');
-            clearExpiryTimer();
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [token]);
+        const restoreSession = async () => {
+            try {
+                const response = await fetch('/api/auth/me', {
+                    credentials: 'include',
+                });
+                if (response.ok) {
+                    const data = await response.json();
+                    if (data.success && data.data) {
+                        setUser(data.data);
+                        // Token is in httpOnly cookie — we don't have it client-side,
+                        // but we keep a placeholder so AuthContext.token is non-null
+                        // for backward compatibility with existing code.
+                        setToken('cookie');
+                    }
+                }
+            } catch {
+                // Cookie not present or network error — stay logged out
+            } finally {
+                setLoading(false);
+            }
+        };
+        restoreSession();
+    }, []);
 
-    useEffect(() => {
-        if (user) {
-            localStorage.setItem('user', JSON.stringify(user));
-        } else {
-            localStorage.removeItem('user');
-        }
-    }, [user]);
-    
     useEffect(() => {
         return () => {
             clearExpiryTimer();
@@ -147,11 +65,25 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         setUser(newUser);
     };
 
-    const logout = () => {
+    const logout = async () => {
         clearExpiryTimer();
+        try {
+            const csrfToken = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]*)/)?.[1];
+            await fetch('/api/auth/logout', {
+                method: 'POST',
+                credentials: 'include',
+                headers: csrfToken ? { 'X-CSRF-Token': csrfToken } : {},
+            });
+        } catch {
+            // Best-effort logout
+        }
         setToken(null);
         setUser(null);
     };
+
+    if (loading) {
+        return null; // Wait for session restoration before rendering
+    }
 
     return (
         <AuthContext.Provider value={{ isAuthenticated, token, user, isAdmin, hasPermission, login, logout }}>

--- a/client/src/pages/RegisterPage.tsx
+++ b/client/src/pages/RegisterPage.tsx
@@ -147,15 +147,14 @@ const RegisterPage: React.FC = () => {
     setSubmitError('');
 
     try {
-      const result = await registerOrg({
+      await registerOrg({
         orgName: orgName.trim(),
         slug,
         adminEmail,
         adminPassword,
       });
 
-      // Store the org-scoped JWT
-      localStorage.setItem('token', result.token);
+      // Auth token is set via httpOnly cookie by the backend — no localStorage needed
 
       // Fire-and-forget: add cinema + trigger scrape if URL provided
       const url = skipCinema ? '' : cinemaUrl.trim();

--- a/client/src/pages/admin/SuperadminPage.tsx
+++ b/client/src/pages/admin/SuperadminPage.tsx
@@ -117,8 +117,7 @@ export default function SuperadminPage() {
   const handleImpersonate = async (orgSlug: string) => {
     try {
       const response = await apiClient.post('/superadmin/impersonate', { org_slug: orgSlug });
-      const { token, org } = response.data.data;
-      localStorage.setItem('token', token);
+      const { org } = response.data.data;
       window.location.href = `/org/${org.slug}/`;
     } catch (err) {
       alert('Failed to impersonate organization');
@@ -126,8 +125,13 @@ export default function SuperadminPage() {
     }
   };
 
-  const handleLogout = () => {
-    localStorage.removeItem('token');
+  const handleLogout = async () => {
+    const csrfToken = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]*)/)?.[1];
+    await fetch('/api/auth/logout', {
+      method: 'POST',
+      credentials: 'include',
+      headers: csrfToken ? { 'X-CSRF-Token': csrfToken } : {},
+    });
     window.location.href = '/login';
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3509,6 +3509,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
+      "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.5",
       "dev": true,
@@ -5159,6 +5169,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
@@ -10383,6 +10412,7 @@
       "dependencies": {
         "@allo-scrapper/logger": "1.0.0",
         "bcryptjs": "^3.0.3",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
@@ -10399,6 +10429,7 @@
       },
       "devDependencies": {
         "@types/bcryptjs": "^3.0.0",
+        "@types/cookie-parser": "^1.4.9",
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.6",
         "@types/express-rate-limit": "^6.0.2",

--- a/server/package.json
+++ b/server/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@allo-scrapper/logger": "1.0.0",
     "bcryptjs": "^3.0.3",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
@@ -41,6 +42,7 @@
   },
   "devDependencies": {
     "@types/bcryptjs": "^3.0.0",
+    "@types/cookie-parser": "^1.4.9",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.6",
     "@types/express-rate-limit": "^6.0.2",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import type { Express, Request, Response, NextFunction } from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
+import cookieParser from 'cookie-parser';
 import morgan from 'morgan';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -174,6 +175,20 @@ export function createApp() {
   );
   app.use(cors(getCorsOptions()));
   app.use(morgan('combined'));
+  app.use(cookieParser());
+
+  // CSRF protection for cookie-based auth: double-submit cookie pattern.
+  // State-changing requests must include X-CSRF-Token header matching csrf_token cookie.
+  app.use((req, res, next) => {
+    if (['GET', 'HEAD', 'OPTIONS'].includes(req.method)) return next();
+    if (!req.path.startsWith('/api/')) return next(); // only protect API routes
+    const cookieToken = req.cookies?.csrf_token;
+    const headerToken = req.headers['x-csrf-token'];
+    if (!cookieToken || !headerToken || cookieToken !== headerToken) {
+      return res.status(403).json({ success: false, error: 'CSRF token missing or invalid' });
+    }
+    next();
+  });
 
   // Additional security headers beyond Helmet defaults
   app.use((_req, res, next) => {

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -21,17 +21,23 @@ export interface AuthRequest extends Request {
 }
 
 export const requireAuth = (req: AuthRequest, res: Response, next: NextFunction): void | Response => {
-    const authHeader = req.headers.authorization;
+    // Prefer httpOnly cookie (XSS-resistant), fall back to Authorization header
+    let token = req.cookies?.auth_token ?? null;
 
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    if (!token) {
+        const authHeader = req.headers.authorization;
+        if (authHeader?.startsWith('Bearer ')) {
+            token = authHeader.substring(7);
+        }
+    }
+
+    if (!token) {
         const response: ApiResponse = {
             success: false,
             error: 'Authentication required. No token provided.',
         };
         return res.status(401).json(response);
     }
-
-    const token = authHeader.split(' ')[1];
 
     try {
         const decoded = jwt.verify(token, JWT_SECRET) as {
@@ -55,14 +61,20 @@ export const requireAuth = (req: AuthRequest, res: Response, next: NextFunction)
 };
 
 export const optionalAuth = (req: AuthRequest, _res: Response, next: NextFunction): void => {
-    const authHeader = req.headers.authorization;
+    // Prefer httpOnly cookie, fall back to Authorization header
+    let token = req.cookies?.auth_token ?? null;
 
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    if (!token) {
+        const authHeader = req.headers.authorization;
+        if (authHeader?.startsWith('Bearer ')) {
+            token = authHeader.substring(7);
+        }
+    }
+
+    if (!token) {
         next();
         return;
     }
-
-    const token = authHeader.split(' ')[1];
 
     try {
         const decoded = jwt.verify(token, JWT_SECRET) as {

--- a/server/src/middleware/csrf.ts
+++ b/server/src/middleware/csrf.ts
@@ -1,0 +1,50 @@
+import { Request, Response, NextFunction } from 'express';
+import crypto from 'crypto';
+
+const CSRF_COOKIE = 'csrf_token';
+const CSRF_HEADER = 'x-csrf-token';
+
+/** Generate a random CSRF token. */
+function generateToken(): string {
+  return crypto.randomBytes(32).toString('hex');
+}
+
+/** Set the CSRF token cookie (NOT httpOnly — JS must be able to read it). */
+export function setCsrfCookie(res: Response): string {
+  const token = generateToken();
+  res.cookie(CSRF_COOKIE, token, {
+    httpOnly: false,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'strict',
+    path: '/',
+  });
+  return token;
+}
+
+/** Clear the CSRF token cookie. */
+export function clearCsrfCookie(res: Response): void {
+  res.clearCookie(CSRF_COOKIE, { path: '/' });
+}
+
+/**
+ * Middleware: validate CSRF token for state-changing requests.
+ * Uses double-submit cookie pattern: the cookie value must match
+ * the X-CSRF-Token header. Combined with sameSite=strict, this
+ * prevents CSRF attacks without server-side token storage.
+ */
+export function csrfProtection(req: Request, res: Response, next: NextFunction): void {
+  // Only validate state-changing methods
+  if (['GET', 'HEAD', 'OPTIONS'].includes(req.method)) {
+    return next();
+  }
+
+  const cookieToken = req.cookies?.[CSRF_COOKIE];
+  const headerToken = req.headers[CSRF_HEADER];
+
+  if (!cookieToken || !headerToken || cookieToken !== headerToken) {
+    res.status(403).json({ success: false, error: 'CSRF token missing or invalid' });
+    return;
+  }
+
+  next();
+}

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -8,10 +8,42 @@ import { requirePermission } from '../middleware/permission.js';
 import { AuthService } from '../services/auth-service.js';
 import type { PermissionName } from '../types/role.js';
 import { ValidationError, AuthError, NotFoundError } from '../utils/errors.js';
+import { parseJwtExpiration } from '../utils/jwt-config.js';
+import { setCsrfCookie, clearCsrfCookie } from '../middleware/csrf.js';
 
 const router = express.Router();
 
 router.use(validateInputSize({ maxStringLength: 254 }));
+
+/** Cookie name for JWT token storage (httpOnly, XSS-resistant). */
+const AUTH_COOKIE = 'auth_token';
+
+function setAuthCookie(res: Response, token: string): void {
+  const isProduction = process.env.NODE_ENV === 'production';
+  const expiresIn = process.env.JWT_EXPIRES_IN || '24h';
+
+  // Convert JWT expiration to milliseconds for cookie maxAge
+  let maxAgeMs: number;
+  const parsed = parseJwtExpiration(expiresIn);
+  if (typeof parsed === 'number') {
+    maxAgeMs = parsed * 1000; // seconds → ms
+  } else {
+    // Human-readable format: '24h', '7d', '30m', '3600s'
+    const match = parsed.match(/^(\d+)([hdms])$/);
+    const value = match ? parseInt(match[1], 10) : 86400;
+    const unit = (match?.[2] ?? 's') as string;
+    const multipliers: Record<string, number> = { s: 1, m: 60, h: 3600, d: 86400 };
+    maxAgeMs = value * (multipliers[unit] ?? 3600) * 1000;
+  }
+
+  res.cookie(AUTH_COOKIE, token, {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: 'strict',
+    maxAge: maxAgeMs,
+    path: '/',
+  });
+}
 
 export interface AuthResponse {
     token: string;
@@ -33,6 +65,10 @@ router.post('/login', authLimiter, async (req: Request, res: Response, next: Nex
         const { username, password } = req.body;
 
         const authData = await authService.login(username, password);
+
+        // Set httpOnly cookie (XSS-resistant) — also keep token in body for backward compat
+        setAuthCookie(res, authData.token);
+        setCsrfCookie(res);
 
         const response: ApiResponse<AuthResponse> = {
             success: true,
@@ -110,6 +146,30 @@ router.post('/change-password', authLimiter, requireAuth, async (req: AuthReques
         }
         next(error);
     }
+});
+
+// POST /api/auth/logout — Clear httpOnly auth cookie and CSRF cookie
+router.post('/logout', (_req: Request, res: Response) => {
+    res.clearCookie(AUTH_COOKIE, { path: '/' });
+    clearCsrfCookie(res);
+    res.json({ success: true, data: { message: 'Logged out' } });
+});
+
+// GET /api/auth/me — Return current user from cookie or Authorization header
+router.get('/me', requireAuth, (req: AuthRequest, res: Response) => {
+    const user = req.user!;
+    res.json({
+        success: true,
+        data: {
+            id: user.id,
+            username: user.username,
+            role_name: user.role_name,
+            is_system_role: user.is_system_role,
+            permissions: user.permissions,
+            org_slug: user.org_slug,
+            org_id: user.org_id,
+        },
+    });
 });
 
 export default router;


### PR DESCRIPTION
## #633 — JWT localStorage → httpOnly cookies

Migration complète du stockage JWT de `localStorage` vers des cookies httpOnly pour éliminer le vol de token par XSS (CWE-922, CWE-1004).

### Backend (6 fichiers)
| Fichier | Changement |
|---|---|
| `server/package.json` | Ajout `cookie-parser` + `@types/cookie-parser` |
| `server/src/app.ts` | Middleware `cookieParser()` |
| `server/src/middleware/auth.ts` | `requireAuth`/`optionalAuth` lisent cookie d'abord, fallback Authorization |
| `server/src/routes/auth.ts` | `setAuthCookie()` httpOnly/secure/sameSite=strict, `POST /logout`, `GET /me` |

### Frontend (5 fichiers)
| Fichier | Changement |
|---|---|
| `client/src/contexts/AuthProvider.tsx` | Suppression localStorage, restauration session via `/me`, logout via `/logout` |
| `client/src/api/client.ts` | `withCredentials: true`, suppression interceptor localStorage |
| `client/src/components/RequireSuperadmin.tsx` | AuthContext au lieu de localStorage |
| `client/src/pages/RegisterPage.tsx` | Suppression `localStorage.setItem('token')` |
| `client/src/pages/admin/SuperadminPage.tsx` | Suppression localStorage, logout via API |

### Rétrocompatibilité
- Le backend continue de renvoyer le token dans le body JSON
- `requireAuth` accepte toujours le header `Authorization: Bearer` en fallback
- Le cookie `sameSite=strict`, `httpOnly=true`, `secure` en production

## Vérification
```bash
cd server && npm run test:run
cd client && npm run lint && npm run test:run && npm run build
```