### PR TITLE
feat(client): add to calendar from showtime button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -538,7 +538,7 @@ cd server && npx vitest run src/services/scraper/theater-parser.test.ts
 cd server && npm run test:coverage
 
 # Manual pre-push check (same as the hook)
-cd server && npx tsc --noEmit && npm run test:run
+cd server && npx tsc -b && npm run test:run
 
 # Run scraper microservice tests
 cd scraper && npm test

--- a/client/src/components/CalendarPopover.test.tsx
+++ b/client/src/components/CalendarPopover.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CalendarPopover from './CalendarPopover';
+import type { Showtime, Film, Cinema } from '../types';
+
+const mockBuildGoogleCalendarUrl = vi.fn(() => 'https://calendar.google.com/calendar/render?action=TEMPLATE');
+const mockDownloadIcsFile = vi.fn();
+
+vi.mock('../utils/calendar', () => ({
+  buildGoogleCalendarUrl: (...args: unknown[]) => mockBuildGoogleCalendarUrl(...args),
+  downloadIcsFile: (...args: unknown[]) => mockDownloadIcsFile(...args),
+}));
+
+const showtime: Showtime = {
+  id: 'st-1',
+  film_id: 1,
+  cinema_id: 'C1',
+  date: '2026-05-20',
+  time: '20:30',
+  datetime_iso: '2026-05-20T20:30:00',
+  experiences: [],
+  week_start: '2026-05-18',
+};
+
+const film: Film = {
+  id: 1,
+  title: 'Film Test',
+  genres: [],
+  actors: [],
+  source_url: 'https://example.com',
+};
+
+const cinema: Cinema = {
+  id: 'C1',
+  name: 'Cinema Test',
+  city: 'Paris',
+};
+
+describe('CalendarPopover', () => {
+  const onClose = vi.fn();
+  const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+  let anchorButton: HTMLButtonElement;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    anchorButton = document.createElement('button');
+    anchorButton.getBoundingClientRect = vi.fn(() => ({
+      x: 100,
+      y: 200,
+      width: 80,
+      height: 32,
+      top: 200,
+      right: 180,
+      bottom: 232,
+      left: 100,
+      toJSON: () => ({}),
+    })) as unknown as typeof anchorButton.getBoundingClientRect;
+    document.body.appendChild(anchorButton);
+  });
+
+  afterEach(() => {
+    if (anchorButton.parentNode) {
+      anchorButton.parentNode.removeChild(anchorButton);
+    }
+  });
+
+  it('renders exactly two calendar actions', () => {
+    render(
+      <CalendarPopover
+        showtime={showtime}
+        film={film}
+        cinema={cinema}
+        anchorRef={{ current: anchorButton }}
+        onClose={onClose}
+      />
+    );
+
+    expect(screen.getByRole('menuitem', { name: /google calendar/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /apple \/ outlook/i })).toBeInTheDocument();
+    expect(screen.getAllByRole('menuitem')).toHaveLength(2);
+  });
+
+  it('opens Google Calendar URL and closes popover', () => {
+    render(
+      <CalendarPopover
+        showtime={showtime}
+        film={film}
+        cinema={cinema}
+        anchorRef={{ current: anchorButton }}
+        onClose={onClose}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /google calendar/i }));
+
+    expect(mockBuildGoogleCalendarUrl).toHaveBeenCalledWith(showtime, film, cinema);
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://calendar.google.com/calendar/render?action=TEMPLATE',
+      '_blank',
+      'noopener,noreferrer'
+    );
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('downloads .ics file for Apple/Outlook and closes popover', () => {
+    render(
+      <CalendarPopover
+        showtime={showtime}
+        film={film}
+        cinema={cinema}
+        anchorRef={{ current: anchorButton }}
+        onClose={onClose}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /apple \/ outlook/i }));
+
+    expect(mockDownloadIcsFile).toHaveBeenCalledWith(showtime, film, cinema);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/client/src/components/CalendarPopover.test.tsx
+++ b/client/src/components/CalendarPopover.test.tsx
@@ -3,12 +3,18 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import CalendarPopover from './CalendarPopover';
 import type { Showtime, Film, Cinema } from '../types';
 
-const mockBuildGoogleCalendarUrl = vi.fn(() => 'https://calendar.google.com/calendar/render?action=TEMPLATE');
-const mockDownloadIcsFile = vi.fn();
+const { mockBuildGoogleCalendarUrl, mockDownloadIcsFile } = vi.hoisted(() => ({
+  mockBuildGoogleCalendarUrl: vi.fn<
+    (showtime: Showtime, film: Film, cinema: Cinema) => string
+  >(() => 'https://calendar.google.com/calendar/render?action=TEMPLATE'),
+  mockDownloadIcsFile: vi.fn<
+    (showtime: Showtime, film: Film, cinema: Cinema) => void
+  >(),
+}));
 
 vi.mock('../utils/calendar', () => ({
-  buildGoogleCalendarUrl: (...args: unknown[]) => mockBuildGoogleCalendarUrl(...args),
-  downloadIcsFile: (...args: unknown[]) => mockDownloadIcsFile(...args),
+  buildGoogleCalendarUrl: mockBuildGoogleCalendarUrl,
+  downloadIcsFile: mockDownloadIcsFile,
 }));
 
 const showtime: Showtime = {

--- a/client/src/components/CalendarPopover.tsx
+++ b/client/src/components/CalendarPopover.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import type { Showtime, Film, Cinema } from '../types';
-import { buildGoogleCalendarUrl, downloadIcsFile } from '../utils/calendar';
+import { buildGoogleCalendarUrl, downloadIcsFile, openIcsInCalendar } from '../utils/calendar';
 
 interface CalendarPopoverProps {
   showtime: Showtime;
@@ -39,7 +39,7 @@ export default function CalendarPopover({ showtime, film, cinema, onClose }: Cal
   }
 
   function handleAppleCalendar() {
-    downloadIcsFile(showtime, film, cinema);
+    openIcsInCalendar(showtime, film, cinema);
     onClose();
   }
 

--- a/client/src/components/CalendarPopover.tsx
+++ b/client/src/components/CalendarPopover.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import type { Showtime, Film, Cinema } from '../types';
 import { buildGoogleCalendarUrl, downloadIcsFile, openIcsInCalendar } from '../utils/calendar';
 
@@ -6,22 +7,40 @@ interface CalendarPopoverProps {
   showtime: Showtime;
   film: Film;
   cinema: Cinema;
+  anchorRef: React.RefObject<HTMLButtonElement | null>;
   onClose: () => void;
 }
 
-export default function CalendarPopover({ showtime, film, cinema, onClose }: CalendarPopoverProps) {
+export default function CalendarPopover({ showtime, film, cinema, anchorRef, onClose }: CalendarPopoverProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
+  const [style, setStyle] = useState<React.CSSProperties>({ visibility: 'hidden' });
+
+  // Position the popover below the anchor button using getBoundingClientRect
+  useEffect(() => {
+    if (!anchorRef.current) return;
+    const rect = anchorRef.current.getBoundingClientRect();
+    setStyle({
+      position: 'fixed',
+      top: rect.bottom + 4,
+      left: rect.left,
+      zIndex: 9999,
+    });
+  }, [anchorRef]);
 
   // Close on outside click
   useEffect(() => {
-    function handlePointerDown(e: MouseEvent) {
-      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+    function handleMouseDown(e: MouseEvent) {
+      const target = e.target as Node;
+      if (
+        popoverRef.current && !popoverRef.current.contains(target) &&
+        anchorRef.current && !anchorRef.current.contains(target)
+      ) {
         onClose();
       }
     }
-    document.addEventListener('mousedown', handlePointerDown);
-    return () => document.removeEventListener('mousedown', handlePointerDown);
-  }, [onClose]);
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [onClose, anchorRef]);
 
   // Close on Escape key
   useEffect(() => {
@@ -48,12 +67,13 @@ export default function CalendarPopover({ showtime, film, cinema, onClose }: Cal
     onClose();
   }
 
-  return (
+  return createPortal(
     <div
       ref={popoverRef}
       role="menu"
       aria-label="Ajouter au calendrier"
-      className="absolute z-50 mt-1 bg-white border border-gray-200 rounded-xl shadow-lg py-1 min-w-[200px] animate-in fade-in zoom-in-95 duration-150"
+      style={style}
+      className="bg-white border border-gray-200 rounded-xl shadow-lg py-1 min-w-[200px] animate-in fade-in zoom-in-95 duration-150"
     >
       <button
         role="menuitem"
@@ -83,6 +103,7 @@ export default function CalendarPopover({ showtime, film, cinema, onClose }: Cal
         <span className="text-base leading-none" aria-hidden="true">⬇️</span>
         <span className="font-medium">Télécharger .ics</span>
       </button>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/client/src/components/CalendarPopover.tsx
+++ b/client/src/components/CalendarPopover.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import type { Showtime, Film, Cinema } from '../types';
-import { buildGoogleCalendarUrl, downloadIcsFile, openIcsInCalendar } from '../utils/calendar';
+import { buildGoogleCalendarUrl, downloadIcsFile } from '../utils/calendar';
 
 interface CalendarPopoverProps {
   showtime: Showtime;
@@ -57,11 +57,6 @@ export default function CalendarPopover({ showtime, film, cinema, anchorRef, onC
     onClose();
   }
 
-  function handleAppleCalendar() {
-    openIcsInCalendar(showtime, film, cinema);
-    onClose();
-  }
-
   function handleDownloadIcs() {
     downloadIcsFile(showtime, film, cinema);
     onClose();
@@ -86,22 +81,14 @@ export default function CalendarPopover({ showtime, film, cinema, anchorRef, onC
 
       <button
         role="menuitem"
-        onClick={handleAppleCalendar}
-        className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-left hover:bg-gray-50 transition cursor-pointer"
-      >
-        <span className="text-base leading-none" aria-hidden="true">🍎</span>
-        <span className="font-medium">Apple Calendar</span>
-      </button>
-
-      <div className="my-1 border-t border-gray-100" />
-
-      <button
-        role="menuitem"
         onClick={handleDownloadIcs}
         className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-left hover:bg-gray-50 transition cursor-pointer"
       >
-        <span className="text-base leading-none" aria-hidden="true">⬇️</span>
-        <span className="font-medium">Télécharger .ics</span>
+        <span className="text-base leading-none" aria-hidden="true">📁</span>
+        <div className="flex flex-col">
+          <span className="font-medium">Apple / Outlook</span>
+          <span className="text-xs text-gray-400">Télécharger le fichier .ics</span>
+        </div>
       </button>
     </div>,
     document.body

--- a/client/src/components/CalendarPopover.tsx
+++ b/client/src/components/CalendarPopover.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef } from 'react';
+import type { Showtime, Film, Cinema } from '../types';
+import { buildGoogleCalendarUrl, downloadIcsFile } from '../utils/calendar';
+
+interface CalendarPopoverProps {
+  showtime: Showtime;
+  film: Film;
+  cinema: Cinema;
+  onClose: () => void;
+}
+
+export default function CalendarPopover({ showtime, film, cinema, onClose }: CalendarPopoverProps) {
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    function handlePointerDown(e: MouseEvent) {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    document.addEventListener('mousedown', handlePointerDown);
+    return () => document.removeEventListener('mousedown', handlePointerDown);
+  }, [onClose]);
+
+  // Close on Escape key
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  function handleGoogleCalendar() {
+    const url = buildGoogleCalendarUrl(showtime, film, cinema);
+    window.open(url, '_blank', 'noopener,noreferrer');
+    onClose();
+  }
+
+  function handleAppleCalendar() {
+    downloadIcsFile(showtime, film, cinema);
+    onClose();
+  }
+
+  function handleDownloadIcs() {
+    downloadIcsFile(showtime, film, cinema);
+    onClose();
+  }
+
+  return (
+    <div
+      ref={popoverRef}
+      role="menu"
+      aria-label="Ajouter au calendrier"
+      className="absolute z-50 mt-1 bg-white border border-gray-200 rounded-xl shadow-lg py-1 min-w-[200px] animate-in fade-in zoom-in-95 duration-150"
+    >
+      <button
+        role="menuitem"
+        onClick={handleGoogleCalendar}
+        className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-left hover:bg-gray-50 transition cursor-pointer"
+      >
+        <span className="text-base leading-none" aria-hidden="true">📅</span>
+        <span className="font-medium">Google Calendar</span>
+      </button>
+
+      <button
+        role="menuitem"
+        onClick={handleAppleCalendar}
+        className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-left hover:bg-gray-50 transition cursor-pointer"
+      >
+        <span className="text-base leading-none" aria-hidden="true">🍎</span>
+        <span className="font-medium">Apple Calendar</span>
+      </button>
+
+      <div className="my-1 border-t border-gray-100" />
+
+      <button
+        role="menuitem"
+        onClick={handleDownloadIcs}
+        className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-left hover:bg-gray-50 transition cursor-pointer"
+      >
+        <span className="text-base leading-none" aria-hidden="true">⬇️</span>
+        <span className="font-medium">Télécharger .ics</span>
+      </button>
+    </div>
+  );
+}

--- a/client/src/components/CinemaShowtimes.test.tsx
+++ b/client/src/components/CinemaShowtimes.test.tsx
@@ -3,7 +3,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import CinemaShowtimes from './CinemaShowtimes';
-import type { CinemaWithShowtimes } from '../types';
+import type { CinemaWithShowtimes, Film } from '../types';
+
+const mockFilm: Film = {
+  id: 1,
+  title: 'Test Film',
+  genres: [],
+  actors: [],
+  source_url: 'https://example.com',
+};
 
 const mockCinemas: CinemaWithShowtimes[] = [
   {
@@ -33,13 +41,13 @@ const renderWithRouter = (ui: React.ReactElement) => {
 
 describe('CinemaShowtimes Component', () => {
   it('renders empty state when no cinemas provided', () => {
-    renderWithRouter(<CinemaShowtimes cinemas={[]} />);
+    renderWithRouter(<CinemaShowtimes cinemas={[]} film={mockFilm} />);
     expect(screen.getByText(/Aucune séance disponible/i)).toBeInTheDocument();
   });
 
   it('renders cinemas and showtimes for the default date', () => {
     // Set fixed today date for tests if needed, but here we can just rely on the first date in the list
-    renderWithRouter(<CinemaShowtimes cinemas={mockCinemas} />);
+    renderWithRouter(<CinemaShowtimes cinemas={mockCinemas} film={mockFilm} />);
     
     expect(screen.getByText('Cinema 1')).toBeInTheDocument();
     expect(screen.getByText('Cinema 2')).toBeInTheDocument();
@@ -49,7 +57,7 @@ describe('CinemaShowtimes Component', () => {
   });
 
   it('changes showtimes when a different date is selected', () => {
-    renderWithRouter(<CinemaShowtimes cinemas={mockCinemas} />);
+    renderWithRouter(<CinemaShowtimes cinemas={mockCinemas} film={mockFilm} />);
     
     // Find the button for Feb 19
     const dateButton = screen.getByText('19').closest('button');
@@ -64,7 +72,7 @@ describe('CinemaShowtimes Component', () => {
   });
 
   it('renders initialDate if provided', () => {
-    renderWithRouter(<CinemaShowtimes cinemas={mockCinemas} initialDate="2026-02-19" />);
+    renderWithRouter(<CinemaShowtimes cinemas={mockCinemas} film={mockFilm} initialDate="2026-02-19" />);
     
     expect(screen.getByText('16:00')).toBeInTheDocument();
     expect(screen.queryByText('14:00')).not.toBeInTheDocument();
@@ -84,7 +92,7 @@ describe('CinemaShowtimes Component', () => {
       } as any
     ];
 
-    renderWithRouter(<CinemaShowtimes cinemas={singleDateCinemas} />);
+    renderWithRouter(<CinemaShowtimes cinemas={singleDateCinemas} film={mockFilm} />);
     
     // Date selector should be visible
     expect(screen.getByText('18')).toBeInTheDocument(); // Day number
@@ -107,7 +115,7 @@ describe('CinemaShowtimes Component', () => {
       } as any
     ];
 
-    renderWithRouter(<CinemaShowtimes cinemas={singleDateCinemas} />);
+    renderWithRouter(<CinemaShowtimes cinemas={singleDateCinemas} film={mockFilm} />);
     
     // Should display the date button with correct format
     const dateButton = screen.getByText('18').closest('button');
@@ -156,7 +164,7 @@ describe('CinemaShowtimes — bouton Maintenant', () => {
   });
 
   it('renders the Maintenant button as the first button', () => {
-    renderWithRouter(<CinemaShowtimes cinemas={cinemasWithToday} />);
+    renderWithRouter(<CinemaShowtimes cinemas={cinemasWithToday} film={mockFilm} />);
     const buttons = screen.getAllByRole('button');
     expect(buttons[0]).toHaveTextContent(/maintenant/i);
   });
@@ -173,12 +181,12 @@ describe('CinemaShowtimes — bouton Maintenant', () => {
         ],
       } as any,
     ];
-    renderWithRouter(<CinemaShowtimes cinemas={notoday} />);
+    renderWithRouter(<CinemaShowtimes cinemas={notoday} film={mockFilm} />);
     expect(screen.getByRole('button', { name: /maintenant/i })).toBeDisabled();
   });
 
   it('filters out showtimes before current time when Maintenant is clicked', () => {
-    renderWithRouter(<CinemaShowtimes cinemas={cinemasWithToday} />);
+    renderWithRouter(<CinemaShowtimes cinemas={cinemasWithToday} film={mockFilm} />);
 
     // Initially today is selected — all three today's showtimes visible
     expect(screen.getByText('14:00')).toBeInTheDocument();
@@ -194,7 +202,7 @@ describe('CinemaShowtimes — bouton Maintenant', () => {
   });
 
   it('resets time filter when another date button is clicked after Maintenant', () => {
-    renderWithRouter(<CinemaShowtimes cinemas={cinemasWithToday} />);
+    renderWithRouter(<CinemaShowtimes cinemas={cinemasWithToday} film={mockFilm} />);
 
     fireEvent.click(screen.getByRole('button', { name: /maintenant/i }));
     expect(screen.queryByText('14:00')).not.toBeInTheDocument();

--- a/client/src/components/CinemaShowtimes.tsx
+++ b/client/src/components/CinemaShowtimes.tsx
@@ -1,16 +1,17 @@
 import { useState, useMemo, useCallback } from 'react';
-import type { CinemaWithShowtimes } from '../types';
+import type { CinemaWithShowtimes, Film } from '../types';
 import ShowtimeList from './ShowtimeList';
 import { Link } from 'react-router-dom';
 import { getUniqueDates, formatDateLabel } from '../utils/date';
 
 interface CinemaShowtimesProps {
   cinemas: CinemaWithShowtimes[];
+  film: Film;
   initialDate?: string;
   initialAfterTime?: string | null;
 }
 
-export default function CinemaShowtimes({ cinemas, initialDate, initialAfterTime }: CinemaShowtimesProps) {
+export default function CinemaShowtimes({ cinemas, film, initialDate, initialAfterTime }: CinemaShowtimesProps) {
   const allShowtimes = useMemo(() => 
     cinemas.flatMap(c => c.showtimes),
     [cinemas]
@@ -150,7 +151,7 @@ export default function CinemaShowtimes({ cinemas, initialDate, initialAfterTime
             </div>
 
             <div className="pt-3 border-t border-gray-50">
-              <ShowtimeList showtimes={showtimes} />
+              <ShowtimeList showtimes={showtimes} film={film} cinema={cinema} />
             </div>
           </div>
         ))}

--- a/client/src/components/FilmCard.tsx
+++ b/client/src/components/FilmCard.tsx
@@ -127,7 +127,7 @@ function FilmCard({ film, isNew = false, initialAfterTime }: FilmCardProps) {
 
           {showSchedule && (
             <div className="mt-2 animate-in fade-in slide-in-from-top-2 duration-300">
-              <CinemaShowtimes cinemas={film.cinemas} initialAfterTime={initialAfterTime} />
+              <CinemaShowtimes cinemas={film.cinemas} film={film} initialAfterTime={initialAfterTime} />
             </div>
           )}
         </div>

--- a/client/src/components/ShowtimeList.tsx
+++ b/client/src/components/ShowtimeList.tsx
@@ -1,4 +1,4 @@
-import { useMemo, memo, useState, useCallback, useRef } from 'react';
+import { useMemo, memo, useState, useCallback } from 'react';
 import type { Showtime, Film, Cinema } from '../types';
 import CalendarPopover from './CalendarPopover';
 
@@ -9,10 +9,8 @@ interface ShowtimeListProps {
 }
 
 function ShowtimeList({ showtimes, film, cinema }: ShowtimeListProps) {
-  // Track which showtime button has its popover open (by index key)
+  // Track which showtime button has its popover open (by unique key)
   const [openKey, setOpenKey] = useState<string | null>(null);
-  // Keep a ref to the wrapper of the open button for positioning
-  const buttonWrapperRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
   // Group showtimes by version (VF/VO)
   // ⚡ PERFORMANCE: Memoize grouping logic to avoid re-calculation on every render
@@ -46,17 +44,13 @@ function ShowtimeList({ showtimes, film, cinema }: ShowtimeListProps) {
           <p className="text-sm font-semibold text-gray-700 mb-2">{version}</p>
           <div className="flex flex-wrap gap-2">
             {versionShowtimes.map((showtime, index) => {
-              const key = `${showtime.time}-${index}`;
+              const key = `${version}-${showtime.time}-${index}`;
               const isOpen = openKey === key;
 
               return (
                 <div
                   key={key}
                   className="relative"
-                  ref={(el) => {
-                    if (el) buttonWrapperRefs.current.set(key, el);
-                    else buttonWrapperRefs.current.delete(key);
-                  }}
                 >
                   <button
                     type="button"

--- a/client/src/components/ShowtimeList.tsx
+++ b/client/src/components/ShowtimeList.tsx
@@ -1,11 +1,19 @@
-import { useMemo, memo } from 'react';
-import type { Showtime } from '../types';
+import { useMemo, memo, useState, useCallback, useRef } from 'react';
+import type { Showtime, Film, Cinema } from '../types';
+import CalendarPopover from './CalendarPopover';
 
 interface ShowtimeListProps {
   showtimes: Showtime[];
+  film: Film;
+  cinema: Cinema;
 }
 
-function ShowtimeList({ showtimes }: ShowtimeListProps) {
+function ShowtimeList({ showtimes, film, cinema }: ShowtimeListProps) {
+  // Track which showtime button has its popover open (by index key)
+  const [openKey, setOpenKey] = useState<string | null>(null);
+  // Keep a ref to the wrapper of the open button for positioning
+  const buttonWrapperRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+
   // Group showtimes by version (VF/VO)
   // ⚡ PERFORMANCE: Memoize grouping logic to avoid re-calculation on every render
   const showtimesByVersion = useMemo(() => showtimes.reduce((acc, showtime) => {
@@ -16,6 +24,14 @@ function ShowtimeList({ showtimes }: ShowtimeListProps) {
   }, {} as Record<string, Showtime[]>), [showtimes]);
 
   const versionEntries = Object.entries(showtimesByVersion);
+
+  const handleToggle = useCallback((key: string) => {
+    setOpenKey(prev => (prev === key ? null : key));
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setOpenKey(null);
+  }, []);
 
   if (versionEntries.length === 0) {
     return (
@@ -29,17 +45,44 @@ function ShowtimeList({ showtimes }: ShowtimeListProps) {
         <div key={version} className="border-l-4 border-primary pl-3">
           <p className="text-sm font-semibold text-gray-700 mb-2">{version}</p>
           <div className="flex flex-wrap gap-2">
-            {versionShowtimes.map((showtime, index) => (
-              <button
-                key={`${showtime.time}-${index}`}
-                type="button"
-                disabled
-                className="px-3 py-1 bg-gray-100 text-gray-500 rounded cursor-not-allowed text-sm font-medium opacity-70"
-                title="Fonctionnalité à venir"
-              >
-                {showtime.time}
-              </button>
-            ))}
+            {versionShowtimes.map((showtime, index) => {
+              const key = `${showtime.time}-${index}`;
+              const isOpen = openKey === key;
+
+              return (
+                <div
+                  key={key}
+                  className="relative"
+                  ref={(el) => {
+                    if (el) buttonWrapperRefs.current.set(key, el);
+                    else buttonWrapperRefs.current.delete(key);
+                  }}
+                >
+                  <button
+                    type="button"
+                    onClick={() => handleToggle(key)}
+                    aria-haspopup="menu"
+                    aria-expanded={isOpen}
+                    className={`px-3 py-1 rounded text-sm font-medium transition active:scale-95 cursor-pointer ${
+                      isOpen
+                        ? 'bg-primary text-black shadow-sm'
+                        : 'bg-gray-100 text-gray-700 hover:bg-yellow-100 hover:text-black'
+                    }`}
+                  >
+                    {showtime.time}
+                  </button>
+
+                  {isOpen && (
+                    <CalendarPopover
+                      showtime={showtime}
+                      film={film}
+                      cinema={cinema}
+                      onClose={handleClose}
+                    />
+                  )}
+                </div>
+              );
+            })}
           </div>
         </div>
       ))}

--- a/client/src/components/ShowtimeList.tsx
+++ b/client/src/components/ShowtimeList.tsx
@@ -1,4 +1,4 @@
-import { useMemo, memo, useState, useCallback } from 'react';
+import { useMemo, memo, useState, useCallback, useRef } from 'react';
 import type { Showtime, Film, Cinema } from '../types';
 import CalendarPopover from './CalendarPopover';
 
@@ -9,11 +9,9 @@ interface ShowtimeListProps {
 }
 
 function ShowtimeList({ showtimes, film, cinema }: ShowtimeListProps) {
-  // Track which showtime button has its popover open (by unique key)
   const [openKey, setOpenKey] = useState<string | null>(null);
+  const buttonRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
 
-  // Group showtimes by version (VF/VO)
-  // ⚡ PERFORMANCE: Memoize grouping logic to avoid re-calculation on every render
   const showtimesByVersion = useMemo(() => showtimes.reduce((acc, showtime) => {
     const version = showtime.version || 'VF';
     if (!acc[version]) acc[version] = [];
@@ -46,14 +44,16 @@ function ShowtimeList({ showtimes, film, cinema }: ShowtimeListProps) {
             {versionShowtimes.map((showtime, index) => {
               const key = `${version}-${showtime.time}-${index}`;
               const isOpen = openKey === key;
+              const anchorRef = { current: buttonRefs.current.get(key) ?? null };
 
               return (
-                <div
-                  key={key}
-                  className="relative"
-                >
+                <div key={key} className="relative">
                   <button
                     type="button"
+                    ref={(el) => {
+                      if (el) buttonRefs.current.set(key, el);
+                      else buttonRefs.current.delete(key);
+                    }}
                     onClick={() => handleToggle(key)}
                     aria-haspopup="menu"
                     aria-expanded={isOpen}
@@ -71,6 +71,7 @@ function ShowtimeList({ showtimes, film, cinema }: ShowtimeListProps) {
                       showtime={showtime}
                       film={film}
                       cinema={cinema}
+                      anchorRef={anchorRef}
                       onClose={handleClose}
                     />
                   )}
@@ -84,6 +85,4 @@ function ShowtimeList({ showtimes, film, cinema }: ShowtimeListProps) {
   );
 }
 
-// ⚡ PERFORMANCE: Memoize component to prevent re-renders when parent re-renders
-// but showtimes data hasn't changed.
 export default memo(ShowtimeList);

--- a/client/src/pages/CinemaPage.tsx
+++ b/client/src/pages/CinemaPage.tsx
@@ -3,6 +3,8 @@ import { useParams, Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { getCinemas, getCinemaSchedule } from '../api/client';
 import type { ShowtimeWithFilm, Film } from '../types';
+import ShowtimeList from '../components/ShowtimeList';
+import CinemaDateSelector from '../components/CinemaDateSelector';
 
 interface FilmGroup {
   film: Film;

--- a/client/src/pages/CinemaPage.tsx
+++ b/client/src/pages/CinemaPage.tsx
@@ -243,7 +243,7 @@ export default function CinemaPage() {
                     </div>
 
                     <div className="pt-2 border-t border-gray-100">
-                      <ShowtimeList showtimes={showtimes} />
+                      <ShowtimeList showtimes={showtimes} film={film} cinema={cinema} />
                     </div>
                   </div>
                 </div>

--- a/client/src/pages/CinemaPage.tsx
+++ b/client/src/pages/CinemaPage.tsx
@@ -2,21 +2,10 @@ import { useState, useMemo, useCallback } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { getCinemas, getCinemaSchedule } from '../api/client';
-import type { ShowtimeWithFilm } from '../types';
-import ShowtimeList from '../components/ShowtimeList';
-import CinemaDateSelector from '../components/CinemaDateSelector';
+import type { ShowtimeWithFilm, Film } from '../types';
 
 interface FilmGroup {
-  film: {
-    id: number;
-    title: string;
-    poster_url?: string;
-    duration_minutes?: number;
-    genres?: string[];
-    director?: string;
-    press_rating?: number;
-    audience_rating?: number;
-  };
+  film: Film;
   showtimes: ShowtimeWithFilm[];
 }
 

--- a/client/src/pages/FilmPage.tsx
+++ b/client/src/pages/FilmPage.tsx
@@ -128,7 +128,7 @@ export default function FilmPage() {
             <h2 className="text-2xl font-bold mb-4 flex items-center gap-2">
               <span>📅 Horaires et Cinémas</span>
             </h2>
-            <CinemaShowtimes cinemas={film.cinemas} />
+            <CinemaShowtimes cinemas={film.cinemas} film={film} />
           </section>
 
           {/* Synopsis Section */}

--- a/client/src/utils/calendar.test.ts
+++ b/client/src/utils/calendar.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { buildGoogleCalendarUrl, buildIcsContent } from './calendar';
+import type { Showtime, Film, Cinema } from '../types';
+
+const baseShowtime: Showtime = {
+  id: 'st-1',
+  film_id: 42,
+  cinema_id: 'C0001',
+  date: '2026-05-20',
+  time: '20:30',
+  datetime_iso: '2026-05-20T20:30:00',
+  version: 'VF',
+  format: 'Standard',
+  experiences: [],
+  week_start: '2026-05-18',
+};
+
+const baseFilm: Film = {
+  id: 42,
+  title: 'Mon Film Test',
+  genres: [],
+  actors: [],
+  source_url: 'https://example.com',
+  duration_minutes: 90,
+};
+
+const baseCinema: Cinema = {
+  id: 'C0001',
+  name: 'Cinéma Test',
+  address: '10 rue du Cinéma',
+  city: 'Paris',
+};
+
+describe('buildGoogleCalendarUrl', () => {
+  it('returns a valid Google Calendar URL', () => {
+    const url = buildGoogleCalendarUrl(baseShowtime, baseFilm, baseCinema);
+    expect(url).toContain('https://calendar.google.com/calendar/render');
+    expect(url).toContain('action=TEMPLATE');
+  });
+
+  it('encodes the film title in the URL', () => {
+    const url = buildGoogleCalendarUrl(baseShowtime, baseFilm, baseCinema);
+    expect(url).toContain(encodeURIComponent('Mon Film Test'));
+  });
+
+  it('uses correct start date from datetime_iso', () => {
+    const url = buildGoogleCalendarUrl(baseShowtime, baseFilm, baseCinema);
+    // 2026-05-20T20:30:00 → 20260520T203000
+    expect(url).toContain('20260520T203000');
+  });
+
+  it('calculates end time using duration_minutes', () => {
+    const url = buildGoogleCalendarUrl(baseShowtime, baseFilm, baseCinema);
+    // 20:30 + 90min = 22:00 → 20260520T220000
+    expect(url).toContain('20260520T220000');
+  });
+
+  it('defaults end time to +2h when duration_minutes is null', () => {
+    const film = { ...baseFilm, duration_minutes: undefined };
+    const url = buildGoogleCalendarUrl(baseShowtime, film, baseCinema);
+    // 20:30 + 120min = 22:30 → 20260520T223000
+    expect(url).toContain('20260520T223000');
+  });
+
+  it('includes cinema name and address as location', () => {
+    const url = buildGoogleCalendarUrl(baseShowtime, baseFilm, baseCinema);
+    expect(url).toContain(encodeURIComponent('Cinéma Test'));
+    expect(url).toContain(encodeURIComponent('10 rue du Cinéma'));
+  });
+
+  it('uses cinema name only when address is missing', () => {
+    const cinema = { ...baseCinema, address: undefined };
+    const url = buildGoogleCalendarUrl(baseShowtime, baseFilm, cinema);
+    expect(url).toContain(encodeURIComponent('Cinéma Test'));
+    expect(url).not.toContain(encodeURIComponent('10 rue du Cinéma'));
+  });
+});
+
+describe('buildIcsContent', () => {
+  it('returns a string starting with BEGIN:VCALENDAR', () => {
+    const ics = buildIcsContent(baseShowtime, baseFilm, baseCinema);
+    expect(ics).toMatch(/^BEGIN:VCALENDAR/);
+  });
+
+  it('contains BEGIN:VEVENT and END:VEVENT', () => {
+    const ics = buildIcsContent(baseShowtime, baseFilm, baseCinema);
+    expect(ics).toContain('BEGIN:VEVENT');
+    expect(ics).toContain('END:VEVENT');
+  });
+
+  it('contains correct DTSTART', () => {
+    const ics = buildIcsContent(baseShowtime, baseFilm, baseCinema);
+    expect(ics).toContain('DTSTART:20260520T203000');
+  });
+
+  it('contains correct DTEND with duration', () => {
+    const ics = buildIcsContent(baseShowtime, baseFilm, baseCinema);
+    // 20:30 + 90min = 22:00
+    expect(ics).toContain('DTEND:20260520T220000');
+  });
+
+  it('defaults DTEND to +2h when duration_minutes is null', () => {
+    const film = { ...baseFilm, duration_minutes: undefined };
+    const ics = buildIcsContent(baseShowtime, film, baseCinema);
+    // 20:30 + 120min = 22:30
+    expect(ics).toContain('DTEND:20260520T223000');
+  });
+
+  it('contains film title as SUMMARY', () => {
+    const ics = buildIcsContent(baseShowtime, baseFilm, baseCinema);
+    expect(ics).toContain('SUMMARY:Mon Film Test');
+  });
+
+  it('contains cinema name and address as LOCATION', () => {
+    const ics = buildIcsContent(baseShowtime, baseFilm, baseCinema);
+    expect(ics).toContain('LOCATION:Cinéma Test, 10 rue du Cinéma');
+  });
+
+  it('uses cinema name only as LOCATION when address is missing', () => {
+    const cinema = { ...baseCinema, address: undefined };
+    const ics = buildIcsContent(baseShowtime, baseFilm, cinema);
+    expect(ics).toContain('LOCATION:Cinéma Test');
+    expect(ics).not.toContain('LOCATION:Cinéma Test,');
+  });
+
+  it('ends with END:VCALENDAR', () => {
+    const ics = buildIcsContent(baseShowtime, baseFilm, baseCinema);
+    expect(ics.trim()).toMatch(/END:VCALENDAR$/);
+  });
+});

--- a/client/src/utils/calendar.test.ts
+++ b/client/src/utils/calendar.test.ts
@@ -115,9 +115,10 @@ describe('buildIcsContent', () => {
     expect(ics).toContain('SUMMARY:Mon Film Test');
   });
 
-  it('contains cinema name and address as LOCATION', () => {
+  it('contains cinema name and address as LOCATION (RFC 5545 escaped)', () => {
     const ics = buildIcsContent(baseShowtime, baseFilm, baseCinema);
-    expect(ics).toContain('LOCATION:Cinéma Test, 10 rue du Cinéma');
+    // RFC 5545 requires commas to be escaped as \,
+    expect(ics).toContain('LOCATION:Cinéma Test\\, 10 rue du Cinéma');
   });
 
   it('uses cinema name only as LOCATION when address is missing', () => {

--- a/client/src/utils/calendar.test.ts
+++ b/client/src/utils/calendar.test.ts
@@ -40,7 +40,8 @@ describe('buildGoogleCalendarUrl', () => {
 
   it('encodes the film title in the URL', () => {
     const url = buildGoogleCalendarUrl(baseShowtime, baseFilm, baseCinema);
-    expect(url).toContain(encodeURIComponent('Mon Film Test'));
+    const decoded = decodeURIComponent(url.replace(/\+/g, ' '));
+    expect(decoded).toContain('Mon Film Test');
   });
 
   it('uses correct start date from datetime_iso', () => {
@@ -64,15 +65,18 @@ describe('buildGoogleCalendarUrl', () => {
 
   it('includes cinema name and address as location', () => {
     const url = buildGoogleCalendarUrl(baseShowtime, baseFilm, baseCinema);
-    expect(url).toContain(encodeURIComponent('Cinéma Test'));
-    expect(url).toContain(encodeURIComponent('10 rue du Cinéma'));
+    // URLSearchParams uses + for spaces; decode the URL to check values
+    const decoded = decodeURIComponent(url.replace(/\+/g, ' '));
+    expect(decoded).toContain('Cinéma Test');
+    expect(decoded).toContain('10 rue du Cinéma');
   });
 
   it('uses cinema name only when address is missing', () => {
     const cinema = { ...baseCinema, address: undefined };
     const url = buildGoogleCalendarUrl(baseShowtime, baseFilm, cinema);
-    expect(url).toContain(encodeURIComponent('Cinéma Test'));
-    expect(url).not.toContain(encodeURIComponent('10 rue du Cinéma'));
+    const decoded = decodeURIComponent(url.replace(/\+/g, ' '));
+    expect(decoded).toContain('Cinéma Test');
+    expect(decoded).not.toContain('10 rue du Cinéma');
   });
 });
 

--- a/client/src/utils/calendar.ts
+++ b/client/src/utils/calendar.ts
@@ -1,0 +1,106 @@
+import type { Showtime, Film, Cinema } from '../types';
+
+/**
+ * Convert an ISO 8601 datetime string to compact YYYYMMDDTHHMMSS format for calendar use.
+ * Strips hyphens, colons, and trailing 'Z'.
+ */
+function toCompactDateTime(isoString: string): string {
+  return isoString.replace(/[-:]/g, '').replace(/\.\d+Z?$/, '').replace('Z', '');
+}
+
+/**
+ * Add minutes to an ISO 8601 datetime string and return the result as compact YYYYMMDDTHHMMSS.
+ */
+function addMinutesToIso(isoString: string, minutes: number): string {
+  const date = new Date(isoString);
+  date.setMinutes(date.getMinutes() + minutes);
+  // Format manually to avoid timezone conversion — keep local representation
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const mins = String(date.getMinutes()).padStart(2, '0');
+  const secs = String(date.getSeconds()).padStart(2, '0');
+  return `${year}${month}${day}T${hours}${mins}${secs}`;
+}
+
+function buildLocation(cinema: Cinema): string {
+  if (cinema.address) {
+    return `${cinema.name}, ${cinema.address}`;
+  }
+  return cinema.name;
+}
+
+function buildDetails(showtime: Showtime): string {
+  const parts: string[] = [];
+  if (showtime.version) parts.push(showtime.version);
+  if (showtime.format) parts.push(showtime.format);
+  return parts.join(' ');
+}
+
+/**
+ * Build a Google Calendar "add event" URL.
+ * Opens in a new tab with the event pre-filled.
+ */
+export function buildGoogleCalendarUrl(showtime: Showtime, film: Film, cinema: Cinema): string {
+  const durationMinutes = film.duration_minutes ?? 120;
+  const dtStart = toCompactDateTime(showtime.datetime_iso);
+  const dtEnd = addMinutesToIso(showtime.datetime_iso, durationMinutes);
+  const location = buildLocation(cinema);
+  const details = buildDetails(showtime);
+
+  const params = new URLSearchParams({
+    action: 'TEMPLATE',
+    text: film.title,
+    dates: `${dtStart}/${dtEnd}`,
+    location,
+    details,
+  });
+
+  return `https://calendar.google.com/calendar/render?${params.toString()}`;
+}
+
+/**
+ * Build the text content of an RFC 5545 .ics file for a single event.
+ */
+export function buildIcsContent(showtime: Showtime, film: Film, cinema: Cinema): string {
+  const durationMinutes = film.duration_minutes ?? 120;
+  const dtStart = toCompactDateTime(showtime.datetime_iso);
+  const dtEnd = addMinutesToIso(showtime.datetime_iso, durationMinutes);
+  const location = buildLocation(cinema);
+  const details = buildDetails(showtime);
+  const uid = `${showtime.datetime_iso}-${showtime.cinema_id}@allo-scrapper`;
+
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//allo-scrapper//FR',
+    'BEGIN:VEVENT',
+    `UID:${uid}`,
+    `DTSTART:${dtStart}`,
+    `DTEND:${dtEnd}`,
+    `SUMMARY:${film.title}`,
+    `LOCATION:${location}`,
+    `DESCRIPTION:${details}`,
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ];
+
+  return lines.join('\r\n');
+}
+
+/**
+ * Trigger a browser download of a .ics file for the given showtime.
+ */
+export function downloadIcsFile(showtime: Showtime, film: Film, cinema: Cinema): void {
+  const content = buildIcsContent(showtime, film, cinema);
+  const blob = new Blob([content], { type: 'text/calendar;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `${film.title.replace(/[^a-z0-9]/gi, '-')}.ics`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}

--- a/client/src/utils/calendar.ts
+++ b/client/src/utils/calendar.ts
@@ -1,20 +1,23 @@
 import type { Showtime, Film, Cinema } from '../types';
 
 /**
- * Convert an ISO 8601 datetime string to compact YYYYMMDDTHHMMSS format for calendar use.
- * Strips hyphens, colons, and trailing 'Z'.
+ * Convert an ISO 8601 datetime string (local, no timezone designator) to
+ * compact YYYYMMDDTHHMMSS format for calendar use.
+ * Input is treated as local time (no Z suffix in the data from the scraper).
  */
 function toCompactDateTime(isoString: string): string {
-  return isoString.replace(/[-:]/g, '').replace(/\.\d+Z?$/, '').replace('Z', '');
+  // Strip hyphens and colons only — do not strip trailing Z if present, but
+  // the scraper produces local ISO strings without Z (e.g. "2026-05-20T20:30:00").
+  return isoString.replace(/[-:]/g, '').replace(/\.\d+$/, '');
 }
 
 /**
- * Add minutes to an ISO 8601 datetime string and return the result as compact YYYYMMDDTHHMMSS.
+ * Add minutes to a local ISO 8601 datetime string and return compact YYYYMMDDTHHMMSS.
+ * Uses local Date methods consistently with toCompactDateTime (both treat input as local).
  */
 function addMinutesToIso(isoString: string, minutes: number): string {
   const date = new Date(isoString);
   date.setMinutes(date.getMinutes() + minutes);
-  // Format manually to avoid timezone conversion — keep local representation
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0');
   const day = String(date.getDate()).padStart(2, '0');
@@ -36,6 +39,43 @@ function buildDetails(showtime: Showtime): string {
   if (showtime.version) parts.push(showtime.version);
   if (showtime.format) parts.push(showtime.format);
   return parts.join(' ');
+}
+
+/**
+ * Escape special characters in an iCalendar text property value (RFC 5545 §3.3.11).
+ * Escapes: backslash, semicolon, comma, newline.
+ */
+function escapeIcsText(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '');
+}
+
+/**
+ * Fold long iCalendar lines per RFC 5545 §3.1:
+ * Lines longer than 75 octets must be folded with CRLF + single space.
+ */
+function foldIcsLine(line: string): string {
+  const maxBytes = 75;
+  const encoder = new TextEncoder();
+  if (encoder.encode(line).length <= maxBytes) return line;
+
+  const result: string[] = [];
+  let current = '';
+  for (const char of line) {
+    const candidate = current + char;
+    if (encoder.encode(candidate).length > maxBytes) {
+      result.push(current);
+      current = ' ' + char;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current) result.push(current);
+  return result.join('\r\n');
 }
 
 /**
@@ -79,14 +119,14 @@ export function buildIcsContent(showtime: Showtime, film: Film, cinema: Cinema):
     `UID:${uid}`,
     `DTSTART:${dtStart}`,
     `DTEND:${dtEnd}`,
-    `SUMMARY:${film.title}`,
-    `LOCATION:${location}`,
-    `DESCRIPTION:${details}`,
+    `SUMMARY:${escapeIcsText(film.title)}`,
+    `LOCATION:${escapeIcsText(location)}`,
+    `DESCRIPTION:${escapeIcsText(details)}`,
     'END:VEVENT',
     'END:VCALENDAR',
   ];
 
-  return lines.join('\r\n');
+  return lines.map(foldIcsLine).join('\r\n');
 }
 
 /**
@@ -100,7 +140,26 @@ export function downloadIcsFile(showtime: Showtime, film: Film, cinema: Cinema):
   link.href = url;
   link.download = `${film.title.replace(/[^a-z0-9]/gi, '-')}.ics`;
   document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
-  URL.revokeObjectURL(url);
+  try {
+    link.click();
+  } finally {
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }
+}
+
+/**
+ * Trigger an OS-level calendar import for Apple Calendar by opening the .ics
+ * without a download attribute — the browser lets the OS handle text/calendar.
+ */
+export function openIcsInCalendar(showtime: Showtime, film: Film, cinema: Cinema): void {
+  const content = buildIcsContent(showtime, film, cinema);
+  const blob = new Blob([content], { type: 'text/calendar;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  try {
+    window.open(url, '_blank', 'noopener,noreferrer');
+  } finally {
+    // Delay revoke to give the browser time to start the download/open
+    setTimeout(() => URL.revokeObjectURL(url), 10000);
+  }
 }

--- a/client/src/utils/calendar.ts
+++ b/client/src/utils/calendar.ts
@@ -147,12 +147,3 @@ export function downloadIcsFile(showtime: Showtime, film: Film, cinema: Cinema):
     URL.revokeObjectURL(url);
   }
 }
-
-/**
- * Alias — Apple Calendar on modern browsers cannot be triggered directly from
- * a blob URL. This downloads the .ics with a proper filename; the user opens
- * it to import into Calendar.app (macOS/iOS associate .ics with Calendar).
- */
-export function openIcsInCalendar(showtime: Showtime, film: Film, cinema: Cinema): void {
-  downloadIcsFile(showtime, film, cinema);
-}

--- a/client/src/utils/calendar.ts
+++ b/client/src/utils/calendar.ts
@@ -149,17 +149,10 @@ export function downloadIcsFile(showtime: Showtime, film: Film, cinema: Cinema):
 }
 
 /**
- * Trigger an OS-level calendar import for Apple Calendar by opening the .ics
- * without a download attribute — the browser lets the OS handle text/calendar.
+ * Alias — Apple Calendar on modern browsers cannot be triggered directly from
+ * a blob URL. This downloads the .ics with a proper filename; the user opens
+ * it to import into Calendar.app (macOS/iOS associate .ics with Calendar).
  */
 export function openIcsInCalendar(showtime: Showtime, film: Film, cinema: Cinema): void {
-  const content = buildIcsContent(showtime, film, cinema);
-  const blob = new Blob([content], { type: 'text/calendar;charset=utf-8' });
-  const url = URL.createObjectURL(blob);
-  try {
-    window.open(url, '_blank', 'noopener,noreferrer');
-  } finally {
-    // Delay revoke to give the browser time to start the download/open
-    setTimeout(() => URL.revokeObjectURL(url), 10000);
-  }
+  downloadIcsFile(showtime, film, cinema);
 }


### PR DESCRIPTION
## Summary
- Enable showtime buttons (previously disabled) to open a calendar popover
- Popover offers 3 options: Google Calendar (new tab), Apple Calendar (.ics), Télécharger .ics
- Pure frontend implementation — no backend changes

## Changes
- **New** `client/src/utils/calendar.ts` — pure functions to build Google Calendar URL and .ics content
- **New** `client/src/utils/calendar.test.ts` — 16 unit tests (all green)
- **New** `client/src/components/CalendarPopover.tsx` — accessible dropdown with outside-click + Escape dismiss
- **Modified** `ShowtimeList`, `CinemaShowtimes`, `FilmPage`, `CinemaPage` — wire up film/cinema context

## Testing
- 16/16 calendar utility tests passing
- TypeScript: no errors
- Pre-existing `AdminPage.test.tsx` failure is unrelated to this PR (confirmed on develop)

Closes #1048