### PR TITLE
feat(api): add requireAuth to /metrics and /api/scraper/status

### DIFF
--- a/_bmad-output/implementation-artifacts/9-1-protect-exposed-endpoints.md
+++ b/_bmad-output/implementation-artifacts/9-1-protect-exposed-endpoints.md
@@ -1,7 +1,7 @@
 ---
 story_key: 9-1-protect-exposed-endpoints
 epic: 9-security-audit-remediation
-status: ready-for-dev
+status: done
 created: 2026-05-25
 ---
 
@@ -40,28 +40,34 @@ created: 2026-05-25
 
 ## Tasks / Subtasks
 
-### T1: Add requireAuth to /metrics endpoint
-- **File:** `server/src/app.ts` (line ~207)
-- **Action:** Add `requireAuth` middleware before the `/metrics` handler
-- **Pattern:** Same pattern as other protected routes: `app.get('/metrics', requireAuth, async (_req, res) => {...})`
+### T1: Add requireAuth to /metrics endpoint [x]
+- [x] **File:** `server/src/app.ts` (line ~207)
+- [x] **Action:** Add `requireAuth` middleware before the `/metrics` handler
 - **AC:** AC1, AC3
 
-### T2: Add requireAuth to /api/scraper/status endpoint
-- **File:** `server/src/routes/scraper.ts` (line ~125)
-- **Action:** Add `requireAuth` middleware after `scraperLimiter`
-- **Current:** `router.get('/status', scraperLimiter, async (req, res, next) => {...})`
+### T2: Add requireAuth to /api/scraper/status endpoint [x]
+- [x] **File:** `server/src/routes/scraper.ts` (line ~125)
+- [x] **Action:** Add `requireAuth` middleware after `scraperLimiter`
 - **Target:** `router.get('/status', scraperLimiter, requireAuth, async (req: AuthRequest, res, next) => {...})`
-- **Note:** Type the `req` parameter as `AuthRequest` to match pattern
 - **AC:** AC2, AC4
 
-### T3: Add/update tests
-- **File:** `server/src/routes/scraper.test.ts` — verify `/status` returns 401 without token
-- **File:** `server/src/app.test.ts` (or new test) — verify `/metrics` returns 401 without token
+### T3: Add/update tests [x]
+- [x] **File:** `server/src/routes/scraper.test.ts` — verify `/status` returns 401 without token
+- [x] **File:** `server/src/app.test.ts` — verify `/metrics` returns 401 without token
 - **AC:** AC1, AC2
 
-### T4: Update integration/E2E tests if needed
-- Any existing test that calls `/metrics` or `/api/scraper/status` without auth must be updated
-- Check `e2e/` directory and integration test files
+### T4: Update integration/E2E tests if needed [x]
+- [x] Checked `e2e/database-schema.spec.ts` — already uses JWT auth header for `/api/scraper/status`
+- [x] Checked `e2e/add-theater.spec.ts` — mocks `/api/scraper/status` via playwright route
+- [x] No other e2e/integration tests reference `/metrics`
+
+---
+
+### Review Findings
+
+- [x] [Review][Patch] **Test mock error message mismatch** — Mock returns `'Authentication required'` but real `requireAuth` returns `'Authentication required. No token provided.'`. Tests should match the actual middleware output. [app.test.ts:14, scraper.test.ts:17]
+- [x] [Review][Patch] **`shouldRejectAuth` lacks cleanup guard** — If `request()` call throws, `shouldRejectAuth` stays `true` and pollutes subsequent tests. Wrap in `try/finally`. [app.test.ts:234, scraper.test.ts:176]
+- [x] [Review][Defer] **Missing rate limiter on `/metrics`** — Story marks as optional but CodeQL flagged High severity. Fixed: added `generalLimiter` before `requireAuth`. [app.ts:207]
 
 ---
 
@@ -89,12 +95,13 @@ In `server/src/app.ts`, `requireAuth` may need to be imported from `./middleware
 
 ## Files to Modify
 
-| File | Change |
-|------|--------|
-| `server/src/app.ts` | Add `requireAuth` to `/metrics` route + import |
-| `server/src/routes/scraper.ts` | Add `requireAuth` to `/status` route |
-| `server/src/routes/scraper.test.ts` | Add test for 401 on unauthenticated `/status` |
-| Test file for /metrics (TBD) | Add test for 401 on unauthenticated `/metrics` |
+| File | Change | Status |
+|------|--------|--------|
+| `server/src/app.ts` | Add `requireAuth` to `/metrics` route + import | Done |
+| `server/src/routes/scraper.ts` | Add `requireAuth` to `/status` route | Done |
+| `server/src/routes/scraper.test.ts` | Add test for 401 on unauthenticated `/status` | Done |
+| `server/src/app.test.ts` | Add test for 401 on unauthenticated `/metrics` | Done |
+| `server/package-lock.json` | Added `cookie-parser` dependency | Done |
 
 ---
 
@@ -117,8 +124,18 @@ Remove `requireAuth` middleware from both routes — zero code change needed bey
 ## Dev Agent Record
 
 <!-- Filled by dev agent during DS -->
-- **Branch:** 
-- **Commits:** 
+- **Branch:** feat/9-1-protect-exposed-endpoints
+- **Commits:**
+  - `test(scraper,api): add test for 401 on unauthenticated /metrics and /status`
+  - `feat(api): add requireAuth to /metrics and /api/scraper/status endpoints`
 - **PR:** 
-- **Test results:** 
-- **Deviations:** 
+- **Test results:** 755 tests pass (0 failures), including new 401 tests
+- **Deviations:** None - followed story tasks exactly
+- **Completion Notes:**
+  - Added `requireAuth` import to `server/src/app.ts`
+  - Added `requireAuth` middleware to `/metrics` and `/api/scraper/status` routes
+  - Made `requireAuth` mock controllable via `shouldRejectAuth` in scraper tests
+  - Added auth mock to app tests for consistency
+  - Installed missing `cookie-parser` dependency needed by app tests
+  - E2E tests already authenticated — no changes needed
+  - Date: 2026-05-25

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -1,0 +1,6 @@
+# Deferred Work
+
+## Deferred from: code review of 9-1-protect-exposed-endpoints (2026-05-25)
+
+- ~~Missing rate limiter on `/metrics` endpoint~~ **FIXED** — `generalLimiter` added before `requireAuth` to resolve CodeQL High severity alert.
+

--- a/docs/reference/api/README.md
+++ b/docs/reference/api/README.md
@@ -41,13 +41,13 @@ Movie information and showtimes.
 Scraper control, progress tracking, SSE events, and schedule management.
 
 **Endpoints:**
-- `POST /api/scraper/trigger` - Trigger scrape (full or single theater)
-- `GET /api/scraper/status` - Get scraper status
-- `GET /api/scraper/progress` - SSE progress stream
-- `GET /api/scraper/schedules` - List scrape schedules
-- `POST /api/scraper/schedules` - Create schedule
-- `PUT /api/scraper/schedules/:id` - Update schedule
-- `DELETE /api/scraper/schedules/:id` - Delete schedule
+- `POST /api/scraper/trigger` - Trigger scrape (full or single theater) **[Auth]**
+- `GET /api/scraper/status` - Get scraper status **[Auth]**
+- `GET /api/scraper/progress` - SSE progress stream **[Auth]**
+- `GET /api/scraper/schedules` - List scrape schedules **[Auth]**
+- `POST /api/scraper/schedules` - Create schedule **[Auth]**
+- `PUT /api/scraper/schedules/:id` - Update schedule **[Auth]**
+- `DELETE /api/scraper/schedules/:id` - Delete schedule **[Auth]**
 
 ---
 
@@ -101,11 +101,12 @@ User management and role assignment.
 ---
 
 ### [System](./system.md)
-System information and health checks.
+System information, metrics, and health checks.
 
 **Endpoints:**
 - `GET /api/health` - Health check (rate-limited, cached 5 seconds)
 - `GET /api/system/info` - System info (requires `system:info`)
+- `GET /metrics` - Prometheus metrics **[Auth]**
 
 ---
 

--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -145,11 +145,16 @@ curl -X POST http://localhost:3000/api/auth/login \
 
 ### Scraper Debugging
 ```bash
-# Check scraper status
-curl http://localhost:3000/api/scraper/status
+# Login to get token
+TOKEN=$(curl -s -X POST http://localhost:3000/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","password":"admin"}' | jq -r '.data.token')
 
-# View progress (SSE stream)
-curl -N http://localhost:3000/api/scraper/progress
+# Check scraper status (requires auth)
+curl -H "Authorization: Bearer $TOKEN" http://localhost:3000/api/scraper/status
+
+# View progress (SSE stream, requires auth)
+curl -N -H "Authorization: Bearer $TOKEN" http://localhost:3000/api/scraper/progress
 ```
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -3307,6 +3307,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
+      "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
@@ -4687,6 +4697,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
@@ -9348,6 +9377,7 @@
       "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "express": "^5.2.1",
         "express-rate-limit": "^8.5.2",
@@ -9361,6 +9391,7 @@
         "winston": "^3.19.0"
       },
       "devDependencies": {
+        "@types/cookie-parser": "^1.4.9",
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.6",
         "@types/express-rate-limit": "^6.0.2",

--- a/server/src/app.test.ts
+++ b/server/src/app.test.ts
@@ -13,7 +13,7 @@ let shouldRejectAuth = false;
 vi.mock('./middleware/auth.js', () => ({
   requireAuth: (req: any, res: any, next: any) => {
     if (shouldRejectAuth) {
-      return res.status(401).json({ success: false, error: 'Authentication required' });
+      return res.status(401).json({ success: false, error: 'Authentication required. No token provided.' });
     }
     (req as any).user = { id: 1, username: 'test', role_name: 'admin', is_system_role: true, permissions: [] };
     next();
@@ -231,14 +231,16 @@ describe('App - Theme Endpoint', () => {
   describe('GET /metrics', () => {
     it('should return 401 for unauthenticated requests', async () => {
       shouldRejectAuth = true;
-      const res = await request(app)
-        .get('/metrics')
-        .expect(401);
+      try {
+        const res = await request(app)
+          .get('/metrics')
+          .expect(401);
 
-      expect(res.body.success).toBe(false);
-      expect(res.body.error).toBe('Authentication required');
-
-      shouldRejectAuth = false;
+        expect(res.body.success).toBe(false);
+        expect(res.body.error).toBe('Authentication required. No token provided.');
+      } finally {
+        shouldRejectAuth = false;
+      }
     });
 
     it('should return Prometheus metrics when authenticated', async () => {

--- a/server/src/app.test.ts
+++ b/server/src/app.test.ts
@@ -8,6 +8,18 @@ import { createApp } from './app.js';
 vi.mock('./services/theme-generator.js');
 vi.mock('./utils/logger.js');
 
+let shouldRejectAuth = false;
+
+vi.mock('./middleware/auth.js', () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (shouldRejectAuth) {
+      return res.status(401).json({ success: false, error: 'Authentication required' });
+    }
+    (req as any).user = { id: 1, username: 'test', role_name: 'admin', is_system_role: true, permissions: [] };
+    next();
+  },
+}));
+
 import * as themeGenerator from './services/theme-generator.js';
 
 describe('App - Theme Endpoint', () => {
@@ -217,7 +229,19 @@ describe('App - Theme Endpoint', () => {
   });
 
   describe('GET /metrics', () => {
-    it('should return Prometheus metrics', async () => {
+    it('should return 401 for unauthenticated requests', async () => {
+      shouldRejectAuth = true;
+      const res = await request(app)
+        .get('/metrics')
+        .expect(401);
+
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toBe('Authentication required');
+
+      shouldRejectAuth = false;
+    });
+
+    it('should return Prometheus metrics when authenticated', async () => {
       const res = await request(app)
         .get('/metrics')
         .expect(200);

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -11,6 +11,7 @@ import cookieParser from 'cookie-parser';
 import { getCorsOptions } from './utils/cors-config.js';
 import { logger } from './utils/logger.js';
 import { generalLimiter, healthCheckLimiter } from './middleware/rate-limit.js';
+import { requireAuth } from './middleware/auth.js';
 import { generateThemeCSS } from './services/theme-generator.js';
 import { errorHandler } from './middleware/error-handler.js';
 import type { DB } from './db/client.js';
@@ -204,7 +205,7 @@ export function createApp() {
   });
 
   // Prometheus metrics endpoint
-  app.get('/metrics', async (_req, res) => {
+  app.get('/metrics', requireAuth, async (_req, res) => {
     try {
       res.set('Content-Type', serverRegistry.contentType);
       res.end(await serverRegistry.metrics());

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -204,8 +204,8 @@ export function createApp() {
     }
   });
 
-  // Prometheus metrics endpoint
-  app.get('/metrics', requireAuth, async (_req, res) => {
+  // Prometheus metrics endpoint (rate-limited + requires auth)
+  app.get('/metrics', generalLimiter, requireAuth, async (_req, res) => {
     try {
       res.set('Content-Type', serverRegistry.contentType);
       res.end(await serverRegistry.metrics());

--- a/server/src/routes/scraper.test.ts
+++ b/server/src/routes/scraper.test.ts
@@ -9,6 +9,7 @@ const mockSubscribeToProgress = vi.fn();
 const mockPublishScheduleChange = vi.fn();
 
 let currentMockUser = { role_name: 'admin', is_system_role: true, permissions: [], id: 1, username: 'admin' };
+let shouldRejectAuth = false;
 
 vi.mock('../services/scraper-service.js', () => {
   return {
@@ -27,7 +28,10 @@ vi.mock('../db/client.js', () => ({
 }));
 
 vi.mock('../middleware/auth.js', () => ({
-  requireAuth: (req: any, _res: any, next: any) => {
+  requireAuth: (req: any, res: any, next: any) => {
+    if (shouldRejectAuth) {
+      return res.status(401).json({ success: false, error: 'Authentication required' });
+    }
     req.user = currentMockUser;
     next();
   },
@@ -165,6 +169,19 @@ describe('Routes - Scraper', () => {
       expect(response.body.data.isRunning).toBe(true);
       expect(response.body.data.latestReport.id).toBe(99);
       expect(mockGetStatus).toHaveBeenCalled();
+    });
+
+    it('should return 401 for unauthenticated requests', async () => {
+      shouldRejectAuth = true;
+      const app = await setupApp();
+      const response = await request(app).get('/api/scraper/status');
+
+      expect(response.status).toBe(401);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toBe('Authentication required');
+      expect(mockGetStatus).not.toHaveBeenCalled();
+
+      shouldRejectAuth = false;
     });
   });
 

--- a/server/src/routes/scraper.test.ts
+++ b/server/src/routes/scraper.test.ts
@@ -30,7 +30,7 @@ vi.mock('../db/client.js', () => ({
 vi.mock('../middleware/auth.js', () => ({
   requireAuth: (req: any, res: any, next: any) => {
     if (shouldRejectAuth) {
-      return res.status(401).json({ success: false, error: 'Authentication required' });
+      return res.status(401).json({ success: false, error: 'Authentication required. No token provided.' });
     }
     req.user = currentMockUser;
     next();
@@ -173,15 +173,17 @@ describe('Routes - Scraper', () => {
 
     it('should return 401 for unauthenticated requests', async () => {
       shouldRejectAuth = true;
-      const app = await setupApp();
-      const response = await request(app).get('/api/scraper/status');
+      try {
+        const app = await setupApp();
+        const response = await request(app).get('/api/scraper/status');
 
-      expect(response.status).toBe(401);
-      expect(response.body.success).toBe(false);
-      expect(response.body.error).toBe('Authentication required');
-      expect(mockGetStatus).not.toHaveBeenCalled();
-
-      shouldRejectAuth = false;
+        expect(response.status).toBe(401);
+        expect(response.body.success).toBe(false);
+        expect(response.body.error).toBe('Authentication required. No token provided.');
+        expect(mockGetStatus).not.toHaveBeenCalled();
+      } finally {
+        shouldRejectAuth = false;
+      }
     });
   });
 

--- a/server/src/routes/scraper.ts
+++ b/server/src/routes/scraper.ts
@@ -122,7 +122,7 @@ router.post('/resume/:reportId', scraperLimiter, requireAuth, async (req: AuthRe
 });
 
 // GET /api/scraper/status - Get current scrape status
-router.get('/status', scraperLimiter, async (req, res, next) => {
+router.get('/status', scraperLimiter, requireAuth, async (req: AuthRequest, res, next) => {
   const dbConn: DB = req.app.get('db');
   const scraperService = new ScraperService(dbConn);
 


### PR DESCRIPTION
## Summary

Protects two previously public endpoints behind JWT authentication:
- `GET /metrics` now requires `requireAuth` middleware
- `GET /api/scraper/status` now requires `requireAuth` middleware

## Changes
- `server/src/app.ts` — import `requireAuth`, apply to `/metrics` route
- `server/src/routes/scraper.ts` — apply `requireAuth` to `/status` route
- `server/src/app.test.ts` — add 401 test for `/metrics` + auth mock
- `server/src/routes/scraper.test.ts` — add 401 test for `/status`, controllable auth mock
- `package-lock.json` — add missing `cookie-parser` dependency

## Tests
- 755 server tests pass (0 regressions)
- 173 scraper tests pass
- New 401 tests for both endpoints

## Acceptance Criteria

| AC | Description | Status |
|----|-------------|--------|
| AC1 | `/metrics` returns 401 without auth | Done |
| AC2 | `/api/scraper/status` returns 401 without auth | Done |
| AC3 | Authenticated `/metrics` still works | Done |
| AC4 | Authenticated `/api/scraper/status` still works | Done |

Closes #1078