### PR TITLE
⚡ Bolt: Parallelize DB queries in reports endpoint

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -29,3 +29,7 @@
 ## 2024-05-24 - [Optimize groupShowtimesByCinema iteration]
 **Learning:** Destructuring with rest operator (`...`) is surprisingly slow compared to `Object.assign` combined with `delete` in V8 when cloning large arrays of objects, and using plain Objects instead of `Map` can be >2x faster in tight loops grouping thousands of objects.
 **Action:** In performance-critical loops processing arrays, prefer `Record<string, any>` maps, standard `for` loops, and `Object.assign` + `delete` over modern ES6 destructuring and `Map` collections.
+
+## 2026-05-14 - [Concurrent Report Queries in reports.ts]
+**Learning:** Sequential database queries for fetching a scrape report and its associated attempts (e.g., `getScrapeReport` then `getScrapeAttemptsByReport`) create a performance bottleneck in the `/api/reports/:id/details` endpoint. This is an architecture-specific issue that adds noticeable latency to the API route since both queries are independent.
+**Action:** Replaced sequential awaits in `GET /api/reports/:id/details` with a `Promise.all()` to fetch `report` and `attempts` concurrently, improving the endpoint's response time.

--- a/server/src/routes/reports.ts
+++ b/server/src/routes/reports.ts
@@ -95,14 +95,15 @@ router.get('/:id/details', protectedLimiter, requireAuth, requirePermission('rep
       return next(new ValidationError('Invalid report ID'));
     }
 
-    const report = await getScrapeReport(db, reportId);
+    // Fetch report and attempts concurrently for better performance
+    const [report, attempts] = await Promise.all([
+      getScrapeReport(db, reportId),
+      getScrapeAttemptsByReport(db, reportId)
+    ]);
 
     if (!report) {
       return next(new NotFoundError('Report not found'));
     }
-
-    // Get all attempts for this report
-    const attempts = await getScrapeAttemptsByReport(db, reportId);
 
     // Group attempts by cinema
     const attemptsByCinema: Record<string, any[]> = {};


### PR DESCRIPTION
💡 **What**: Refactored the `GET /api/reports/:id/details` endpoint to fetch the `ScrapeReport` and its associated `attempts` concurrently rather than sequentially.
🎯 **Why**: Sequential database queries that are independent (like `getScrapeReport` and `getScrapeAttemptsByReport`) create a performance bottleneck. Parallelizing them reduces the total DB roundtrip time to that of the slowest query, improving backend API latency.
📊 **Impact**: Decreases endpoint latency, especially noticeable under load or when the database connection has higher latency, reducing response time for the admin panel report views.
🔬 **Measurement**: Verified with the `server` test suite (`src/routes/reports.test.ts`), which continues to pass, ensuring that the endpoint handles existing behaviors correctly.

---
*PR created automatically by Jules for task [10095850493392902912](https://jules.google.com/task/10095850493392902912) started by @PhBassin*