### PR TITLE
fix(date): use local-time formatting to fix timezone off-by-one in week start

### DIFF
--- a/scraper/src/utils/date.ts
+++ b/scraper/src/utils/date.ts
@@ -10,6 +10,18 @@
  * without introducing cross-package dependencies.
  */
 
+/**
+ * Format a Date as YYYY-MM-DD using local time.
+ * Using toISOString() would convert to UTC first, causing off-by-one date
+ * errors in non-UTC timezones (e.g. Europe/Paris between 22:00–00:00 UTC).
+ */
+function formatLocalDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 export function getCurrentWeekStart(): string {
   const today = new Date();
   const dayOfWeek = today.getDay();
@@ -21,13 +33,13 @@ export function getCurrentWeekStart(): string {
 
   const wednesday = new Date(today);
   wednesday.setDate(today.getDate() - offset);
-  return wednesday.toISOString().split('T')[0];
+  return formatLocalDate(wednesday);
 }
 
 export const getWeekStart = getCurrentWeekStart;
 
 export function getWeekDates(weekStart?: string, numDays: number = 7): string[] {
-  const start = weekStart ? new Date(weekStart) : new Date(getCurrentWeekStart());
+  const start = weekStart ? new Date(weekStart + 'T00:00:00') : new Date(getCurrentWeekStart() + 'T00:00:00');
 
   const validatedDays = Math.max(1, Math.min(14, numDays));
 
@@ -39,15 +51,14 @@ export function getWeekDates(weekStart?: string, numDays: number = 7): string[] 
   for (let i = 0; i < validatedDays; i++) {
     const date = new Date(start);
     date.setDate(start.getDate() + i);
-    dates.push(date.toISOString().split('T')[0]);
+    dates.push(formatLocalDate(date));
   }
 
   return dates;
 }
 
 export function getTodayDate(): string {
-  const today = new Date();
-  return today.toISOString().split('T')[0];
+  return formatLocalDate(new Date());
 }
 
 export type ScrapeMode = 'weekly' | 'from_today' | 'from_today_limited';

--- a/server/src/utils/date.test.ts
+++ b/server/src/utils/date.test.ts
@@ -220,6 +220,18 @@ describe('getCurrentWeekStart', () => {
     const date = new Date(weekStart + 'T00:00:00');
     expect(date.getDay()).toBe(3); // Wednesday
   });
+
+  it('should return the correct Wednesday even just after local midnight (timezone regression)', () => {
+    // Regression: toISOString() caused off-by-one when server TZ is UTC+N and
+    // local time is past midnight but UTC is still the previous day.
+    // Simulate Sunday 00:30 local (= Saturday 22:30 UTC in Europe/Paris UTC+2).
+    // The correct weekStart must still be the Wednesday of the current local week.
+    vi.setSystemTime(new Date('2026-05-09T22:30:00Z')); // Sunday 00:30 Paris
+    const weekStart = getCurrentWeekStart();
+    expect(weekStart).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    const date = new Date(weekStart + 'T00:00:00');
+    expect(date.getDay()).toBe(3); // Must be a Wednesday
+  });
 });
 
 describe('getTodayDate', () => {

--- a/server/src/utils/date.ts
+++ b/server/src/utils/date.ts
@@ -12,6 +12,18 @@
 
 import { logger } from '../utils/logger.js';
 
+/**
+ * Format a Date as YYYY-MM-DD using local time.
+ * Using toISOString() would convert to UTC first, causing off-by-one date
+ * errors in non-UTC timezones (e.g. Europe/Paris between 22:00–00:00 UTC).
+ */
+function formatLocalDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 export function getCurrentWeekStart(): string {
   const today = new Date();
   const dayOfWeek = today.getDay(); // 0 = Sunday, 3 = Wednesday
@@ -24,7 +36,7 @@ export function getCurrentWeekStart(): string {
   
   const wednesday = new Date(today);
   wednesday.setDate(today.getDate() - offset);
-  return wednesday.toISOString().split('T')[0];
+  return formatLocalDate(wednesday);
 }
 
 // Alias for getCurrentWeekStart
@@ -51,8 +63,7 @@ export function getWeekDates(weekStart?: string, numDays: number = 7): string[] 
 }
 
 export function getTodayDate(): string {
-  const today = new Date();
-  return today.toISOString().split('T')[0];
+  return formatLocalDate(new Date());
 }
 
 export type ScrapeMode = 'weekly' | 'from_today' | 'from_today_limited';


### PR DESCRIPTION
## Summary

- Replace toISOString().split('T')[0] with a local-time formatter in date utilities
- Fix affects getCurrentWeekStart, getTodayDate (server + scraper) and getWeekDates (scraper)
- Add regression test that catches the exact production failure window

## Why

When the server runs in Europe/Paris (UTC+2), getCurrentWeekStart() returned the wrong
Wednesday between 22:00 and 00:00 UTC each night. toISOString() serialises to UTC,
so a Date object holding Wednesday 00:30 local time is encoded as Tuesday 22:30 UTC —
shifting the result back one day. The /api/films endpoint then filtered on a week_start
that matched no scraped data, returning an empty film list despite the database being
populated. The bug was silent: no errors, just an empty response.

The existing getWeekStartForDate() function already used the correct local-time formatting
pattern; this fix applies the same approach to the remaining helpers.

## What Changed

- server/src/utils/date.ts: added formatLocalDate helper; applied to getCurrentWeekStart and getTodayDate
- scraper/src/utils/date.ts: same helper; also fixed getWeekDates which parsed weekStart strings without anchoring to T00:00:00
- server/src/utils/date.test.ts: added regression test simulating Sunday 00:30 Paris (= 22:30 UTC Saturday) to verify the result is always a Wednesday

## Scope

Only the three date utility files are changed. No schema, route, or service changes.

## Validation

```
cd server && npm run test:run -- src/utils/date.test.ts   # 25 passed
cd server && npm run test:run                              # 885 passed
cd scraper && npm run test:run                             # 209 passed (6 pre-existing failures unrelated to this change)
```

## Related

Closes #1011