### PR TITLE
perf(api): consolidate Bolt performance optimizations

### DIFF
--- a/server/src/db/report-queries.test.ts
+++ b/server/src/db/report-queries.test.ts
@@ -48,4 +48,38 @@ describe('Report Queries', () => {
       );
     });
   });
+
+  describe('getScrapeReports', () => {
+    it('should query count and paginated reports concurrently', async () => {
+      const { getScrapeReports } = await import('./report-queries.js');
+      
+      const mockDb = {
+        query: vi.fn().mockImplementation((sql: string) => {
+          if (sql.includes('COUNT(*)')) {
+            return { rows: [{ count: '10' }] };
+          }
+          return { rows: [{ id: 1 }, { id: 2 }] };
+        }),
+      } as unknown as DB;
+
+      const result = await getScrapeReports(mockDb, { limit: 5, offset: 2 });
+
+      expect(result).toEqual({
+        reports: [{ id: 1 }, { id: 2 }],
+        total: 10,
+      });
+
+      expect(mockDb.query).toHaveBeenCalledTimes(2);
+      expect(mockDb.query).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining('SELECT COUNT(*)'),
+        []
+      );
+      expect(mockDb.query).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('SELECT * FROM scrape_reports'),
+        [5, 2]
+      );
+    });
+  });
 });

--- a/server/src/db/report-queries.ts
+++ b/server/src/db/report-queries.ts
@@ -127,22 +127,25 @@ export async function getScrapeReports(
 
   const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
-  // Get total count
-  const countResult = await db.query<{ count: string }>(
-    `SELECT COUNT(*) as count FROM scrape_reports ${whereClause}`,
-    params
-  );
-  const total = parseInt(countResult.rows[0].count);
+  // Get total count and paginated results concurrently (Promise.all)
+  const countParams = [...params];
+  const listParams = [...params, limit, offset];
 
-  // Get paginated results
-  params.push(limit, offset);
-  const result = await db.query<ScrapeReport>(
-    `SELECT * FROM scrape_reports 
-     ${whereClause}
-     ORDER BY started_at DESC 
-     LIMIT $${paramIndex++} OFFSET $${paramIndex++}`,
-    params
-  );
+  const [countResult, result] = await Promise.all([
+    db.query<{ count: string }>(
+      `SELECT COUNT(*) as count FROM scrape_reports ${whereClause}`,
+      countParams
+    ),
+    db.query<ScrapeReport>(
+      `SELECT * FROM scrape_reports 
+       ${whereClause}
+       ORDER BY started_at DESC 
+       LIMIT $${paramIndex++} OFFSET $${paramIndex++}`,
+      listParams
+    )
+  ]);
+
+  const total = parseInt(countResult.rows[0].count);
 
   return {
     reports: result.rows,

--- a/server/src/routes/reports.test.ts
+++ b/server/src/routes/reports.test.ts
@@ -109,4 +109,57 @@ describe('Routes - Reports', () => {
       }));
     });
   });
+
+  describe('GET /:id/details', () => {
+    it('should return report details with grouped attempts and calculated summary statistics', async () => {
+      mockReq = {
+        params: { id: '42' },
+        app: mockApp,
+      };
+
+      const mockReport = { id: 42, status: 'success', trigger_type: 'manual' };
+      const mockAttempts = [
+        { id: 1, report_id: 42, theater_id: 'theater-1', status: 'success' },
+        { id: 2, report_id: 42, theater_id: 'theater-1', status: 'failed' },
+        { id: 3, report_id: 42, theater_id: 'theater-2', status: 'success' },
+        { id: 4, report_id: 42, theater_id: 'theater-2', status: 'rate_limited' },
+        { id: 5, report_id: 42, theater_id: 'theater-3', status: 'pending' },
+      ];
+
+      vi.mocked(reportQueries.getScrapeReport).mockResolvedValue(mockReport as any);
+      
+      const { getScrapeAttemptsByReport } = await import('../db/scrape-attempt-queries.js');
+      vi.mock('../db/scrape-attempt-queries.js', () => ({
+        getScrapeAttemptsByReport: vi.fn(),
+      }));
+      vi.mocked(getScrapeAttemptsByReport).mockResolvedValue(mockAttempts as any);
+
+      const handler = getRouteHandler('/:id/details', 'get');
+      expect(handler).toBeDefined();
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(reportQueries.getScrapeReport).toHaveBeenCalledWith(expect.anything(), 42);
+      expect(getScrapeAttemptsByReport).toHaveBeenCalledWith(expect.anything(), 42);
+
+      expect(mockRes.json).toHaveBeenCalledWith({
+        success: true,
+        data: {
+          report: mockReport,
+          attempts: {
+            'theater-1': [mockAttempts[0], mockAttempts[1]],
+            'theater-2': [mockAttempts[2], mockAttempts[3]],
+            'theater-3': [mockAttempts[4]],
+          },
+          summary: {
+            total_attempts: 5,
+            successful: 2,
+            failed: 1,
+            rate_limited: 1,
+            not_attempted: 0,
+            pending: 1,
+          },
+        },
+      });
+    });
+  });
 });

--- a/server/src/routes/reports.ts
+++ b/server/src/routes/reports.ts
@@ -95,32 +95,52 @@ router.get('/:id/details', protectedLimiter, requireAuth, requirePermission('rep
       return next(new ValidationError('Invalid report ID'));
     }
 
-    const report = await getScrapeReport(db, reportId);
+    // Fetch report and attempts concurrently (Promise.all)
+    const [report, attempts] = await Promise.all([
+      getScrapeReport(db, reportId),
+      getScrapeAttemptsByReport(db, reportId),
+    ]);
 
     if (!report) {
       return next(new NotFoundError('Report not found'));
     }
 
-    // Get all attempts for this report
-    const attempts = await getScrapeAttemptsByReport(db, reportId);
-
-    // Group attempts by theater
+    // Group attempts by theater and calculate summary statistics in a single pass
     const attemptsByTheater: Record<string, any[]> = {};
+    let successful = 0;
+    let failed = 0;
+    let rate_limited = 0;
+    let not_attempted = 0;
+    let pending = 0;
+
     for (const attempt of attempts) {
-      if (!attemptsByTheater[attempt.theater_id]) {
-        attemptsByTheater[attempt.theater_id] = [];
+      const theaterId = attempt.theater_id;
+      if (!attemptsByTheater[theaterId]) {
+        attemptsByTheater[theaterId] = [];
       }
-      attemptsByTheater[attempt.theater_id].push(attempt);
+      attemptsByTheater[theaterId].push(attempt);
+
+      const status = attempt.status;
+      if (status === 'success') {
+        successful++;
+      } else if (status === 'failed') {
+        failed++;
+      } else if (status === 'rate_limited') {
+        rate_limited++;
+      } else if (status === 'not_attempted') {
+        not_attempted++;
+      } else if (status === 'pending') {
+        pending++;
+      }
     }
 
-    // Calculate summary statistics
     const summary = {
       total_attempts: attempts.length,
-      successful: attempts.filter(a => a.status === 'success').length,
-      failed: attempts.filter(a => a.status === 'failed').length,
-      rate_limited: attempts.filter(a => a.status === 'rate_limited').length,
-      not_attempted: attempts.filter(a => a.status === 'not_attempted').length,
-      pending: attempts.filter(a => a.status === 'pending').length,
+      successful,
+      failed,
+      rate_limited,
+      not_attempted,
+      pending,
     };
 
     const response: ApiResponse = {

--- a/server/src/routes/system.ts
+++ b/server/src/routes/system.ts
@@ -56,9 +56,11 @@ router.get('/migrations', protectedLimiter, requireAuth, requirePermission('syst
   try {
     const db: DB = req.app.get('db');
 
-    // Get applied and pending migrations
-    const applied = await getAppliedMigrations(db);
-    const pending = await getPendingMigrations(db);
+    // Get applied and pending migrations concurrently (Promise.all)
+    const [applied, pending] = await Promise.all([
+      getAppliedMigrations(db),
+      getPendingMigrations(db),
+    ]);
 
     const response: ApiResponse = {
       success: true,
@@ -82,14 +84,15 @@ router.get('/health', protectedLimiter, requireAuth, requirePermission('system:h
   try {
     const db: DB = req.app.get('db');
 
-    // Get scraper status (async, may throw)
-    const scraperStatus = await getScraperStatus(db);
+    // Get scraper status and pending migrations concurrently (Promise.all)
+    const [scraperStatus, pendingMigrations] = await Promise.all([
+      getScraperStatus(db),
+      getPendingMigrations(db),
+    ]);
 
     // Get server health (synchronous)
     const serverHealth = getServerHealth();
 
-    // Check migrations status
-    const pendingMigrations = await getPendingMigrations(db);
     const migrationsOk = pendingMigrations.length === 0;
 
     // Determine overall status


### PR DESCRIPTION
## Summary
- Parallelized total count and list queries in `getScrapeReports` using `Promise.all`.
- Parallelized `getScrapeReport` and `getScrapeAttemptsByReport` details endpoints queries.
- Optimized details report statistics computation using a single-pass loop, reducing (N)$ overhead and removing deprecated film references.
- Parallelized migrations checks and scraper checks in `system` endpoints.

Closes #1061