### PR TITLE
feat: add Google Calendar event on showtime click (#1017)

### DIFF
--- a/client/src/components/ShowtimeList.tsx
+++ b/client/src/components/ShowtimeList.tsx
@@ -1,19 +1,43 @@
-import { useMemo, memo } from 'react';
+import { useMemo, memo, useCallback } from 'react';
 import type { Showtime } from '../types';
+import { toGoogleCalendarFormat } from '../utils/date';
 
 interface ShowtimeListProps {
   showtimes: Showtime[];
+  movieTitle?: string;
+  theaterName?: string;
+  theaterAddress?: string;
 }
 
-function ShowtimeList({ showtimes }: ShowtimeListProps) {
-  // Group showtimes by version (VF/VO)
-  // ⚡ PERFORMANCE: Memoize grouping logic to avoid re-calculation on every render
+function ShowtimeList({ showtimes, movieTitle, theaterName, theaterAddress }: ShowtimeListProps) {
   const showtimesByVersion = useMemo(() => showtimes.reduce((acc, showtime) => {
     const version = showtime.version || 'VF';
     if (!acc[version]) acc[version] = [];
     acc[version].push(showtime);
     return acc;
   }, {} as Record<string, Showtime[]>), [showtimes]);
+
+  const isActive = !!theaterName;
+
+  const handleClick = useCallback((showtime: Showtime) => {
+    if (!theaterName) return;
+
+    const title = movieTitle || `Séance au ${theaterName}`;
+    const dates = toGoogleCalendarFormat(showtime.datetime_iso);
+    const location = theaterAddress || theaterName;
+    const details = movieTitle
+      ? `Séance de ${movieTitle} au ${theaterName} - ${showtime.version || 'VF'}`
+      : `Séance au ${theaterName} - ${showtime.version || 'VF'}`;
+
+    const url = new URL('https://calendar.google.com/calendar/render');
+    url.searchParams.set('action', 'TEMPLATE');
+    url.searchParams.set('text', title);
+    url.searchParams.set('dates', dates);
+    url.searchParams.set('location', location);
+    url.searchParams.set('details', details);
+
+    window.open(url.toString(), '_blank', 'noopener,noreferrer');
+  }, [theaterName, movieTitle, theaterAddress]);
 
   const versionEntries = Object.entries(showtimesByVersion);
 
@@ -33,9 +57,14 @@ function ShowtimeList({ showtimes }: ShowtimeListProps) {
               <button
                 key={`${showtime.time}-${index}`}
                 type="button"
-                disabled
-                className="px-3 py-1 bg-gray-100 text-gray-500 rounded cursor-not-allowed text-sm font-medium opacity-70"
-                title="Fonctionnalité à venir"
+                disabled={!isActive}
+                onClick={() => handleClick(showtime)}
+                className={
+                  isActive
+                    ? 'px-3 py-1 bg-primary text-white rounded hover:bg-primary-dark transition text-sm font-medium cursor-pointer active:scale-95'
+                    : 'px-3 py-1 bg-gray-100 text-gray-500 rounded cursor-not-allowed text-sm font-medium opacity-70'
+                }
+                title={isActive ? `Ajouter au calendrier — ${showtime.time}` : 'Fonctionnalité à venir'}
               >
                 {showtime.time}
               </button>
@@ -47,6 +76,4 @@ function ShowtimeList({ showtimes }: ShowtimeListProps) {
   );
 }
 
-// ⚡ PERFORMANCE: Memoize component to prevent re-renders when parent re-renders
-// but showtimes data hasn't changed.
 export default memo(ShowtimeList);

--- a/client/src/components/TheaterShowtimes.tsx
+++ b/client/src/components/TheaterShowtimes.tsx
@@ -150,7 +150,11 @@ export default function TheaterShowtimes({ theaters, initialDate, initialAfterTi
             </div>
 
             <div className="pt-3 border-t border-gray-50">
-              <ShowtimeList showtimes={showtimes} />
+              <ShowtimeList
+                showtimes={showtimes}
+                theaterName={theater.name}
+                theaterAddress={theater.address && theater.city ? `${theater.address}, ${theater.city}` : theater.address || theater.city || theater.name}
+              />
             </div>
           </div>
         ))}

--- a/client/src/pages/TheaterPage.tsx
+++ b/client/src/pages/TheaterPage.tsx
@@ -250,7 +250,12 @@ export default function TheaterPage() {
                     </div>
 
                     <div className="pt-2 border-t border-gray-100">
-                      <ShowtimeList showtimes={showtimes} />
+                      <ShowtimeList
+                        showtimes={showtimes}
+                        movieTitle={movie.title}
+                        theaterName={theater.name}
+                        theaterAddress={theater.address && theater.city ? `${theater.address}, ${theater.postal_code || ''} ${theater.city}`.trim() : theater.address || theater.city || theater.name}
+                      />
                     </div>
                   </div>
                 </div>

--- a/client/src/utils/date.test.ts
+++ b/client/src/utils/date.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getUniqueDates, formatDateLabel } from './date';
+import { getUniqueDates, formatDateLabel, toGoogleCalendarFormat } from './date';
 
 describe('Date Utils', () => {
   describe('getUniqueDates', () => {
@@ -29,6 +29,33 @@ describe('Date Utils', () => {
       expect(label.day).toBe(18);
       expect(label.month.toLowerCase()).toContain('févr');
       expect(label.full.toLowerCase()).toContain('mercredi 18 février');
+    });
+  });
+
+  describe('toGoogleCalendarFormat', () => {
+    it('formats an ISO datetime with default 2h duration', () => {
+      const result = toGoogleCalendarFormat('2026-02-24T14:30:00.000Z');
+      expect(result).toBe('20260224T143000Z/20260224T163000Z');
+    });
+
+    it('formats with custom duration', () => {
+      const result = toGoogleCalendarFormat('2026-02-24T14:30:00.000Z', 90);
+      expect(result).toBe('20260224T143000Z/20260224T160000Z');
+    });
+
+    it('handles midnight correctly', () => {
+      const result = toGoogleCalendarFormat('2026-12-31T00:00:00.000Z', 60);
+      expect(result).toBe('20261231T000000Z/20261231T010000Z');
+    });
+
+    it('handles month boundary', () => {
+      const result = toGoogleCalendarFormat('2026-01-31T23:30:00.000Z', 60);
+      expect(result).toBe('20260131T233000Z/20260201T003000Z');
+    });
+
+    it('handles year boundary', () => {
+      const result = toGoogleCalendarFormat('2026-12-31T23:45:00.000Z', 30);
+      expect(result).toBe('20261231T234500Z/20270101T001500Z');
     });
   });
 });

--- a/client/src/utils/date.ts
+++ b/client/src/utils/date.ts
@@ -21,3 +21,15 @@ export const formatDateLabel = (dateStr: string) => {
     full: formatterFull.format(date),
   };
 };
+
+const pad = (n: number) => String(n).padStart(2, '0');
+
+export const toGoogleCalendarFormat = (datetimeIso: string, durationMinutes = 120): string => {
+  const start = new Date(datetimeIso);
+  const end = new Date(start.getTime() + durationMinutes * 60_000);
+
+  const fmt = (d: Date) =>
+    `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}T${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}Z`;
+
+  return `${fmt(start)}/${fmt(end)}`;
+};


### PR DESCRIPTION
## Summary
- Adds Google Calendar integration on showtime button click in `ShowtimeList`
- On the single-theater page (`TheaterPage`): full event with movie title, theater name/address, date/time, and version
- On the multi-theater homepage (`TheaterShowtimes`): event with theater info (movie title unavailable at this API level)
- 100% frontend, zero backend — uses Google Calendar URL schema

## Changes
- `utils/date.ts` — new `toGoogleCalendarFormat()` utility (+ tests)
- `ShowtimeList.tsx` — new optional props `movieTitle`, `theaterName`, `theaterAddress`; active button opens Google Calendar
- `TheaterShowtimes.tsx` — passes theater info to `ShowtimeList`
- `TheaterPage.tsx` — passes movie + theater info to `ShowtimeList`

## Verification
- `cd client && npx vitest run` — 543 tests passed
- `cd scraper && npm run test:run` — 215 tests passed

Closes #1017