### PR TITLE
fix(api,client): stop exposing plaintext passwords in logs and HTTP responses

### DIFF
--- a/client/src/api/users.test.ts
+++ b/client/src/api/users.test.ts
@@ -235,7 +235,7 @@ describe('Users API Client', () => {
   });
 
   describe('resetUserPassword', () => {
-    it('should reset user password and return new password', async () => {
+    it('should send client-generated password and return user info', async () => {
       const mockResponse = {
         user: {
           id: 2,
@@ -244,7 +244,6 @@ describe('Users API Client', () => {
           role_name: 'user',
           created_at: '2024-01-02T00:00:00Z',
         },
-        newPassword: 'Abc123!@#$%^&*()',
       };
 
       vi.mocked(apiClient.post).mockResolvedValueOnce({
@@ -252,11 +251,12 @@ describe('Users API Client', () => {
         data: mockResponse,
       });
 
-      const result = await resetUserPassword(2);
+      const newPassword = 'Abc123!@#$%^&*()';
+      const result = await resetUserPassword(2, newPassword);
 
-      expect(apiClient.post).toHaveBeenCalledWith('/users/2/reset-password');
+      expect(apiClient.post).toHaveBeenCalledWith('/users/2/reset-password', { newPassword });
       expect(result).toEqual(mockResponse);
-      expect(result.newPassword).toHaveLength(16);
+      expect(result).not.toHaveProperty('newPassword');
     });
 
     it('should throw error when user not found', async () => {
@@ -265,7 +265,7 @@ describe('Users API Client', () => {
         error: 'User not found',
       });
 
-      await expect(resetUserPassword(999)).rejects.toThrow('User not found');
+      await expect(resetUserPassword(999, 'Abc123!@#$%^&*()')).rejects.toThrow('User not found');
     });
   });
 

--- a/client/src/api/users.ts
+++ b/client/src/api/users.ts
@@ -25,7 +25,6 @@ export interface UserRoleUpdate {
 
 export interface PasswordResetResult {
   user: UserPublic;
-  newPassword: string;
 }
 
 // ============================================================================
@@ -100,12 +99,13 @@ export async function updateUserRole(id: number, roleId: number): Promise<UserPu
 
 /**
  * Reset user password (admin only)
- * Generates a secure random password (16 characters)
+ * Sends a client-generated password to be hashed server-side
  * @param id User ID
- * @returns User and new password (must be shown to admin immediately)
+ * @param newPassword Password generated on the client side
+ * @returns User info (password NOT returned in response)
  */
-export async function resetUserPassword(id: number): Promise<PasswordResetResult> {
-  const response = await apiClient.post<ApiResponse<PasswordResetResult>>(`/users/${id}/reset-password`);
+export async function resetUserPassword(id: number, newPassword: string): Promise<PasswordResetResult> {
+  const response = await apiClient.post<ApiResponse<PasswordResetResult>>(`/users/${id}/reset-password`, { newPassword });
 
   if (!response.success || !response.data) {
     throw new Error(response.error || 'Failed to reset password');

--- a/client/src/pages/admin/UsersPage.test.tsx
+++ b/client/src/pages/admin/UsersPage.test.tsx
@@ -314,7 +314,6 @@ describe('UsersPage', () => {
       const user = userEvent.setup();
       vi.mocked(usersApi.resetUserPassword).mockResolvedValue({
         user: mockUsers[1],
-        newPassword: 'NewRandomPass123!',
       });
 
       renderWithAuth(<UsersPage />);
@@ -327,11 +326,10 @@ describe('UsersPage', () => {
       await user.click(resetButtons[1]);
 
       await waitFor(() => {
-        expect(usersApi.resetUserPassword).toHaveBeenCalledWith(2);
+        expect(usersApi.resetUserPassword).toHaveBeenCalledWith(2, expect.any(String));
       });
 
       expect(await screen.findByRole('heading', { name: /password reset successful/i })).toBeInTheDocument();
-      expect(screen.getByDisplayValue('NewRandomPass123!')).toBeInTheDocument();
     });
   });
 

--- a/client/src/pages/admin/UsersPage.tsx
+++ b/client/src/pages/admin/UsersPage.tsx
@@ -4,6 +4,7 @@ import type { UserPublic, UserCreate } from '../../api/users';
 import { rolesApi } from '../../api/roles';
 import type { RoleWithPermissions } from '../../types/role';
 import { AuthContext } from '../../contexts/AuthContext';
+import { generateRandomPassword } from '../../utils/password';
 import RoleBadge from '../../components/admin/RoleBadge';
 import CreateUserModal from '../../components/admin/CreateUserModal';
 import DeleteUserDialog from '../../components/admin/DeleteUserDialog';
@@ -157,10 +158,11 @@ const UsersPage: React.FC = () => {
   const handleResetPassword = async (userId: number) => {
     try {
       setError(null);
-      const result = await resetUserPassword(userId);
+      const newPassword = generateRandomPassword();
+      const result = await resetUserPassword(userId, newPassword);
       setPasswordResetData({
         username: result.user.username,
-        newPassword: result.newPassword,
+        newPassword,
       });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to reset password');

--- a/client/src/utils/password.test.ts
+++ b/client/src/utils/password.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { generateRandomPassword } from './password';
+
+describe('generateRandomPassword', () => {
+  it('should generate a 16-character password', () => {
+    const password = generateRandomPassword();
+    expect(password).toHaveLength(16);
+  });
+
+  it('should generate unique passwords on each call', () => {
+    const password1 = generateRandomPassword();
+    const password2 = generateRandomPassword();
+    const password3 = generateRandomPassword();
+
+    expect(password1).not.toBe(password2);
+    expect(password1).not.toBe(password3);
+    expect(password2).not.toBe(password3);
+  });
+
+  it('should contain at least one uppercase letter', () => {
+    const password = generateRandomPassword();
+    expect(password).toMatch(/[A-Z]/);
+  });
+
+  it('should contain at least one lowercase letter', () => {
+    const password = generateRandomPassword();
+    expect(password).toMatch(/[a-z]/);
+  });
+
+  it('should contain at least one digit', () => {
+    const password = generateRandomPassword();
+    expect(password).toMatch(/[0-9]/);
+  });
+
+  it('should contain at least one special character', () => {
+    const password = generateRandomPassword();
+    expect(password).toMatch(/[!@#$%^&*()_+\-=[\]{}|;:,.<>?]/);
+  });
+
+  it('should only contain valid characters', () => {
+    const validChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+-=[]{}|;:,.<>?';
+    const password = generateRandomPassword();
+    for (const char of password) {
+      expect(validChars).toContain(char);
+    }
+  });
+});

--- a/client/src/utils/password.ts
+++ b/client/src/utils/password.ts
@@ -1,0 +1,37 @@
+const UPPERCASE = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const LOWERCASE = 'abcdefghijklmnopqrstuvwxyz';
+const DIGITS = '0123456789';
+const SPECIAL = '!@#$%^&*()_+-=[]{}|;:,.<>?';
+const ALL = UPPERCASE + LOWERCASE + DIGITS + SPECIAL;
+const LENGTH = 16;
+
+function getRandomChar(chars: string, randomArray: Uint8Array, offset: number): string {
+  return chars[randomArray[offset] % chars.length];
+}
+
+function fisherYatesShuffle(chars: string[], randomArray: Uint8Array): void {
+  for (let i = chars.length - 1; i > 0; i--) {
+    const j = randomArray[i] % (chars.length);
+    [chars[i], chars[j]] = [chars[j], chars[i]];
+  }
+}
+
+export function generateRandomPassword(): string {
+  const randomArray = new Uint8Array(LENGTH * 2);
+  crypto.getRandomValues(randomArray);
+
+  let password = '';
+  password += getRandomChar(UPPERCASE, randomArray, 0);
+  password += getRandomChar(LOWERCASE, randomArray, 1);
+  password += getRandomChar(DIGITS, randomArray, 2);
+  password += getRandomChar(SPECIAL, randomArray, 3);
+
+  for (let i = 4; i < LENGTH; i++) {
+    password += getRandomChar(ALL, randomArray, i);
+  }
+
+  const chars = password.split('');
+  const shuffleRandom = randomArray.slice(LENGTH);
+  fisherYatesShuffle(chars, shuffleRandom);
+  return chars.join('');
+}

--- a/server/src/db/migrations.ts
+++ b/server/src/db/migrations.ts
@@ -285,12 +285,12 @@ async function handleAdminSeed(db: DB): Promise<void> {
   logger.warn('🔐 DEFAULT ADMIN USER CREATED');
   logger.warn('═══════════════════════════════════════════════════════════');
   logger.warn('Username: admin');
-  logger.warn(`Password: ${password}`);
+  console.log(`Password: ${password}`);
   logger.warn('═══════════════════════════════════════════════════════════');
   logger.warn('⚠️  SECURITY WARNING:');
   logger.warn('1. Save this password immediately');
   logger.warn('2. Change it after first login');
-  logger.warn('3. This password will NOT be shown again');
+  logger.warn('3. This password will NOT be logged or shown again');
   logger.warn('═══════════════════════════════════════════════════════════');
 }
 
@@ -349,11 +349,11 @@ async function handleAdminRoleIdSeed(db: DB): Promise<void> {
   logger.warn('🔐 DEFAULT ADMIN USER CREATED');
   logger.warn('═══════════════════════════════════════════════════════════');
   logger.warn('Username: admin');
-  logger.warn(`Password: ${password}`);
+  console.log(`Password: ${password}`);
   logger.warn('═══════════════════════════════════════════════════════════');
   logger.warn('⚠️  SECURITY WARNING:');
   logger.warn('1. Save this password immediately');
   logger.warn('2. Change it after first login');
-  logger.warn('3. This password will NOT be shown again');
+  logger.warn('3. This password will NOT be logged or shown again');
   logger.warn('═══════════════════════════════════════════════════════════');
 }

--- a/server/src/routes/users.test.ts
+++ b/server/src/routes/users.test.ts
@@ -579,54 +579,80 @@ describe('User Management Routes', () => {
   });
 
   describe('POST /api/users/:id/reset-password', () => {
-    it('should generate random password and update user (200)', async () => {
+    it('should accept client-generated password and update (200)', async () => {
       const mockUser = makeUser(2, 'user1', 2, 'operator', '2024-01-02T00:00:00Z');
 
       vi.mocked(userQueries.getUserById).mockResolvedValue(mockUser);
-      vi.mocked(userQueries.generateRandomPassword).mockReturnValue('RandomPass123!@#');
       vi.mocked(db.query).mockResolvedValue({ rows: [], rowCount: 1 } as any);
 
       const response = await request(app)
         .post('/api/users/2/reset-password')
-        .set('Authorization', 'Bearer valid-admin-token');
+        .set('Authorization', 'Bearer valid-admin-token')
+        .send({ newPassword: 'RandomPass123!@#' });
 
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
-      expect(response.body.data.newPassword).toBe('RandomPass123!@#');
+      expect(response.body.data.newPassword).toBeUndefined();
       expect(response.body.data.user).toEqual(mockUser);
     });
 
-    it('should return new password in response for admin to share', async () => {
+    it('should not return password in response', async () => {
       const mockUser = makeUser(2, 'user1', 2, 'operator', '2024-01-02T00:00:00Z');
 
       vi.mocked(userQueries.getUserById).mockResolvedValue(mockUser);
-      vi.mocked(userQueries.generateRandomPassword).mockReturnValue('NewPass456!@#');
       vi.mocked(db.query).mockResolvedValue({ rows: [], rowCount: 1 } as any);
 
       const response = await request(app)
         .post('/api/users/2/reset-password')
-        .set('Authorization', 'Bearer valid-admin-token');
+        .set('Authorization', 'Bearer valid-admin-token')
+        .send({ newPassword: 'NewPass456!@#' });
 
-      expect(response.body.data).toHaveProperty('newPassword');
-      expect(typeof response.body.data.newPassword).toBe('string');
+      expect(response.body.data).not.toHaveProperty('newPassword');
+      expect(response.body.data).toHaveProperty('user');
     });
 
     it('should hash password before storing', async () => {
       const mockUser = makeUser(2, 'user1', 2, 'operator', '2024-01-02T00:00:00Z');
 
       vi.mocked(userQueries.getUserById).mockResolvedValue(mockUser);
-      vi.mocked(userQueries.generateRandomPassword).mockReturnValue('RandomPass123!@#');
       vi.mocked(db.query).mockResolvedValue({ rows: [], rowCount: 1 } as any);
 
       await request(app)
         .post('/api/users/2/reset-password')
-        .set('Authorization', 'Bearer valid-admin-token');
+        .set('Authorization', 'Bearer valid-admin-token')
+        .send({ newPassword: 'RandomPass123!@#' });
 
-      // Verify password was hashed (scrypt format)
       expect(db.query).toHaveBeenCalled();
       const queryCall = vi.mocked(db.query).mock.calls[0];
       expect(queryCall[1][0]).toMatch(/^scrypt:/);
       expect(queryCall[1][0]).not.toBe('RandomPass123!@#');
+    });
+
+    it('should return 400 when newPassword is missing', async () => {
+      const mockUser = makeUser(2, 'user1', 2, 'operator', '2024-01-02T00:00:00Z');
+
+      vi.mocked(userQueries.getUserById).mockResolvedValue(mockUser);
+
+      const response = await request(app)
+        .post('/api/users/2/reset-password')
+        .set('Authorization', 'Bearer valid-admin-token')
+        .send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('password');
+    });
+
+    it('should return 400 when newPassword is empty string', async () => {
+      const mockUser = makeUser(2, 'user1', 2, 'operator', '2024-01-02T00:00:00Z');
+
+      vi.mocked(userQueries.getUserById).mockResolvedValue(mockUser);
+
+      const response = await request(app)
+        .post('/api/users/2/reset-password')
+        .set('Authorization', 'Bearer valid-admin-token')
+        .send({ newPassword: '' });
+
+      expect(response.status).toBe(400);
     });
 
     it('should return 404 for non-existent user', async () => {
@@ -634,7 +660,8 @@ describe('User Management Routes', () => {
 
       const response = await request(app)
         .post('/api/users/999/reset-password')
-        .set('Authorization', 'Bearer valid-admin-token');
+        .set('Authorization', 'Bearer valid-admin-token')
+        .send({ newPassword: 'RandomPass123!@#' });
 
       expect(response.status).toBe(404);
       expect(response.body.error).toBe('User not found');

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -12,7 +12,6 @@ import {
   updateUserRole,
   deleteUser,
   getAdminCount,
-  generateRandomPassword,
 } from '../db/user-queries.js';
 import { logger } from '../utils/logger.js';
 import { validatePasswordStrength } from '../utils/security.js';
@@ -284,8 +283,8 @@ router.put(
 
 /**
  * POST /api/users/:id/reset-password
- * Reset user's password to a randomly generated one
- * Requires admin authentication
+ * Reset user's password. Password is generated client-side and sent in request body.
+ * Requires admin authentication.
  */
 router.post(
   '/:id/reset-password',
@@ -298,24 +297,27 @@ router.post(
 
       const userId = parseStrictInt(req.params.id);
 
-      // Validate user ID
       if (isNaN(userId)) {
         return next(new ValidationError('Invalid user ID'));
       }
 
-      // Check if user exists
       const targetUser = await getUserById(db, userId);
       if (!targetUser) {
         return next(new NotFoundError('User not found'));
       }
 
-      // Generate new password
-      const newPassword = generateRandomPassword();
+      const { newPassword } = req.body;
+      if (!newPassword || typeof newPassword !== 'string') {
+        return next(new ValidationError('New password is required'));
+      }
 
-      // Hash password
+      const passwordError = validatePasswordStrength(newPassword);
+      if (passwordError) {
+        return next(new ValidationError(passwordError));
+      }
+
       const passwordHash = await hashPassword(newPassword);
 
-      // Update password in database
       await db.query('UPDATE users SET password_hash = $1 WHERE id = $2', [
         passwordHash,
         userId,
@@ -332,9 +334,8 @@ router.post(
         success: true,
         data: {
           user: targetUser,
-          newPassword,
         },
-      } as ApiResponse<{ user: UserPublic; newPassword: string }>);
+      } as ApiResponse<{ user: UserPublic }>);
     } catch (error) {
       next(error);
     }


### PR DESCRIPTION
## Summary

Fixes two critical password exposure vulnerabilities.

### Item 1 — Admin password in migration logs
- Replace `logger.warn()` with `console.log()` for admin password display in migrations
- Password goes to stdout (terminal) but bypasses Winston → not stored in Loki/Grafana
- Affects `handleAdminSeed()` and `handleAdminRoleIdSeed()` in `server/src/db/migrations.ts`

### Item 2 — Password reset: client-side generation
- Password is now generated client-side using Web Crypto API (`crypto.getRandomValues()`)
- New utility: `client/src/utils/password.ts` — browser-compatible `generateRandomPassword()`
- Password is sent to server as request body (never returned in HTTP response)
- Server validates, hashes, and stores; response contains only user info
- Removed unused `generateRandomPassword` import from `routes/users.ts`

### Files Changed
| File | Change |
|------|--------|
| `server/src/db/migrations.ts` | `logger.warn` → `console.log` for password (2 occurrences) |
| `server/src/routes/users.ts` | Accept password from `req.body`, validate, don't return |
| `server/src/routes/users.test.ts` | Updated tests: password in body, not in response |
| `client/src/utils/password.ts` | **NEW** — browser-compatible password generator |
| `client/src/utils/password.test.ts` | **NEW** — 7 tests |
| `client/src/api/users.ts` | `resetUserPassword()` now takes `newPassword` param |
| `client/src/api/users.test.ts` | Updated tests |
| `client/src/pages/admin/UsersPage.tsx` | Generates password before API call |
| `client/src/pages/admin/UsersPage.test.tsx` | Updated tests |

### Verification
- [x] Server: 800 tests pass, coverage 97.31% / 88.93%
- [x] Client: 62 affected tests pass
- [x] Scraper: 173 tests pass
- [x] TypeScript compiles clean

Closes #1094