### PR TITLE
⚡ Bolt: Parallelize report and attempts database queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -29,3 +29,6 @@
 ## 2024-05-24 - [Optimize groupShowtimesByCinema iteration]
 **Learning:** Destructuring with rest operator (`...`) is surprisingly slow compared to `Object.assign` combined with `delete` in V8 when cloning large arrays of objects, and using plain Objects instead of `Map` can be >2x faster in tight loops grouping thousands of objects.
 **Action:** In performance-critical loops processing arrays, prefer `Record<string, any>` maps, standard `for` loops, and `Object.assign` + `delete` over modern ES6 destructuring and `Map` collections.
+## 2026-05-15 - [Parallelize Independent DB Queries in Express Routes]
+**Learning:** Sequential await statements for independent database queries (e.g., fetching a parent record and its child records) inside Express route handlers introduce unnecessary latency equal to the sum of the queries' execution times. This is a common pattern in REST APIs that can be easily optimized.
+**Action:** When a route handler requires multiple database queries that do not depend on each other's results, wrap them in a `Promise.all` to execute them concurrently, reducing total latency to the maximum of the individual queries' execution times.

--- a/server/src/routes/reports.ts
+++ b/server/src/routes/reports.ts
@@ -95,14 +95,15 @@ router.get('/:id/details', protectedLimiter, requireAuth, requirePermission('rep
       return next(new ValidationError('Invalid report ID'));
     }
 
-    const report = await getScrapeReport(db, reportId);
+    // ⚡ Bolt: Execute independent queries concurrently
+    const [report, attempts] = await Promise.all([
+      getScrapeReport(db, reportId),
+      getScrapeAttemptsByReport(db, reportId)
+    ]);
 
     if (!report) {
       return next(new NotFoundError('Report not found'));
     }
-
-    // Get all attempts for this report
-    const attempts = await getScrapeAttemptsByReport(db, reportId);
 
     // Group attempts by cinema
     const attemptsByCinema: Record<string, any[]> = {};


### PR DESCRIPTION
💡 **What:**
Updated `server/src/routes/reports.ts` to execute `getScrapeReport` and `getScrapeAttemptsByReport` concurrently using `Promise.all()` instead of awaiting them sequentially.

🎯 **Why:**
The `/api/reports/:id/details` endpoint previously suffered from an unnecessary performance bottleneck because it fetched the parent report record and its associated attempts sequentially. Since the attempts query only relies on the `reportId` from the route params (and not the report result itself), these queries are entirely independent. Running them sequentially resulted in the total response latency being the sum of both queries. 

📊 **Impact:**
Reduces endpoint latency for the details view. Overall latency is reduced from `Time(reportQuery) + Time(attemptsQuery)` to `max(Time(reportQuery), Time(attemptsQuery))`. In environments with high database latency or large attempt datasets, this translates directly to faster page loads.

🔬 **Measurement:**
- Run `npm run test -w server` to ensure the route logic functions correctly.
- Verified in testing environment that all relevant tests pass.

---
*PR created automatically by Jules for task [3434884400181140428](https://jules.google.com/task/3434884400181140428) started by @PhBassin*