### PR TITLE
fix(e2e): move vitest unit tests out of Playwright testDir to prevent worker crash

### DIFF
--- a/e2e-unit/fixtures/org-cleanup.test.ts
+++ b/e2e-unit/fixtures/org-cleanup.test.ts
@@ -13,7 +13,7 @@ describe('org-cleanup utilities', () => {
     const dir = await mkdtemp(path.join(tmpdir(), 'org-cleanup-test-'));
     process.env['ALLO_E2E_ORG_REGISTRY_DIR'] = dir;
 
-    const mod = await import('./org-cleanup');
+    const mod = await import('../../e2e/fixtures/org-cleanup');
 
     await mod.registerTestOrg({ orgId: 101, orgSlug: 'e2e-test-a', testId: 't-1', workerId: '1', createdAt: Date.now() });
     await mod.registerTestOrg({ orgId: 101, orgSlug: 'e2e-test-a', testId: 't-1', workerId: '1', createdAt: Date.now() });
@@ -37,7 +37,7 @@ describe('org-cleanup utilities', () => {
     const dir = await mkdtemp(path.join(tmpdir(), 'org-cleanup-test-'));
     process.env['ALLO_E2E_ORG_REGISTRY_DIR'] = dir;
 
-    const mod = await import('./org-cleanup');
+    const mod = await import('../../e2e/fixtures/org-cleanup');
     const now = Date.now();
 
     await mod.registerTestOrg({ orgId: 201, orgSlug: 'e2e-test-good', testId: 't-2', workerId: '2', createdAt: now - 1000 });
@@ -65,7 +65,7 @@ describe('org-cleanup utilities', () => {
     const dir = await mkdtemp(path.join(tmpdir(), 'org-cleanup-test-'));
     process.env['ALLO_E2E_ORG_REGISTRY_DIR'] = dir;
 
-    const mod = await import('./org-cleanup');
+    const mod = await import('../../e2e/fixtures/org-cleanup');
 
     await mod.registerTestOrg({ orgId: 301, orgSlug: 'e2e-test-1', testId: 't-3', workerId: '3', createdAt: Date.now() });
     await mod.registerTestOrg({ orgId: 302, orgSlug: 'e2e-test-2', testId: 't-3', workerId: '3', createdAt: Date.now() });
@@ -91,7 +91,7 @@ describe('org-cleanup utilities', () => {
     const dir = await mkdtemp(path.join(tmpdir(), 'org-cleanup-test-'));
     process.env['ALLO_E2E_ORG_REGISTRY_DIR'] = dir;
 
-    const mod = await import('./org-cleanup');
+    const mod = await import('../../e2e/fixtures/org-cleanup');
     const now = Date.now();
 
     await mod.registerTestOrg({ orgId: 401, orgSlug: 'e2e-test-orphan-a', testId: 't-4a', workerId: '4', createdAt: now - 500 });
@@ -119,7 +119,7 @@ describe('org-cleanup utilities', () => {
     const dir = await mkdtemp(path.join(tmpdir(), 'org-cleanup-test-'));
     process.env['ALLO_E2E_ORG_REGISTRY_DIR'] = dir;
 
-    const mod = await import('./org-cleanup');
+    const mod = await import('../../e2e/fixtures/org-cleanup');
     const now = Date.now();
 
     await mod.registerTestOrg({ orgId: 501, orgSlug: 'e2e-test-global-a', testId: 't-5a', workerId: '5', createdAt: now - 500 });
@@ -152,7 +152,7 @@ describe('org-cleanup utilities', () => {
     const dir = await mkdtemp(path.join(tmpdir(), 'org-cleanup-test-'));
     process.env['ALLO_E2E_ORG_REGISTRY_DIR'] = dir;
 
-    const mod = await import('./org-cleanup');
+    const mod = await import('../../e2e/fixtures/org-cleanup');
     const now = Date.now();
 
     await mod.registerTestOrg({ orgId: 601, orgSlug: 'e2e-test-dupe-a', testId: 't-6a', workerId: '6', createdAt: now - 500 });

--- a/e2e-unit/fixtures/org-fixture.test.ts
+++ b/e2e-unit/fixtures/org-fixture.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { assertFixtureCleanupSummary, assertFixtureRuntimeWithinLimit } from './org-fixture';
+import { assertFixtureCleanupSummary, assertFixtureRuntimeWithinLimit } from '../../e2e/fixtures/org-fixture';
 
 describe('org fixture assertions', () => {
   it('accepts runtime within the story threshold', () => {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "install:all": "npm install",
     "clean": "rm -rf server/dist client/dist scraper/dist server/node_modules client/node_modules scraper/node_modules node_modules package-lock.json client/package-lock.json server/package-lock.json scraper/package-lock.json",
     "test": "npm test --workspaces --if-present",
+    "test:e2e-unit": "vitest run e2e-unit",
     "e2e": "playwright test",
     "e2e:benchmark:parallel": "bash ./scripts/e2e-benchmark-parallel.sh",
     "e2e:headed": "playwright test --headed",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true
+  },
+  "include": ["e2e/**/*", "playwright.config.ts"]
+}


### PR DESCRIPTION
## Summary

- Playwright workers were crashing on boot with `TypeError: Cannot redefine property: Symbol($$jest-matchers-object)` — 0 tests ran, exit code 1
- Root cause: two Vitest unit tests inside `e2e/fixtures/` caused `@vitest/expect` to load inside Playwright workers before `testIgnore` filtering could exclude them
- Fix: relocate the two test files to `e2e-unit/fixtures/` (outside Playwright's `testDir`)

## Why

Playwright's ESM transform layer (`playwright/lib/transform/transform.js`) walks and loads **all** files in `testDir` during module resolution — before `testIgnore` is applied. `org-cleanup.test.ts` and `org-fixture.test.ts` import from `vitest`, which triggers `@vitest/expect` ESM top-level code to call `Object.defineProperty` on `Symbol($$jest-matchers-object)`. Playwright had already defined that symbol as non-configurable, so the redefinition throws, crashing both worker processes.

**Confirmed via ESM loader tracing:**
```
Parent: file:///…/e2e/fixtures/org-cleanup.test.ts
Specifier: vitest
```

## What Changed

- `e2e/fixtures/org-cleanup.test.ts` → `e2e-unit/fixtures/org-cleanup.test.ts` (relative imports updated)
- `e2e/fixtures/org-fixture.test.ts` → `e2e-unit/fixtures/org-fixture.test.ts` (relative imports updated)
- `package.json`: added `test:e2e-unit` script (`vitest run e2e-unit`)
- `tsconfig.json`: added root-level tsconfig scoped to `e2e/**/*` and `playwright.config.ts` for TS/editor tooling

## Scope

No changes to E2E test logic, fixture implementations (`org-fixture.ts`, `org-cleanup.ts`), or `playwright.config.ts`. Pure file relocation.

## Validation

```
npx playwright test --list          # 128 tests in 22 files — no crash
npx vitest run e2e-unit             # 2 files, 10 tests — all pass
```

## Related

Closes #1029