### PR TITLE
⚡ Bolt: Execute scrape report DB queries concurrently

### DIFF
--- a/server/src/db/report-queries.ts
+++ b/server/src/db/report-queries.ts
@@ -127,22 +127,25 @@ export async function getScrapeReports(
 
   const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
-  // Get total count
-  const countResult = await db.query<{ count: string }>(
-    `SELECT COUNT(*) as count FROM scrape_reports ${whereClause}`,
-    params
-  );
-  const total = parseInt(countResult.rows[0].count);
+  // ⚡ Bolt: Execute independent COUNT and SELECT queries concurrently
+  // Clone params array to avoid race conditions with param mutation
+  const dataParams = [...params, limit, offset];
 
-  // Get paginated results
-  params.push(limit, offset);
-  const result = await db.query<ScrapeReport>(
-    `SELECT * FROM scrape_reports 
-     ${whereClause}
-     ORDER BY started_at DESC 
-     LIMIT $${paramIndex++} OFFSET $${paramIndex++}`,
-    params
-  );
+  const [countResult, result] = await Promise.all([
+    db.query<{ count: string }>(
+      `SELECT COUNT(*) as count FROM scrape_reports ${whereClause}`,
+      params
+    ),
+    db.query<ScrapeReport>(
+      `SELECT * FROM scrape_reports
+       ${whereClause}
+       ORDER BY started_at DESC
+       LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+      dataParams
+    )
+  ]);
+
+  const total = parseInt(countResult.rows[0].count);
 
   return {
     reports: result.rows,


### PR DESCRIPTION
💡 **What**:
Refactored `getScrapeReports` in `server/src/db/report-queries.ts` to execute the `COUNT(*)` query and the paginated `SELECT` query concurrently using `Promise.all`.

🎯 **Why**:
Previously, the queries were executed sequentially: the application waited for the count query to finish before dispatching the paginated select query. By executing them concurrently, we eliminate the latency of one database network roundtrip for requests to the `/api/scraper/reports` endpoint.

📊 **Impact**:
Reduces database latency for listing scrape reports. Depending on the network latency to the Postgres database, this can save ~2ms-10ms per request. 

🔬 **Measurement**:
The `server` test suite (`npm run test:run -w server`) ensures the queries still correctly resolve the `reports` array and the `total` count without regressions. 

*(Also ensured no side-effects using a cloned `dataParams` array to avoid mutating the parameters across asynchronous executions.)*

---
*PR created automatically by Jules for task [4845211381203257599](https://jules.google.com/task/4845211381203257599) started by @PhBassin*