### PR TITLE
fix(security): use extended:false for urlencoded body parser

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -69,7 +69,7 @@ export function createApp() {
   app.use(cors(getCorsOptions()));
   app.use(morgan('combined'));
   app.use(express.json());
-  app.use(express.urlencoded({ extended: true }));
+  app.use(express.urlencoded({ extended: false }));
   app.use(cookieParser());
 
   // CSRF protection: double-submit cookie pattern (inline for CodeQL compliance)


### PR DESCRIPTION
## Summary
Change `express.urlencoded({ extended: true })` to `{ extended: false }` to prevent nested object injection via URL-encoded request bodies.

## Context
- **Epic 9**: Security Audit Remediation
- **Story 9.2**: Harden Express Body Parser Configuration
- **Audit point 5**: `urlencoded extended:true` allows nested object parsing via qs library

## Change
- `server/src/app.ts`: `extended: true` → `extended: false` (1 line)

## Impact
- Uses Node's built-in `querystring` module instead of `qs` for parsing `application/x-www-form-urlencoded` bodies
- No functional impact: the React client sends JSON, and no route relies on nested URL-encoded parameters

## Verification
- Pre-push hook: TypeScript type-check ✅
- Server tests: 753/753 ✅
- Scraper tests: 173/173 ✅

Closes #9-2