### PR TITLE
test(scraper): fix 6 broken tests on develop

### DIFF
--- a/scraper/src/scraper/http-client.test.ts
+++ b/scraper/src/scraper/http-client.test.ts
@@ -60,11 +60,12 @@ describe('HTTP Client - Error Handling', () => {
 
     describe('HTTP 5xx Server Errors', () => {
       it('should throw HttpError on 503 response', async () => {
-        mockFetch.mockResolvedValueOnce({
-          ok: false,
-          status: 503,
-          statusText: 'Service Unavailable',
-        });
+        // 5xx errors are retried 3 times before throwing — mock all attempts
+        const response503 = { ok: false, status: 503, statusText: 'Service Unavailable' };
+        mockFetch
+          .mockResolvedValueOnce(response503)
+          .mockResolvedValueOnce(response503)
+          .mockResolvedValueOnce(response503);
 
         await expect(fetchShowtimesJson('C0072', '2026-03-24')).rejects.toThrow(
           HttpError
@@ -72,11 +73,12 @@ describe('HTTP Client - Error Handling', () => {
       });
 
       it('should preserve status code in HttpError for 500', async () => {
-        mockFetch.mockResolvedValueOnce({
-          ok: false,
-          status: 500,
-          statusText: 'Internal Server Error',
-        });
+        // 5xx errors are retried 3 times before throwing — mock all attempts
+        const response500 = { ok: false, status: 500, statusText: 'Internal Server Error' };
+        mockFetch
+          .mockResolvedValueOnce(response500)
+          .mockResolvedValueOnce(response500)
+          .mockResolvedValueOnce(response500);
 
         try {
           await fetchShowtimesJson('C0072', '2026-03-24');
@@ -165,11 +167,12 @@ describe('HTTP Client - Error Handling', () => {
 
     describe('HTTP 5xx Server Errors', () => {
       it('should throw HttpError on 500 response', async () => {
-        mockFetch.mockResolvedValueOnce({
-          ok: false,
-          status: 500,
-          statusText: 'Internal Server Error',
-        });
+        // 5xx errors are retried 3 times before throwing — mock all attempts
+        const response500 = { ok: false, status: 500, statusText: 'Internal Server Error' };
+        mockFetch
+          .mockResolvedValueOnce(response500)
+          .mockResolvedValueOnce(response500)
+          .mockResolvedValueOnce(response500);
 
         try {
           await fetchFilmPage(12345);

--- a/scraper/src/scraper/strategies/AllocineScraperStrategy.test.ts
+++ b/scraper/src/scraper/strategies/AllocineScraperStrategy.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   upsertWeeklyPrograms: vi.fn(),
   upsertFilm: vi.fn(),
   getFilm: vi.fn(),
+  getFilmsBatch: vi.fn(),
   fetchShowtimesJson: vi.fn(),
   fetchFilmPage: vi.fn(),
   fetchTheaterPage: vi.fn(),
@@ -27,6 +28,7 @@ vi.mock('../../db/showtime-queries.js', () => ({
 vi.mock('../../db/film-queries.js', () => ({
   upsertFilm: mocks.upsertFilm,
   getFilm: mocks.getFilm,
+  getFilmsBatch: mocks.getFilmsBatch,
 }));
 
 vi.mock('../http-client.js', () => ({
@@ -99,12 +101,14 @@ describe('AllocineScraperStrategy scrapeTheater detail refresh fallback', () => 
       },
     ]);
 
-    mocks.getFilm.mockResolvedValue({
-      duration_minutes: 120,
-      director: undefined,
-      screenwriters: ['Existing Writer'],
-      trailer_url: 'https://www.allocine.fr/video/player_gen_cmedia=99&cfilm=123.html',
-    });
+    mocks.getFilmsBatch.mockResolvedValue(new Map([
+      [123, {
+        duration_minutes: 120,
+        director: undefined,
+        screenwriters: ['Existing Writer'],
+        trailer_url: 'https://www.allocine.fr/video/player_gen_cmedia=99&cfilm=123.html',
+      }],
+    ]));
 
     mocks.fetchFilmPage.mockRejectedValue(new Error('Rate limit exceeded for film 123'));
     mocks.parseFilmPage.mockReturnValue({});


### PR DESCRIPTION
## Summary

- Fix 3 failures in AllocineScraperStrategy.test.ts caused by a missing getFilmsBatch mock
- Fix 3 failures in http-client.test.ts caused by under-mocked 5xx retry attempts

## Why

Both test files drifted out of sync with production code changes that landed on develop:
1. The strategy was refactored to use getFilmsBatch (batch DB lookup) but the test mock was never updated
2. fetchWithRetry was hardened to retry 5xx errors 3 times but tests only provided 1 mock response per test

## What Changed

**AllocineScraperStrategy.test.ts**
- Added getFilmsBatch to vi.hoisted mocks object
- Added getFilmsBatch to the vi.mock declaration for film-queries.js
- Replaced mocks.getFilm.mockResolvedValue({...}) with mocks.getFilmsBatch.mockResolvedValue(new Map([[123, {...}]])) in beforeEach

**http-client.test.ts**
- For each 5xx test: replaced single mockResolvedValueOnce with 3 chained mockResolvedValueOnce calls (one per retry attempt)
- Added inline comment explaining why 3 mocks are needed

## Validation

```
cd scraper && npm run test:run   # 215 passed (was 6 failed | 209 passed)
```

## Related

Closes #1013