### PR TITLE
fix(auth): add explicit HS256 algorithm to all JWT sign/verify calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ client/dist/
 .env.*
 !.env.example
 .env-*
+*.bak
 
 # Database
 data/

--- a/server/src/middleware/auth.test.ts
+++ b/server/src/middleware/auth.test.ts
@@ -27,7 +27,7 @@ describe('requireAuth (multi-secret verification)', () => {
     process.env.JWT_PREVIOUS_SECRETS = OLD_SECRET;
 
     const { requireAuth } = await import('./auth.js');
-    const token = jwt.sign({ id: 1, username: 'test' }, VALID_SECRET);
+    const token = jwt.sign({ id: 1, username: 'test' }, VALID_SECRET, { algorithm: 'HS256' });
     const req = { headers: { authorization: `Bearer ${token}` } } as any;
     const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
     const next = vi.fn();
@@ -42,7 +42,7 @@ describe('requireAuth (multi-secret verification)', () => {
     process.env.JWT_PREVIOUS_SECRETS = OLD_SECRET;
 
     const { requireAuth } = await import('./auth.js');
-    const token = jwt.sign({ id: 2, username: 'rotated' }, OLD_SECRET);
+    const token = jwt.sign({ id: 2, username: 'rotated' }, OLD_SECRET, { algorithm: 'HS256' });
     const req = { headers: { authorization: `Bearer ${token}` } } as any;
     const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
     const next = vi.fn();
@@ -57,7 +57,7 @@ describe('requireAuth (multi-secret verification)', () => {
     process.env.JWT_PREVIOUS_SECRETS = OLD_SECRET;
 
     const { requireAuth } = await import('./auth.js');
-    const token = jwt.sign({ id: 3, username: 'hacker' }, 'unknown-secret-min-32-chars-long-here!');
+    const token = jwt.sign({ id: 3, username: 'hacker' }, 'unknown-secret-min-32-chars-long-here!', { algorithm: 'HS256' });
     const req = { headers: { authorization: `Bearer ${token}` } } as any;
     const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
     const next = vi.fn();

--- a/server/src/middleware/rate-limit.test.ts
+++ b/server/src/middleware/rate-limit.test.ts
@@ -19,7 +19,7 @@ import rateLimit from 'express-rate-limit';
 
 // Helper: sign a minimal JWT for rate-limit key tests
 const makeToken = (userId: number): string =>
-  jwt.sign({ id: userId, username: `user${userId}` }, process.env.JWT_SECRET as string);
+  jwt.sign({ id: userId, username: `user${userId}` }, process.env.JWT_SECRET as string, { algorithm: 'HS256' });
 
 describe('Rate Limiting Middleware', () => {
   let app: express.Application;
@@ -210,7 +210,7 @@ describe('Rate Limiting Middleware', () => {
       tightApp.get('/p-invalid', tightLimiter, (_req, res) => res.json({ ok: true }));
 
       // Token with incorrect secret but same spoofed user ID 1
-      const spoofedToken = jwt.sign({ id: 1, username: 'user1' }, 'wrong-secret-minimum-32-chars-long-or-longer');
+      const spoofedToken = jwt.sign({ id: 1, username: 'user1' }, 'wrong-secret-minimum-32-chars-long-or-longer', { algorithm: 'HS256' });
       const sameIp = '1.2.3.4';
 
       // If it fails to verify, it falls back to IP fallback.
@@ -269,7 +269,7 @@ describe('Rate Limiting Middleware', () => {
     it('should verify tokens signed with a previous secret', async () => {
       const oldSecret = 'a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6_old';
       process.env.JWT_PREVIOUS_SECRETS = oldSecret;
-      const oldToken = jwt.sign({ id: 42, username: 'rotated-user' }, oldSecret);
+      const oldToken = jwt.sign({ id: 42, username: 'rotated-user' }, oldSecret, { algorithm: 'HS256' });
 
       const tightApp = express();
       tightApp.set('trust proxy', 1);

--- a/server/src/routes/auth.test.ts
+++ b/server/src/routes/auth.test.ts
@@ -42,7 +42,7 @@ vi.mock('../middleware/auth.js', () => ({
         const token = authHeader.split(' ')[1];
 
         try {
-            const decoded = jwt.verify(token, TEST_JWT_SECRET) as { id: number; username: string };
+            const decoded = jwt.verify(token, TEST_JWT_SECRET, { algorithms: ['HS256'] }) as { id: number; username: string };
             req.user = decoded;
             next();
         } catch (error) {
@@ -230,7 +230,7 @@ describe('Auth Routes', () => {
             validToken = jwt.sign(
                 { id: 1, username: 'testuser' },
                 JWT_SECRET,
-                { expiresIn: '24h' }
+                { algorithm: 'HS256', expiresIn: '24h' }
             );
         });
 

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -249,7 +249,7 @@ router.post('/refresh', authLimiter, async (req: Request, res: Response, next: N
                 permissions,
             },
             secret,
-            { expiresIn: expiresIn as any }
+            { algorithm: 'HS256', expiresIn: expiresIn as any }
         );
 
         // Set new refresh token cookie

--- a/server/src/services/auth-service.ts
+++ b/server/src/services/auth-service.ts
@@ -44,7 +44,7 @@ export class AuthService {
         permissions,
       },
       secret,
-      { expiresIn: expiresIn as any }
+      { algorithm: 'HS256', expiresIn: expiresIn as any }
     );
 
     return {

--- a/server/src/utils/jwt-secrets.test.ts
+++ b/server/src/utils/jwt-secrets.test.ts
@@ -89,19 +89,19 @@ describe('verifyWithMultipleSecrets', () => {
   const payload = { id: 1, username: 'test' };
 
   it('should verify token signed with current secret (first in list)', () => {
-    const token = jwt.sign(payload, VALID_SECRET);
+    const token = jwt.sign(payload, VALID_SECRET, { algorithm: 'HS256' });
     const decoded = verifyWithMultipleSecrets(token, [VALID_SECRET, ANOTHER_VALID_SECRET]);
     expect(decoded.id).toBe(1);
   });
 
   it('should verify token signed with previous secret', () => {
-    const token = jwt.sign(payload, ANOTHER_VALID_SECRET);
+    const token = jwt.sign(payload, ANOTHER_VALID_SECRET, { algorithm: 'HS256' });
     const decoded = verifyWithMultipleSecrets(token, [VALID_SECRET, ANOTHER_VALID_SECRET]);
     expect(decoded.id).toBe(1);
   });
 
   it('should throw on token signed with unknown secret', () => {
-    const token = jwt.sign(payload, 'unknown-secret-that-is-at-least-32-chars-long!');
+    const token = jwt.sign(payload, 'unknown-secret-that-is-at-least-32-chars-long!', { algorithm: 'HS256' });
     expect(() => verifyWithMultipleSecrets(token, [VALID_SECRET])).toThrow();
   });
 
@@ -110,7 +110,7 @@ describe('verifyWithMultipleSecrets', () => {
   });
 
   it('should verify current secret first (fast path)', () => {
-    const token = jwt.sign(payload, VALID_SECRET);
+    const token = jwt.sign(payload, VALID_SECRET, { algorithm: 'HS256' });
     const start = performance.now();
     for (let i = 0; i < 100; i++) {
       verifyWithMultipleSecrets(token, [VALID_SECRET, ANOTHER_VALID_SECRET]);

--- a/server/src/utils/jwt-secrets.ts
+++ b/server/src/utils/jwt-secrets.ts
@@ -57,7 +57,7 @@ export function verifyWithMultipleSecrets(token: string, secrets: string[]): jwt
 
   for (let i = 0; i < secrets.length; i++) {
     try {
-      const decoded = jwt.verify(token, secrets[i]) as jwt.JwtPayload;
+      const decoded = jwt.verify(token, secrets[i], { algorithms: ['HS256'] }) as jwt.JwtPayload;
       if (i > 0) {
         logger.debug(`JWT verified with previous secret (index ${i + 1})`);
       }


### PR DESCRIPTION
## Summary

Hardens JWT configuration against algorithm confusion and downgrade attacks.

### Changes
- `jwt.sign()` calls now explicitly set `algorithm: 'HS256'`
- `jwt.verify()` calls now explicitly set `algorithms: ['HS256']`
- Prevents symmetric algorithm confusion (HS384, HS512, etc.)
- Adds `*.bak` to `.gitignore` for defense-in-depth

### Files Changed
| File | Change |
|------|--------|
| `server/src/services/auth-service.ts` | `algorithm: 'HS256'` on login JWT |
| `server/src/routes/auth.ts` | `algorithm: 'HS256'` on refresh JWT |
| `server/src/utils/jwt-secrets.ts` | `algorithms: ['HS256']` on verify |
| `server/src/utils/jwt-secrets.test.ts` | Updated all `jwt.sign()` test calls |
| `server/src/middleware/auth.test.ts` | Updated all `jwt.sign()` test calls |
| `server/src/middleware/rate-limit.test.ts` | Updated all `jwt.sign()` test calls |
| `server/src/routes/auth.test.ts` | Updated `jwt.sign()` and `jwt.verify()` test calls |
| `.gitignore` | Added `*.bak` pattern |

### Verification
- [x] Server: 800 tests pass
- [x] Scraper: 173 tests pass
- [x] Coverage: 97.31% / 88.93%
- [x] TypeScript compiles clean

Closes #1095