### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix rate-limit DoS via jwt.verify

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** The application was using the native `parseInt(value, 10)` function to parse route parameters (`req.params.id`) and query arguments (`limit`, `offset`). `parseInt` is very permissive and parses strings up to the first non-numeric character (e.g., `parseInt('123abc', 10)` returns `123`). This permissive parsing can lead to unexpected behavior, logic flaws, or even security issues like IDORs if an ID is loosely matched.
 **Learning:** Native `parseInt` should not be used for strict numerical validation of IDs or pagination parameters as it stops parsing at the first non-numeric character and returns the parsed portion, effectively ignoring invalid trailing characters.
 **Prevention:** Use a custom utility (`parseStrictInt` in `server/src/utils/number.ts`) that strictly enforces a valid integer format using regex (`/^-?\d+$/`) or native number validation (`Number.isInteger`) before processing the input.
+
+## 2026-03-26 - JWT Decode used instead of Verify for Rate Limiting
+**Vulnerability:** The rate limiter middleware (`server/src/middleware/rate-limit.ts`) used `jwt.decode(token)` to extract the user ID for bucketing quotas. `jwt.decode` does not check the token's cryptographic signature, allowing an attacker to send unsigned, unverified tokens with arbitrary spoofed user IDs.
+**Learning:** This could lead to a targeted Denial of Service (DoS) attack via quota exhaustion, where an attacker intentionally exhausts the rate limits of other users by spoofing their IDs.
+**Prevention:** Always use `jwt.verify(token, secret)` wrapped in a `try...catch` block to extract data from JWTs, even for seemingly non-auth tasks like rate limiting bucketing, to ensure the token payload cannot be tampered with.

--- a/server/src/middleware/rate-limit.test.ts
+++ b/server/src/middleware/rate-limit.test.ts
@@ -1,3 +1,4 @@
+process.env.JWT_SECRET = "this-is-a-valid-random-key-that-is-at-least-32-chars";
 import { describe, it, expect, beforeEach } from 'vitest';
 import express from 'express';
 import request from 'supertest';
@@ -12,9 +13,9 @@ import {
   healthCheckLimiter,
 } from './rate-limit.js';
 
-// Helper: sign a minimal JWT for rate-limit key tests (secret doesn't matter — we use jwt.decode)
+// Helper: sign a minimal JWT for rate-limit key tests using the valid test secret
 const makeToken = (userId: number): string =>
-  jwt.sign({ id: userId, username: `user${userId}` }, 'test-secret');
+  jwt.sign({ id: userId, username: `user${userId}` }, process.env.JWT_SECRET!);
 
 describe('Rate Limiting Middleware', () => {
   let app: express.Application;

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -1,6 +1,16 @@
 import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import jwt from 'jsonwebtoken';
 import type { Request } from 'express';
+import { validateJWTSecret } from '../utils/jwt-secret-validator.js';
+
+// Lazy load secret for tests
+let cachedSecret: string | null = null;
+const getJwtSecret = (): string => {
+  if (!cachedSecret) {
+    cachedSecret = validateJWTSecret();
+  }
+  return cachedSecret;
+};
 
 // Helper to parse env var as number with fallback
 const parseEnvInt = (key: string, defaultValue: number): number => {
@@ -33,15 +43,14 @@ const WINDOW_MS = parseEnvInt('RATE_LIMIT_WINDOW_MS', 15 * 60 * 1000); // 15 min
 /**
  * Key generator that buckets authenticated requests by user id.
  * Falls back to req.ip for unauthenticated requests.
- * Uses jwt.decode (not jwt.verify) — we only need the payload for bucketing;
- * security verification is already handled by the requireAuth middleware.
+ * Uses jwt.verify to prevent spoofing of user IDs for DoS rate-limit exhaustion.
  */
 export const authenticatedKeyGenerator = (req: Request): string => {
   try {
     const authHeader = req.headers.authorization;
     if (authHeader?.startsWith('Bearer ')) {
       const token = authHeader.split(' ')[1];
-      const decoded = jwt.decode(token) as { id?: number } | null;
+      const decoded = jwt.verify(token, getJwtSecret()) as { id?: number } | null;
       if (decoded?.id) return `user:${decoded.id}`;
     }
   } catch {
@@ -138,4 +147,3 @@ export const healthCheckLimiter = rateLimit({
     error: 'Too many health check requests',
   },
 });
-


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Rate limiting middleware was bucketing requests for authenticated users using `jwt.decode(token)` rather than `jwt.verify(token)`. Because `decode` doesn't check the token's cryptographic signature, an attacker could forge tokens containing arbitrary user IDs to deplete their rate limits without needing a valid session.
🎯 Impact: Denial of Service (DoS) by quota exhaustion targeting specific users or the entire system if done en masse.
🔧 Fix: Swapped `jwt.decode` with `jwt.verify(token, getJwtSecret())`. Implemented `getJwtSecret` to lazily fetch and validate the secret, ensuring it runs reliably during test setups where `process.env` mutations happen post-import. Also updated testing logic to properly inject dummy keys so that rate-limiting logic could correctly verify dummy JWTs.
✅ Verification: Ran `npm run test -w server -- --run src/middleware/rate-limit.test.ts` successfully. Tested `jwt-secret-validator` compatibility.

---
*PR created automatically by Jules for task [3129921765261789013](https://jules.google.com/task/3129921765261789013) started by @PhBassin*