### PR TITLE
perf: Sprint C — resilience scraper et scheduler quota distribué (#992)

### DIFF
--- a/packages/saas/src/quota-reset-scheduler.ts
+++ b/packages/saas/src/quota-reset-scheduler.ts
@@ -4,8 +4,8 @@
  * Runs once per day at midnight UTC and resets scrapes_count + api_calls_count
  * for all organizations on the 1st of each month.
  * 
- * This is a simple in-process scheduler. For production multi-instance deployments,
- * consider using a distributed cron solution (e.g., pg_cron, BullMQ, or external service).
+ * Uses PostgreSQL advisory lock (pg_try_advisory_lock) to ensure only one
+ * instance executes the reset in multi-instance deployments.
  */
 
 import { QuotaService } from './services/quota-service.js';
@@ -13,6 +13,8 @@ import type { DB } from './db/types.js';
 import { logger } from './utils/logger.js';
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+/** PostgreSQL advisory lock key — arbitrary int64, unique to this scheduler. */
+const QUOTA_RESET_LOCK_KEY = 8675309;
 
 /**
  * Calculate milliseconds until next midnight UTC.
@@ -42,6 +44,17 @@ async function runMonthlyReset(db: DB): Promise<void> {
     return; // Not the 1st, skip
   }
 
+  // Try to acquire advisory lock — if another instance holds it, skip silently
+  const lockResult = await db.query<{ locked: boolean }>(
+    `SELECT pg_try_advisory_lock($1) AS locked`,
+    [QUOTA_RESET_LOCK_KEY]
+  );
+
+  if (!lockResult.rows[0]?.locked) {
+    logger.info('[quota-reset] Another instance is already running the monthly reset — skipping');
+    return;
+  }
+
   try {
     // Fetch all active organizations from public schema
     const result = await db.query<{ id: number; slug: string }>(
@@ -62,6 +75,9 @@ async function runMonthlyReset(db: DB): Promise<void> {
     logger.info(`[quota-reset] Monthly reset completed for ${result.rows.length} organizations`);
   } catch (error) {
     logger.error('[quota-reset] Monthly reset failed:', error);
+  } finally {
+    // Always release the lock
+    await db.query(`SELECT pg_advisory_unlock($1)`, [QUOTA_RESET_LOCK_KEY]).catch(() => {});
   }
 }
 

--- a/scraper/src/db/film-queries.ts
+++ b/scraper/src/db/film-queries.ts
@@ -35,6 +35,29 @@ export async function getFilm(db: DB, filmId: number): Promise<Film | undefined>
   const row = result.rows[0];
   if (!row) return undefined;
 
+  return rowToFilm(row);
+}
+
+/**
+ * Récupérer plusieurs films par leurs IDs en une seule requête.
+ * Évite le N+1 lorsqu'on traite plusieurs films dans une boucle.
+ */
+export async function getFilmsBatch(db: DB, filmIds: number[]): Promise<Map<number, Film>> {
+  if (filmIds.length === 0) return new Map();
+
+  const result = await db.query<FilmRow>(
+    'SELECT * FROM films WHERE id = ANY($1)',
+    [filmIds]
+  );
+
+  const map = new Map<number, Film>();
+  for (const row of result.rows) {
+    map.set(row.id, rowToFilm(row));
+  }
+  return map;
+}
+
+function rowToFilm(row: FilmRow): Film {
   return {
     id: row.id,
     title: row.title,

--- a/scraper/src/scraper/http-client.ts
+++ b/scraper/src/scraper/http-client.ts
@@ -11,6 +11,106 @@ import { CircuitBreaker } from './circuit-breaker.js';
 
 const FETCH_TIMEOUT_MS = 15000;
 
+// ── Retry configuration ─────────────────────────────────────────
+const RETRY_MAX_ATTEMPTS = 3;
+const RETRY_BASE_DELAY_MS = 1000;
+const RETRY_MAX_DELAY_MS = 10000;
+
+/**
+ * Determine whether an error is retryable (transient).
+ * 429 and 4xx client errors are NOT retried — they indicate a
+ * condition that retries won't fix (rate-limit, bad request).
+ * 5xx, network/timeout, and DNS errors ARE retried.
+ */
+function isRetryableError(err: unknown): boolean {
+  if (err instanceof RateLimitError) return false;
+  if (err instanceof HttpError && err.statusCode && err.statusCode >= 400 && err.statusCode < 500) return false;
+  return true;
+}
+
+/**
+ * Compute exponential backoff delay with jitter (±25%).
+ * delay = min(base * 2^(attempt-1), maxDelay)
+ * Then apply uniform jitter in [0.75, 1.25].
+ */
+function backoffDelay(attempt: number): number {
+  const exponential = Math.min(RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1), RETRY_MAX_DELAY_MS);
+  const jitter = 0.75 + Math.random() * 0.5; // 0.75 → 1.25
+  return Math.round(exponential * jitter);
+}
+
+/**
+ * Generic fetch with exponential-backoff retry.
+ *
+ * Retries only on transient errors (5xx, network, timeout).
+ * Does NOT retry on 429 (RateLimitError) or 4xx client errors.
+ */
+async function fetchWithRetry(
+  url: string,
+  init: RequestInit,
+  retryOn?: (err: unknown) => boolean,
+): Promise<Response> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= RETRY_MAX_ATTEMPTS; attempt++) {
+    const controller = new AbortController();
+    // Merge the caller's signal with our own timeout
+    const existingSignal = init.signal ?? null;
+    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    // If the caller provided a signal, forward aborts to our controller
+    if (existingSignal) {
+      if (existingSignal.aborted) {
+        clearTimeout(timeoutId);
+        throw new HttpError('Request aborted', 0, url);
+      }
+      existingSignal.addEventListener('abort', () => controller.abort(), { once: true });
+    }
+
+    try {
+      const response = await fetch(url, { ...init, signal: controller.signal });
+
+      if (!response.ok) {
+        // Detect rate limiting specifically
+        if (response.status === 429) {
+          throw new RateLimitError(
+            `Rate limit exceeded for ${url}`,
+            response.status,
+            url
+          );
+        }
+
+        throw new HttpError(
+          `HTTP ${response.status} ${response.statusText} for ${url}`,
+          response.status,
+          url
+        );
+      }
+
+      return response;
+    } catch (err) {
+      lastError = err;
+      clearTimeout(timeoutId);
+
+      const retryable = retryOn ? retryOn(err) : isRetryableError(err);
+      if (!retryable || attempt === RETRY_MAX_ATTEMPTS) {
+        throw err;
+      }
+
+      const delay = backoffDelay(attempt);
+      logger.warn('Retrying HTTP request', {
+        url: url.slice(0, 120),
+        attempt,
+        nextDelayMs: delay,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+
+  throw lastError;
+}
+
 export const circuitBreaker = new CircuitBreaker(5, 60000, (err) => {
   if (err instanceof RateLimitError) return false;
   if (err instanceof HttpError && err.statusCode && err.statusCode < 500) return false;
@@ -212,42 +312,16 @@ export async function fetchShowtimesJson(cinemaId: string, date: string): Promis
   const url = constructed.href;
   logger.info('Fetching showtimes JSON', { url });
 
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  const response = await fetchWithRetry(url, {
+    headers: {
+      'User-Agent': getRandomUserAgent(),
+      Accept: 'application/json',
+      'Accept-Language': 'fr-FR,fr;q=0.9',
+      Referer: `${ALLOCINE_BASE_URL}/seance/salle_gen_csalle=${cinemaId}.html`,
+    },
+  });
 
-  try {
-    const response = await fetch(url, {
-      signal: controller.signal,
-      headers: {
-        'User-Agent': getRandomUserAgent(),
-        Accept: 'application/json',
-        'Accept-Language': 'fr-FR,fr;q=0.9',
-        Referer: `${ALLOCINE_BASE_URL}/seance/salle_gen_csalle=${cinemaId}.html`,
-      },
-    });
-
-    if (!response.ok) {
-      // Detect rate limiting specifically
-      if (response.status === 429) {
-        throw new RateLimitError(
-          `Rate limit exceeded for ${cinemaId} on ${date}`,
-          response.status,
-          url
-        );
-      }
-
-      // Throw generic HttpError for other failures
-      throw new HttpError(
-        `Failed to fetch showtimes JSON for ${cinemaId} on ${date}: ${response.status} ${response.statusText}`,
-        response.status,
-        url
-      );
-    }
-
-    return response.json();
-  } finally {
-    clearTimeout(timeoutId);
-  }
+  return response.json();
 }
 
 export async function fetchFilmPage(filmId: number): Promise<string> {
@@ -264,42 +338,16 @@ export async function fetchFilmPage(filmId: number): Promise<string> {
   logger.info('Fetching film page', { url });
 
   return circuitBreaker.execute(async () => {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    const response = await fetchWithRetry(url, {
+      headers: {
+        'User-Agent': getRandomUserAgent(),
+        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7',
+        'Cache-Control': 'no-cache',
+      },
+    });
 
-    try {
-      const response = await fetch(url, {
-        signal: controller.signal,
-        headers: {
-          'User-Agent': getRandomUserAgent(),
-          Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-          'Accept-Language': 'fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7',
-          'Cache-Control': 'no-cache',
-        },
-      });
-
-      if (!response.ok) {
-        // Detect rate limiting specifically
-        if (response.status === 429) {
-          throw new RateLimitError(
-            `Rate limit exceeded for film ${filmId}`,
-            response.status,
-            url
-          );
-        }
-
-        // Throw generic HttpError for other failures
-        throw new HttpError(
-          `Failed to fetch film page ${filmId}: ${response.status} ${response.statusText}`,
-          response.status,
-          url
-        );
-      }
-
-      return response.text();
-    } finally {
-      clearTimeout(timeoutId);
-    }
+    return response.text();
   });
 }
 

--- a/scraper/src/scraper/strategies/AllocineScraperStrategy.ts
+++ b/scraper/src/scraper/strategies/AllocineScraperStrategy.ts
@@ -6,6 +6,7 @@ import {
 import {
   upsertFilm,
   getFilm,
+  getFilmsBatch,
 } from '../../db/film-queries.js';
 import {
   upsertCinema,
@@ -104,6 +105,10 @@ export class AllocineScraperStrategy implements IScraperStrategy {
 
       logger.info('Films found for date', { count: filmShowtimesData.length, date });
 
+      // Batch-load existing films to avoid N+1 queries
+      const filmIds = filmShowtimesData.map((f) => f.film.id);
+      const existingFilms = await getFilmsBatch(db, filmIds);
+
       const weeklyPrograms: WeeklyProgram[] = [];
 
       for (const filmData of filmShowtimesData) {
@@ -112,7 +117,7 @@ export class AllocineScraperStrategy implements IScraperStrategy {
         await progress?.emit({ type: 'film_started', film_title: film.title, film_id: film.id });
 
         try {
-          const existingFilm = await getFilm(db, film.id);
+          const existingFilm = existingFilms.get(film.id);
 
           if (shouldRefreshFilmDetails(existingFilm)) {
             logger.info('Fetching film details', { title: film.title, id: film.id });


### PR DESCRIPTION
## Scope
Closes #751, Closes #805, Closes #771

### #751 — HTTP retry avec exponential backoff + jitter
- `fetchWithRetry()` avec 3 tentatives max, backoff 1s→2s→4s, jitter ±25%
- Pas de retry sur 429 (RateLimitError) ni 4xx
- Appliqué à `fetchShowtimesJson` et `fetchFilmPage`

### #805 — Batch upsert films (anti N+1)
- Nouvelle fonction `getFilmsBatch()` utilisant `WHERE id = ANY($1)`
- Remplace N appels `getFilm()` par 1 seul appel batch
- Backward-compatible, `getFilm()` toujours exporté

### #771 — Quota reset avec advisory lock PostgreSQL
- `pg_try_advisory_lock(8675309)` empêche la double exécution
- Lock relâché dans `finally`, même en cas d'erreur
- Tolérant aux déploiements multi-instances

## Test commands run
```
cd scraper && npm run test:run
cd packages/saas && npm run test:run
```