### PR TITLE
chore(deps): patch transitive vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4366,9 +4366,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7713,9 +7713,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,9 @@
     "husky": "^9.1.7"
   },
   "overrides": {
-    "flatted": "^3.4.2"
+    "flatted": "^3.4.2",
+    "qs": "6.15.2",
+    "brace-expansion": "5.0.6"
   },
   "optionalDependencies": {
     "fsevents": "^2.3.3"


### PR DESCRIPTION
## Contexte
La branche `develop` conservait encore des vulnerabilites npm transitives qui reduisaient la confiance avant release :
- `qs` au runtime
- `brace-expansion` dans la chaine de tooling client

## Ce que fait cette PR
- ajoute des `overrides` npm au niveau racine pour forcer les versions corrigees
- regenere `package-lock.json` pour appliquer ces resolutions
- corrige les deux dependances transitives restantes :
  - `qs` -> `6.15.2`
  - `brace-expansion` -> `5.0.6`

## Validation
- `npm audit` -> `0 vulnerabilities`
- `cd client && npm test`
- `cd server && npm run test:run`
- `cd scraper && npm run test:run`

## Impact attendu
- plus d'alertes npm locales sur ces dependances transitives
- meilleur niveau de confiance pour proceder a la release

Closes #1092
