### PR TITLE
fix(security): make refresh token rotation atomic using DB transaction

### DIFF
--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -35,7 +35,10 @@ export const db = {
       await client.query('COMMIT');
       return result;
     } catch (error) {
-      await client.query('ROLLBACK');
+      try {
+        await client.query('ROLLBACK');
+      } catch {
+      }
       throw error;
     } finally {
       client.release();

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -20,9 +20,27 @@ export const pool = new pg.Pool(
   connectionString ? { connectionString } : config
 );
 
+export interface TransactionClient {
+  query: (text: string, params?: any[]) => Promise<pg.QueryResult<any>>;
+}
+
 // Wrapper pour garder une API similaire si nécessaire, ou on utilise directement pool
 export const db = {
   query: <T extends pg.QueryResultRow = any>(text: string, params?: any[]) => pool.query<T>(text, params),
+  transaction: async <T>(fn: (client: TransactionClient) => Promise<T>): Promise<T> => {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const result = await fn(client);
+      await client.query('COMMIT');
+      return result;
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  },
   // Méthode utilitaire pour fermer la connexion (utile pour les scripts one-off)
   end: () => pool.end()
 };

--- a/server/src/routes/auth.test.ts
+++ b/server/src/routes/auth.test.ts
@@ -5,6 +5,7 @@ process.env.JWT_SECRET = 'a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6';
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import express from 'express';
+import cookieParser from 'cookie-parser';
 import request from 'supertest';
 import * as passwordUtils from '../utils/password.js';
 import jwt from 'jsonwebtoken';
@@ -12,12 +13,14 @@ import authRouter from './auth.js';
 import { db } from '../db/client.js';
 import * as queries from '../db/user-queries.js';
 import type { AuthRequest } from '../middleware/auth.js';
+import { RefreshTokenService } from '../services/refresh-token-service.js';
 
 const TEST_JWT_SECRET = 'a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6';
 
 vi.mock('../db/client.js', () => ({
     db: {
         query: vi.fn(),
+        transaction: vi.fn(),
     },
 }));
 
@@ -26,6 +29,26 @@ vi.mock('../db/user-queries.js');
 vi.mock('../db/role-queries.js', () => ({
     getPermissionNamesByRoleId: vi.fn().mockResolvedValue(['settings:read', 'reports:list']),
 }));
+
+vi.mock('../services/refresh-token-service.js', () => {
+    const mockValidate = vi.fn();
+    const mockRotate = vi.fn();
+    const mockRevoke = vi.fn();
+    const mockGenerate = vi.fn();
+
+    return {
+        RefreshTokenService: vi.fn(function() {
+            this.validate = mockValidate;
+            this.rotate = mockRotate;
+            this.revoke = mockRevoke;
+            this.generate = mockGenerate;
+        }),
+        __mockValidate: mockValidate,
+        __mockRotate: mockRotate,
+        __mockRevoke: mockRevoke,
+        __mockGenerate: mockGenerate,
+    };
+});
 
 // Mock the auth middleware with proper JWT verification using test secret
 vi.mock('../middleware/auth.js', () => ({
@@ -61,6 +84,7 @@ vi.mock('../middleware/permission.js', () => ({
 
 const app = express();
 app.use(express.json());
+app.use(cookieParser());
 app.set('db', db); // Register mock db for dependency injection
 app.use('/api/auth', authRouter);
 app.use(errorHandler);
@@ -492,6 +516,65 @@ describe('Auth Routes', () => {
             expect(response.status).toBe(500);
             expect(response.body.success).toBe(false);
             expect(response.body.error).toBe('Database error');
+        });
+    });
+
+    describe('POST /api/auth/refresh', () => {
+        it('should return new access token for valid refresh token', async () => {
+            const refreshTokenMocks = await import('../services/refresh-token-service.js');
+            const mockValidate = (refreshTokenMocks as any).__mockValidate;
+            const mockRotate = (refreshTokenMocks as any).__mockRotate;
+            const mockGenerate = (refreshTokenMocks as any).__mockGenerate;
+            const mockRevoke = (refreshTokenMocks as any).__mockRevoke;
+
+            mockValidate.mockResolvedValue(1);
+            mockRotate.mockResolvedValue('new-refresh-token-raw');
+
+            vi.mocked(db.query).mockResolvedValue({
+                rows: [{
+                    id: 1,
+                    username: 'testuser',
+                    role_id: 2,
+                    role_name: 'user',
+                    is_system_role: false,
+                }],
+            });
+
+            const response = await request(app)
+                .post('/api/auth/refresh')
+                .set('Cookie', 'refresh_token=valid-old-token');
+
+            expect(response.status).toBe(200);
+            expect(response.body.success).toBe(true);
+            expect(response.body.data.token).toBeDefined();
+            expect(response.body.data.user.username).toBe('testuser');
+            expect(mockRotate).toHaveBeenCalledWith(1, 'valid-old-token');
+            expect(mockGenerate).not.toHaveBeenCalled();
+            expect(mockRevoke).not.toHaveBeenCalled();
+        });
+
+        it('should return 401 if no refresh token cookie', async () => {
+            const response = await request(app)
+                .post('/api/auth/refresh');
+
+            expect(response.status).toBe(401);
+            expect(response.body.success).toBe(false);
+            expect(response.body.error).toBe('No refresh token provided.');
+        });
+
+        it('should return 401 if refresh token is invalid', async () => {
+            const refreshTokenMocks = await import('../services/refresh-token-service.js');
+            const mockValidate = (refreshTokenMocks as any).__mockValidate;
+
+            mockValidate.mockResolvedValue(null);
+
+            const response = await request(app)
+                .post('/api/auth/refresh')
+                .set('Cookie', 'refresh_token=invalid-token');
+
+            expect(response.status).toBe(401);
+            expect(response.body.success).toBe(false);
+            expect(response.body.error).toBe('Invalid or expired refresh token.');
         });
     });
 });

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -223,12 +223,8 @@ router.post('/refresh', authLimiter, async (req: Request, res: Response, next: N
 
         const user = userResult.rows[0];
 
-        // Generate new refresh token FIRST (before revoking old one)
-        // This ensures we never lose the refresh token if generate fails
-        const newRefreshToken = await refreshTokenService.generate(userId);
-
-        // Revoke the old refresh token (rotation — only after new one is secured)
-        await refreshTokenService.revoke(refreshToken);
+        // Atomically rotate: generate new token AND revoke old one in one transaction
+        const newRefreshToken = await refreshTokenService.rotate(userId, refreshToken);
 
         // Generate new access token
         const jwt = await import('jsonwebtoken');

--- a/server/src/services/refresh-token-service.test.ts
+++ b/server/src/services/refresh-token-service.test.ts
@@ -53,11 +53,13 @@ describe('RefreshTokenService', () => {
   let service: RefreshTokenService;
   let mockDb: {
     query: ReturnType<typeof vi.fn>;
+    transaction: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
     mockDb = {
       query: vi.fn(),
+      transaction: vi.fn(),
     };
     service = new RefreshTokenService(mockDb as unknown as DB);
   });
@@ -206,6 +208,51 @@ describe('RefreshTokenService', () => {
         expect.stringContaining('DELETE FROM refresh_tokens'),
         [7]
       );
+    });
+  });
+
+  describe('rotate', () => {
+    it('should atomically revoke old token and generate new token', async () => {
+      let committed = false;
+      let rolledBack = false;
+
+      mockDb.transaction.mockImplementation(async (fn) => {
+        const clientQuery = vi.fn().mockResolvedValue({ rows: [] });
+        const client = { query: clientQuery };
+        const result = await fn(client);
+        committed = true;
+        return result;
+      });
+
+      const newToken = await service.rotate(1, 'old-raw-token');
+
+      expect(newToken).toBeDefined();
+      expect(newToken.length).toBeGreaterThan(32);
+      expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+      expect(committed).toBe(true);
+    });
+
+    it('should rollback transaction on failure — no partial state', async () => {
+      const dbError = new Error('DB connection lost');
+
+      mockDb.transaction.mockImplementation(async () => {
+        throw dbError;
+      });
+
+      await expect(service.rotate(1, 'old-raw-token')).rejects.toThrow('DB connection lost');
+      expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('should accept custom expiry', async () => {
+      mockDb.transaction.mockImplementation(async (fn) => {
+        const clientQuery = vi.fn().mockResolvedValue({ rows: [] });
+        return fn({ query: clientQuery });
+      });
+
+      const newToken = await service.rotate(1, 'old-token', 3600_000);
+
+      expect(newToken).toBeDefined();
+      expect(mockDb.transaction).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/server/src/services/refresh-token-service.test.ts
+++ b/server/src/services/refresh-token-service.test.ts
@@ -214,10 +214,15 @@ describe('RefreshTokenService', () => {
   describe('rotate', () => {
     it('should atomically revoke old token and generate new token', async () => {
       let committed = false;
-      let rolledBack = false;
+      const issuedQueries: { sql: string; params: any[] }[] = [];
 
       mockDb.transaction.mockImplementation(async (fn) => {
-        const clientQuery = vi.fn().mockResolvedValue({ rows: [] });
+        const clientQuery = vi.fn().mockImplementation((sql: string, params: any[]) => {
+          issuedQueries.push({ sql, params });
+          // First call: UPDATE — must return rowCount=1
+          if (issuedQueries.length === 1) return Promise.resolve({ rows: [], rowCount: 1 });
+          return Promise.resolve({ rows: [] });
+        });
         const client = { query: clientQuery };
         const result = await fn(client);
         committed = true;
@@ -230,6 +235,37 @@ describe('RefreshTokenService', () => {
       expect(newToken.length).toBeGreaterThan(32);
       expect(mockDb.transaction).toHaveBeenCalledTimes(1);
       expect(committed).toBe(true);
+      expect(issuedQueries).toHaveLength(2);
+      expect(issuedQueries[0].sql).toContain('UPDATE refresh_tokens');
+      expect(issuedQueries[0].sql).toContain('user_id');
+      expect(issuedQueries[0].sql).toContain('revoked_at IS NULL');
+      expect(issuedQueries[0].params).toEqual([expect.any(String), 1]);
+      expect(issuedQueries[1].sql).toContain('INSERT INTO refresh_tokens');
+    });
+
+    it('should throw when old token is already revoked (rowCount=0)', async () => {
+      mockDb.transaction.mockImplementation(async (fn) => {
+        const clientQuery = vi.fn()
+          .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+        const client = { query: clientQuery };
+        return fn(client);
+      });
+
+      await expect(service.rotate(1, 'already-revoked-token'))
+        .rejects.toThrow('Refresh token already consumed or invalid');
+      expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw when token belongs to a different user', async () => {
+      mockDb.transaction.mockImplementation(async (fn) => {
+        const clientQuery = vi.fn()
+          .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+        const client = { query: clientQuery };
+        return fn(client);
+      });
+
+      await expect(service.rotate(1, 'bobs-token'))
+        .rejects.toThrow('Refresh token already consumed or invalid');
     });
 
     it('should rollback transaction on failure — no partial state', async () => {
@@ -245,7 +281,9 @@ describe('RefreshTokenService', () => {
 
     it('should accept custom expiry', async () => {
       mockDb.transaction.mockImplementation(async (fn) => {
-        const clientQuery = vi.fn().mockResolvedValue({ rows: [] });
+        const clientQuery = vi.fn()
+          .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+          .mockResolvedValue({ rows: [] });
         return fn({ query: clientQuery });
       });
 

--- a/server/src/services/refresh-token-service.ts
+++ b/server/src/services/refresh-token-service.ts
@@ -108,6 +108,37 @@ export class RefreshTokenService {
   }
 
   /**
+   * Atomically rotate a refresh token: revoke the old one and generate a new one
+   * inside a single database transaction. If any part fails, the entire operation
+   * is rolled back — no two-token state can persist.
+   *
+   * Returns the raw new token on success.
+   */
+  async rotate(userId: number, oldToken: string, expiryMs: number = DEFAULT_EXPIRY_MS): Promise<string> {
+    const oldTokenHash = this.hashToken(oldToken);
+    const rawToken = crypto.randomBytes(48).toString('base64url');
+    const newTokenHash = this.hashToken(rawToken);
+    const expiresAt = new Date(Date.now() + expiryMs);
+
+    await this.db.transaction(async (client) => {
+      await client.query(
+        `UPDATE refresh_tokens SET revoked_at = NOW()
+         WHERE token_hash = $1 AND revoked_at IS NULL`,
+        [oldTokenHash]
+      );
+
+      await client.query(
+        `INSERT INTO refresh_tokens (user_id, token_hash, expires_at)
+         VALUES ($1, $2, $3)`,
+        [userId, newTokenHash, expiresAt]
+      );
+    });
+
+    logger.debug(`Refresh token rotated for user ${userId}`);
+    return rawToken;
+  }
+
+  /**
    * Revoke all refresh tokens for a user (e.g., on password change or logout-all).
    */
   async revokeAllForUser(userId: number): Promise<void> {

--- a/server/src/services/refresh-token-service.ts
+++ b/server/src/services/refresh-token-service.ts
@@ -121,11 +121,15 @@ export class RefreshTokenService {
     const expiresAt = new Date(Date.now() + expiryMs);
 
     await this.db.transaction(async (client) => {
-      await client.query(
+      const updateResult = await client.query(
         `UPDATE refresh_tokens SET revoked_at = NOW()
-         WHERE token_hash = $1 AND revoked_at IS NULL`,
-        [oldTokenHash]
+         WHERE token_hash = $1 AND user_id = $2 AND revoked_at IS NULL`,
+        [oldTokenHash, userId]
       );
+
+      if (updateResult.rowCount === 0) {
+        throw new Error('Refresh token already consumed or invalid');
+      }
 
       await client.query(
         `INSERT INTO refresh_tokens (user_id, token_hash, expires_at)


### PR DESCRIPTION
## Summary

Replaces the two-step generate-then-revoke refresh token pattern with a single atomic `rotate()` method inside a PostgreSQL transaction.

## The Bug

Between `generate()` and `revoke()`, both old and new tokens were valid simultaneously. If the server crashed between those two calls, the old token was never revoked — leaving two valid tokens permanently.

## Fix

- Added `transaction()` helper to `db/client.ts` using a dedicated `PoolClient` with `BEGIN/COMMIT/ROLLBACK`
- Added `rotate(userId, oldToken)` to `RefreshTokenService` that atomically revokes the old and generates the new
- Updated `POST /api/auth/refresh` to use `rotate()` instead of `generate()+revoke()`
- If any part of the transaction fails, the entire operation rolls back — no two-token state

## Changes

| File | Change |
|------|--------|
| `server/src/db/client.ts` | Add `transaction()` method + `TransactionClient` interface |
| `server/src/services/refresh-token-service.ts` | Add `rotate()` method |
| `server/src/routes/auth.ts` | Replace generate+revoke with atomic rotate() |
| `server/src/services/refresh-token-service.test.ts` | Tests for rotate() including rollback |
| `server/src/routes/auth.test.ts` | Integration tests for refresh endpoint |

Closes #1102