### PR TITLE
⚡ Bolt: [Performance] Run pagination queries concurrently in getScrapeReports

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -29,3 +29,6 @@
 ## 2024-05-24 - [Optimize groupShowtimesByCinema iteration]
 **Learning:** Destructuring with rest operator (`...`) is surprisingly slow compared to `Object.assign` combined with `delete` in V8 when cloning large arrays of objects, and using plain Objects instead of `Map` can be >2x faster in tight loops grouping thousands of objects.
 **Action:** In performance-critical loops processing arrays, prefer `Record<string, any>` maps, standard `for` loops, and `Object.assign` + `delete` over modern ES6 destructuring and `Map` collections.
+## 2026-05-20 - [Concurrent Pagination Queries in report-queries.ts]
+**Learning:** Sequential database queries for fetching the total count (`COUNT(*)`) and the paginated results (`SELECT * LIMIT OFFSET`) created a performance bottleneck in `getScrapeReports`. This pattern adds unnecessary DB roundtrip latency.
+**Action:** Replaced sequential awaits with `Promise.all([countQuery, paginatedQuery])` to execute them concurrently, halving the database latency for the `/api/reports` endpoint. Note to carefully avoid mutating shared parameter arrays between queries.

--- a/server/src/db/report-queries.ts
+++ b/server/src/db/report-queries.ts
@@ -127,22 +127,22 @@ export async function getScrapeReports(
 
   const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
-  // Get total count
-  const countResult = await db.query<{ count: string }>(
-    `SELECT COUNT(*) as count FROM scrape_reports ${whereClause}`,
-    params
-  );
-  const total = parseInt(countResult.rows[0].count);
+  // ⚡ PERFORMANCE: Run independent DB queries concurrently to reduce total response time
+  const [countResult, result] = await Promise.all([
+    db.query<{ count: string }>(
+      `SELECT COUNT(*) as count FROM scrape_reports ${whereClause}`,
+      params
+    ),
+    db.query<ScrapeReport>(
+      `SELECT * FROM scrape_reports
+       ${whereClause}
+       ORDER BY started_at DESC
+       LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+      [...params, limit, offset]
+    )
+  ]);
 
-  // Get paginated results
-  params.push(limit, offset);
-  const result = await db.query<ScrapeReport>(
-    `SELECT * FROM scrape_reports 
-     ${whereClause}
-     ORDER BY started_at DESC 
-     LIMIT $${paramIndex++} OFFSET $${paramIndex++}`,
-    params
-  );
+  const total = parseInt(countResult.rows[0].count);
 
   return {
     reports: result.rows,


### PR DESCRIPTION
💡 What: Used `Promise.all` to run `COUNT(*)` and paginated `SELECT` queries concurrently in `server/src/db/report-queries.ts`.
🎯 Why: Running these independent queries sequentially was creating an unnecessary N+1 bottleneck, doubling the database latency for the `/api/reports` endpoint.
📊 Impact: Expected to halve the database wait time when loading the reports page.
🔬 Measurement: Verified that tests pass successfully. The response time of `GET /api/reports` can be measured to see the latency improvement.

---
*PR created automatically by Jules for task [15903514177514222355](https://jules.google.com/task/15903514177514222355) started by @PhBassin*