### PR TITLE
fix(api): secure rate-limiter jwt verification and sanitize 5xx errors in production

### DIFF
--- a/server/src/middleware/error-handler.test.ts
+++ b/server/src/middleware/error-handler.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { errorHandler } from './error-handler.js';
+import { AppError, ValidationError } from '../utils/errors.js';
+
+describe('Error Handler Middleware', () => {
+  let app: express.Application;
+  let originalNodeEnv: string | undefined;
+
+  beforeEach(() => {
+    originalNodeEnv = process.env.NODE_ENV;
+    app = express();
+    app.use(express.json());
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  describe('Non-production environment (development/test)', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'test';
+    });
+
+    it('should pass through the original message and details for 5xx AppError', async () => {
+      app.get('/error-500', (_req, _res, next) => {
+        next(new AppError('Database connection failed', 500, [{ code: 'ECONNREFUSED' }]));
+      });
+      app.use(errorHandler);
+
+      const response = await request(app).get('/error-500');
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Database connection failed',
+        details: [{ code: 'ECONNREFUSED' }],
+      });
+    });
+
+    it('should pass through the original message for generic 500 error', async () => {
+      app.get('/error-generic', (_req, _res, next) => {
+        next(new Error('Something went horribly wrong internally'));
+      });
+      app.use(errorHandler);
+
+      const response = await request(app).get('/error-generic');
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Something went horribly wrong internally',
+      });
+    });
+  });
+
+  describe('Production environment', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'production';
+    });
+
+    it('should sanitize 5xx AppError message and omit details', async () => {
+      app.get('/error-500-prod', (_req, _res, next) => {
+        next(new AppError('Database connection failed', 500, [{ code: 'ECONNREFUSED' }]));
+      });
+      app.use(errorHandler);
+
+      const response = await request(app).get('/error-500-prod');
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Internal server error',
+      });
+    });
+
+    it('should sanitize generic unhandled 500 error message', async () => {
+      app.get('/error-generic-prod', (_req, _res, next) => {
+        next(new Error('System-level memory leak / stack overflow'));
+      });
+      app.use(errorHandler);
+
+      const response = await request(app).get('/error-generic-prod');
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Internal server error',
+      });
+    });
+
+    it('should NOT sanitize or strip details from 4xx errors (e.g., Validation Errors)', async () => {
+      app.get('/error-400-prod', (_req, _res, next) => {
+        next(new ValidationError('Invalid user input', [{ field: 'email', message: 'Email must be valid' }]));
+      });
+      app.use(errorHandler);
+
+      const response = await request(app).get('/error-400-prod');
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Invalid user input',
+        details: [{ field: 'email', message: 'Email must be valid' }],
+      });
+    });
+  });
+});

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -16,10 +16,13 @@ export const errorHandler = (
       logger.warn(`App Error [${error.statusCode}]`, { error: error.message, details: error.details });
     }
 
+    const isProd = process.env.NODE_ENV === 'production';
+    const is5xx = error.statusCode >= 500;
+
     return res.status(error.statusCode).json({
       success: false,
-      error: error.message,
-      ...(error.details && { details: error.details })
+      error: isProd && is5xx ? 'Internal server error' : error.message,
+      ...(!isProd || !is5xx ? (error.details && { details: error.details }) : {})
     });
   }
 

--- a/server/src/middleware/rate-limit.test.ts
+++ b/server/src/middleware/rate-limit.test.ts
@@ -1,3 +1,6 @@
+// Set secure JWT_SECRET BEFORE importing rate-limit
+process.env.JWT_SECRET = 'a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6';
+
 import { describe, it, expect, beforeEach } from 'vitest';
 import express from 'express';
 import request from 'supertest';
@@ -12,9 +15,9 @@ import {
   healthCheckLimiter,
 } from './rate-limit.js';
 
-// Helper: sign a minimal JWT for rate-limit key tests (secret doesn't matter — we use jwt.decode)
+// Helper: sign a minimal JWT for rate-limit key tests
 const makeToken = (userId: number): string =>
-  jwt.sign({ id: userId, username: `user${userId}` }, 'test-secret');
+  jwt.sign({ id: userId, username: `user${userId}` }, process.env.JWT_SECRET as string);
 
 describe('Rate Limiting Middleware', () => {
   let app: express.Application;
@@ -185,6 +188,32 @@ describe('Rate Limiting Middleware', () => {
         .get('/protected-malformed')
         .set('Authorization', 'Bearer not.a.valid.jwt');
       expect(response.status).toBe(200);
+    });
+
+    it('should fall back to IP when Authorization header contains a token with an invalid signature', async () => {
+      // Create a tight-limit app to test fallback
+      const tightApp = express();
+      tightApp.set('trust proxy', 1);
+      const { default: rateLimit } = await import('express-rate-limit');
+      const { authenticatedKeyGenerator } = await import('./rate-limit.js');
+      const tightLimiter = rateLimit({
+        windowMs: 60_000,
+        max: 2,
+        skip: () => false,
+        keyGenerator: authenticatedKeyGenerator,
+      });
+      tightApp.get('/p-invalid', tightLimiter, (_req, res) => res.json({ ok: true }));
+
+      // Token with incorrect secret but same spoofed user ID 1
+      const spoofedToken = jwt.sign({ id: 1, username: 'user1' }, 'wrong-secret-minimum-32-chars-long-or-longer');
+      const sameIp = '1.2.3.4';
+
+      // If it fails to verify, it falls back to IP fallback.
+      // So requests with spoofedToken (invalid signature) and no token at all on same IP will count against the SAME IP bucket.
+      await request(tightApp).get('/p-invalid').set('Authorization', `Bearer ${spoofedToken}`).set('X-Forwarded-For', sameIp);
+      await request(tightApp).get('/p-invalid').set('X-Forwarded-For', sameIp); // no token, same IP
+      const exhausted = await request(tightApp).get('/p-invalid').set('X-Forwarded-For', sameIp);
+      expect(exhausted.status).toBe(429);
     });
   });
 

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -1,6 +1,9 @@
 import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import jwt from 'jsonwebtoken';
 import type { Request } from 'express';
+import { validateJWTSecret } from '../utils/jwt-secret-validator.js';
+
+const JWT_SECRET = validateJWTSecret();
 
 // Helper to parse env var as number with fallback
 const parseEnvInt = (key: string, defaultValue: number): number => {
@@ -33,16 +36,15 @@ const WINDOW_MS = parseEnvInt('RATE_LIMIT_WINDOW_MS', 15 * 60 * 1000); // 15 min
 /**
  * Key generator that buckets authenticated requests by user id.
  * Falls back to req.ip for unauthenticated requests.
- * Uses jwt.decode (not jwt.verify) — we only need the payload for bucketing;
- * security verification is already handled by the requireAuth middleware.
+ * Uses jwt.verify to ensure the token has not been spoofed.
  */
 export const authenticatedKeyGenerator = (req: Request): string => {
   try {
     const authHeader = req.headers.authorization;
     if (authHeader?.startsWith('Bearer ')) {
       const token = authHeader.split(' ')[1];
-      const decoded = jwt.decode(token) as { id?: number } | null;
-      if (decoded?.id) return `user:${decoded.id}`;
+      const verified = jwt.verify(token, JWT_SECRET) as { id?: number } | null;
+      if (verified?.id) return `user:${verified.id}`;
     }
   } catch {
     // fall through to IP fallback


### PR DESCRIPTION
## Summary
- Replaced `jwt.decode` with `jwt.verify` using validated `JWT_SECRET` to prevent JWT spoofing rate-limiting bypass.
- Configured `errorHandler` middleware to sanitize all 500/5xx errors to a generic `'Internal server error'` and strip detail payloads in production.
- Added comprehensive unit tests for both security hardening measures.

Closes #1059