### PR TITLE
chore: remove claudette MCP server from opencode config

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -8,11 +8,4 @@
       "*": "allow"
     }
   },
-  "mcp": {
-    "claudette": {
-      "type": "local",
-      "command": ["claudette", "serve"],
-      "enabled": true
-    }
-  }
 }


### PR DESCRIPTION
Removes the unused `claudette` MCP server entry from `opencode.json`.