### PR TITLE
fix(cors): block requests with no or null origin on auth routes

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -47,8 +47,7 @@ export function createApp() {
   // Security: Helmet with strict CSP (no unsafe-inline/unsafe-eval in script-src)
   // Note: style-src keeps unsafe-inline for React inline styles in 3 components
   // (ScrapeProgress, ColorPicker, FontSelector use dynamic inline styles)
-  app.use(
-    helmet({
+  app.use(helmet({
       contentSecurityPolicy: {
         directives: {
           defaultSrc: ["'self'"],
@@ -67,7 +66,6 @@ export function createApp() {
       },
     })
   );
-  app.use(cors(getCorsOptions()));
   app.use(morgan('combined'));
   app.use(express.json());
   app.use(express.urlencoded({ extended: false }));
@@ -96,8 +94,11 @@ export function createApp() {
   // Rate limiting for all API routes
   app.use('/api', generalLimiter);
 
-  // API routes
-  app.use('/api/auth', authRouter);
+  // Auth routes use strict CORS to prevent sandboxed iframe attacks (issue #1096)
+  app.use('/api/auth', cors(getCorsOptions({ strict: true })), authRouter);
+
+  // All other API routes use lenient CORS (allows curl/mobile requests without Origin header)
+  app.use('/api', cors(getCorsOptions()));
   app.use('/api/movies', moviesRouter);
   app.use('/api/theaters', theatersRouter);
   app.use('/api/scraper', scraperRouter);

--- a/server/src/utils/cors-config.test.ts
+++ b/server/src/utils/cors-config.test.ts
@@ -95,3 +95,90 @@ describe('getCorsOptions', () => {
     }
   });
 });
+
+describe('getCorsOptions strict mode', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should block requests with no origin (undefined)', () => {
+    process.env.ALLOWED_ORIGINS = 'http://example.com';
+    const options = getCorsOptions({ strict: true });
+
+    const originCheck = options.origin;
+    const callback = vi.fn();
+
+    if (typeof originCheck === 'function') {
+      // @ts-ignore
+      originCheck(undefined, callback);
+      expect(callback).toHaveBeenCalledWith(expect.any(Error));
+    }
+  });
+
+  it('should block requests with null origin', () => {
+    process.env.ALLOWED_ORIGINS = 'http://example.com';
+    const options = getCorsOptions({ strict: true });
+
+    const originCheck = options.origin;
+    const callback = vi.fn();
+
+    if (typeof originCheck === 'function') {
+      // @ts-ignore
+      originCheck('null', callback);
+      expect(callback).toHaveBeenCalledWith(expect.any(Error));
+    }
+  });
+
+  it('should block requests with empty string origin', () => {
+    process.env.ALLOWED_ORIGINS = 'http://example.com';
+    const options = getCorsOptions({ strict: true });
+
+    const originCheck = options.origin;
+    const callback = vi.fn();
+
+    if (typeof originCheck === 'function') {
+      // @ts-ignore
+      originCheck('', callback);
+      expect(callback).toHaveBeenCalledWith(expect.any(Error));
+    }
+  });
+
+  it('should still allow requests from allowed origins in strict mode', () => {
+    process.env.ALLOWED_ORIGINS = 'http://example.com,http://test.com';
+    const options = getCorsOptions({ strict: true });
+
+    const originCheck = options.origin;
+    const callback = vi.fn();
+
+    if (typeof originCheck === 'function') {
+      // @ts-ignore
+      originCheck('http://example.com', callback);
+      expect(callback).toHaveBeenCalledWith(null, true);
+
+      // @ts-ignore
+      originCheck('http://test.com', callback);
+      expect(callback).toHaveBeenCalledWith(null, true);
+    }
+  });
+
+  it('should still block requests from disallowed origins in strict mode', () => {
+    process.env.ALLOWED_ORIGINS = 'http://example.com';
+    const options = getCorsOptions({ strict: true });
+
+    const originCheck = options.origin;
+    const callback = vi.fn();
+
+    if (typeof originCheck === 'function') {
+      // @ts-ignore
+      originCheck('http://hacker.com', callback);
+      expect(callback).toHaveBeenCalledWith(expect.any(Error));
+    }
+  });
+});

--- a/server/src/utils/cors-config.ts
+++ b/server/src/utils/cors-config.ts
@@ -1,6 +1,11 @@
 import { CorsOptions } from 'cors';
 
-export const getCorsOptions = (): CorsOptions => {
+export interface CorsConfigOptions {
+  strict?: boolean;
+}
+
+export const getCorsOptions = (opts: CorsConfigOptions = {}): CorsOptions => {
+  const { strict = false } = opts;
   const allowedOriginsEnv = process.env.ALLOWED_ORIGINS;
   const allowedOrigins = allowedOriginsEnv
     ? allowedOriginsEnv.split(',').map((origin) => origin.trim())
@@ -8,7 +13,17 @@ export const getCorsOptions = (): CorsOptions => {
 
   return {
     origin: (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) => {
-      // Allow requests with no origin (like mobile apps or curl requests)
+      // Strict mode: block requests with no origin (prevents sandboxed iframe attacks)
+      if (strict && (!origin || origin === 'null')) {
+        return callback(
+          new Error(
+            `CORS blocked request with no or null origin in strict mode. ` +
+            `Requests to this endpoint must include a valid Origin header.`
+          )
+        );
+      }
+
+      // Lenient mode: allow requests with no origin (mobile apps or curl requests)
       if (!origin) {
         return callback(null, true);
       }


### PR DESCRIPTION
## Summary

- Added optional `strict` mode parameter to `getCorsOptions()` that rejects requests without a valid `Origin` header
- Applied strict CORS to `/api/auth` routes to prevent sandboxed iframe CSRF attacks via null origin bypass
- Public API routes continue to use lenient CORS (allows curl/mobile requests without Origin header)
- Added 5 new tests for strict CORS behavior (null origin, undefined origin, empty origin, allowed origins, disallowed origins)

## Changes

- `server/src/utils/cors-config.ts` — Added `CorsConfigOptions` interface with `strict` flag; strict mode blocks `!origin` and `origin === 'null'`
- `server/src/utils/cors-config.test.ts` — Added `getCorsOptions strict mode` describe block with 5 test cases
- `server/src/app.ts` — Removed global CORS middleware; applied strict CORS on `/api/auth`, lenient CORS on `/api/*`

Closes #1096