### PR TITLE
fix(security): migrate access token to httpOnly cookie, use SHA-256 ETags, pin Node engine

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,6 +92,12 @@ TZ=Europe/Paris
 # AUTHENTICATION & SECURITY
 # ============================================================================
 
+# Cookie Secure flag — whether Set-Cookie headers include the Secure attribute.
+# Must be true when behind HTTPS / TLS-terminating reverse proxy.
+# Set to false only for local dev over plain HTTP (docker-compose.dev.yml does this).
+# Default: true (secure cookies)
+COOKIE_SECURE=true
+
 # JWT secret for signing authentication tokens
 # 
 # ⚠️ CRITICAL SECURITY REQUIREMENT:
@@ -224,8 +230,9 @@ REFRESH_TOKEN_EXPIRY=7d
 # ============================================================================
 
 # Docker image tag for ics-web service (when using pre-built images)
-# Default: latest
-# Examples: latest, v1.0.0, main, develop
+# ALWAYS pin to a specific version in production to avoid untested builds.
+# Default: latest (development only — use a specific version tag in production)
+# Examples: latest, v4.2.0, main, develop
 IMAGE_TAG=latest
 
 # Docker User Permissions (for volume write permissions)

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -54,8 +54,8 @@ async function refreshAccessToken(): Promise<boolean> {
     if (!response.ok) return false;
 
     const data = await response.json();
-    if (data.success && data.data?.token) {
-      if (data.data.user) {
+    if (data.success) {
+      if (data.data?.user) {
         localStorage.setItem('user', JSON.stringify(data.data.user));
       }
       unauthorizedDispatched = false;

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -55,11 +55,9 @@ async function refreshAccessToken(): Promise<boolean> {
 
     const data = await response.json();
     if (data.success && data.data?.token) {
-      localStorage.setItem('token', data.data.token);
       if (data.data.user) {
         localStorage.setItem('user', JSON.stringify(data.data.user));
       }
-      // Reset the dedup flag on successful refresh
       unauthorizedDispatched = false;
       return true;
     }
@@ -97,12 +95,6 @@ async function fetchClient<T>(endpoint: string, options: RequestInit = {}): Prom
     headers.set('Content-Type', 'application/json');
   }
 
-  // Add auth token
-  const token = localStorage.getItem('token');
-  if (token) {
-    headers.set('Authorization', `Bearer ${token}`);
-  }
-
   // Add CSRF token for mutation requests
   const method = (options.method || 'GET').toUpperCase();
   if (!['GET', 'HEAD', 'OPTIONS'].includes(method)) {
@@ -133,11 +125,7 @@ async function fetchClient<T>(endpoint: string, options: RequestInit = {}): Prom
       const refreshed = await refreshPromise;
 
       if (refreshed) {
-        // Retry the original request with new token
-        const newToken = localStorage.getItem('token');
-        if (newToken) {
-          headers.set('Authorization', `Bearer ${newToken}`);
-        }
+        // Retry the original request — browser sends access_token cookie automatically
         // Re-read CSRF token (may have been rotated)
         const newCsrfToken = getCsrfToken();
         if (newCsrfToken && !['GET', 'HEAD', 'OPTIONS'].includes(method)) {

--- a/client/src/contexts/AuthContext.test.tsx
+++ b/client/src/contexts/AuthContext.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, waitFor } from '@testing-library/react';
 import { useContext } from 'react';
 import { AuthContext, type User } from './AuthContext';
 import { AuthProvider } from './AuthProvider';
@@ -60,7 +60,7 @@ describe('AuthContext', () => {
       expect(screen.getByTestId('isAdmin').textContent).toBe('false');
     });
 
-    it('should be authenticated when user is in localStorage', () => {
+    it('should be authenticated when user is in localStorage', async () => {
       localStorage.setItem('user', JSON.stringify(operatorUser));
 
       render(
@@ -69,13 +69,15 @@ describe('AuthContext', () => {
         </AuthProvider>
       );
 
-      expect(screen.getByTestId('isAuthenticated').textContent).toBe('true');
+      await waitFor(() => {
+        expect(screen.getByTestId('isAuthenticated').textContent).toBe('true');
+      });
       expect(screen.getByTestId('username').textContent).toBe('operator');
     });
   });
 
   describe('User interface', () => {
-    it('should expose role_id and role_name on the User type', () => {
+    it('should expose role_id and role_name on the User type', async () => {
       localStorage.setItem('user', JSON.stringify(operatorUser));
 
       render(
@@ -84,7 +86,9 @@ describe('AuthContext', () => {
         </AuthProvider>
       );
 
-      expect(screen.getByTestId('isAuthenticated').textContent).toBe('true');
+      await waitFor(() => {
+        expect(screen.getByTestId('isAuthenticated').textContent).toBe('true');
+      });
       expect(screen.getByTestId('username').textContent).toBe('operator');
       expect(screen.getByTestId('role_name').textContent).toBe('operator');
     });
@@ -192,7 +196,7 @@ describe('AuthContext', () => {
       return (
         <div>
           <span data-testid="auth">{String(ctx.isAuthenticated)}</span>
-          <button onClick={() => ctx.login('tok', adminUser)}>Login</button>
+          <button onClick={() => ctx.login(adminUser)}>Login</button>
           <button onClick={() => ctx.logout()}>Logout</button>
         </div>
       );
@@ -223,7 +227,9 @@ describe('AuthContext', () => {
         </AuthProvider>
       );
 
-      expect(screen.getByTestId('auth').textContent).toBe('true');
+      await waitFor(() => {
+        expect(screen.getByTestId('auth').textContent).toBe('true');
+      });
 
       await act(async () => {
         screen.getByRole('button', { name: 'Logout' }).click();

--- a/client/src/contexts/AuthContext.test.tsx
+++ b/client/src/contexts/AuthContext.test.tsx
@@ -4,16 +4,6 @@ import { useContext } from 'react';
 import { AuthContext, type User } from './AuthContext';
 import { AuthProvider } from './AuthProvider';
 
-function createTokenWithExp(exp: number): string {
-  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
-  const payload = btoa(JSON.stringify({ exp })).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
-  return `${header}.${payload}.signature`;
-}
-
-function createValidToken(): string {
-  return createTokenWithExp(Math.floor(Date.now() / 1000) + 3600);
-}
-
 const adminUser: User = {
   id: 1,
   username: 'admin',
@@ -70,25 +60,7 @@ describe('AuthContext', () => {
       expect(screen.getByTestId('isAdmin').textContent).toBe('false');
     });
 
-    it('should treat expired token as unauthenticated', () => {
-      const expired = createTokenWithExp(Math.floor(Date.now() / 1000) - 60);
-      localStorage.setItem('token', expired);
-      localStorage.setItem('user', JSON.stringify(adminUser));
-
-      render(
-        <AuthProvider>
-          <ContextConsumer />
-        </AuthProvider>
-      );
-
-      expect(screen.getByTestId('isAuthenticated').textContent).toBe('false');
-      expect(localStorage.getItem('token')).toBeNull();
-      expect(localStorage.getItem('user')).toBeNull();
-    });
-
-    it('should keep valid token authenticated', () => {
-      const valid = createTokenWithExp(Math.floor(Date.now() / 1000) + 3600);
-      localStorage.setItem('token', valid);
+    it('should be authenticated when user is in localStorage', () => {
       localStorage.setItem('user', JSON.stringify(operatorUser));
 
       render(
@@ -100,26 +72,10 @@ describe('AuthContext', () => {
       expect(screen.getByTestId('isAuthenticated').textContent).toBe('true');
       expect(screen.getByTestId('username').textContent).toBe('operator');
     });
-
-    it('should treat malformed token as unauthenticated', () => {
-      localStorage.setItem('token', 'not-a-jwt');
-      localStorage.setItem('user', JSON.stringify(adminUser));
-
-      render(
-        <AuthProvider>
-          <ContextConsumer />
-        </AuthProvider>
-      );
-
-      expect(screen.getByTestId('isAuthenticated').textContent).toBe('false');
-      expect(localStorage.getItem('token')).toBeNull();
-      expect(localStorage.getItem('user')).toBeNull();
-    });
   });
 
   describe('User interface', () => {
     it('should expose role_id and role_name on the User type', () => {
-      localStorage.setItem('token', createValidToken());
       localStorage.setItem('user', JSON.stringify(operatorUser));
 
       render(
@@ -136,7 +92,6 @@ describe('AuthContext', () => {
 
   describe('isAdmin', () => {
     it('should be true when role_name is admin AND is_system_role is true', () => {
-      localStorage.setItem('token', createValidToken());
       localStorage.setItem('user', JSON.stringify(adminUser));
 
       render(
@@ -149,7 +104,6 @@ describe('AuthContext', () => {
     });
 
     it('should be false when role_name is not admin', () => {
-      localStorage.setItem('token', createValidToken());
       localStorage.setItem('user', JSON.stringify(operatorUser));
 
       render(
@@ -170,7 +124,6 @@ describe('AuthContext', () => {
         is_system_role: false,
         permissions: ['cinemas:create'],
       };
-      localStorage.setItem('token', createValidToken());
       localStorage.setItem('user', JSON.stringify(fakeAdmin));
 
       render(
@@ -185,7 +138,6 @@ describe('AuthContext', () => {
 
   describe('hasPermission', () => {
     it('should return true for admin regardless of permission string', () => {
-      localStorage.setItem('token', createValidToken());
       localStorage.setItem('user', JSON.stringify(adminUser));
 
       render(
@@ -200,7 +152,6 @@ describe('AuthContext', () => {
     });
 
     it('should return true when permission is in user permissions list', () => {
-      localStorage.setItem('token', createValidToken());
       localStorage.setItem('user', JSON.stringify(operatorUser));
 
       render(
@@ -213,7 +164,6 @@ describe('AuthContext', () => {
     });
 
     it('should return false when permission is not in user permissions list', () => {
-      localStorage.setItem('token', createValidToken());
       localStorage.setItem('user', JSON.stringify(operatorUser));
 
       render(
@@ -265,7 +215,6 @@ describe('AuthContext', () => {
     });
 
     it('should clear auth after logout', async () => {
-      localStorage.setItem('token', createValidToken());
       localStorage.setItem('user', JSON.stringify(adminUser));
 
       render(
@@ -281,148 +230,6 @@ describe('AuthContext', () => {
       });
 
       expect(screen.getByTestId('auth').textContent).toBe('false');
-    });
-  });
-
-  describe('Proactive token expiry', () => {
-    beforeEach(() => {
-      vi.useFakeTimers();
-    });
-
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it('should auto-logout when token expires without page refresh', () => {
-      // Create a token that expires in 2 seconds
-      const expireInTwoSeconds = Math.floor(Date.now() / 1000) + 2;
-      const shortLivedToken = createTokenWithExp(expireInTwoSeconds);
-      
-      localStorage.setItem('token', shortLivedToken);
-      localStorage.setItem('user', JSON.stringify(adminUser));
-      
-      const mockEventListener = vi.fn();
-      window.addEventListener('auth:unauthorized', mockEventListener);
-
-      render(
-        <AuthProvider>
-          <ContextConsumer />
-        </AuthProvider>
-      );
-
-      // Should be authenticated initially
-      expect(screen.getByTestId('isAuthenticated').textContent).toBe('true');
-      expect(screen.getByTestId('username').textContent).toBe('admin');
-      
-      // Fast forward past expiry time
-      act(() => {
-        vi.advanceTimersByTime(2100);
-      });
-
-      // Should auto-logout and dispatch event
-      expect(screen.getByTestId('isAuthenticated').textContent).toBe('false');
-      expect(screen.getByTestId('username').textContent).toBe('');
-      expect(mockEventListener).toHaveBeenCalledWith(
-        expect.objectContaining({
-          detail: expect.objectContaining({
-            reason: 'session_expired'
-          })
-        })
-      );
-      
-      // Token should be removed from localStorage
-      expect(localStorage.getItem('token')).toBeNull();
-      expect(localStorage.getItem('user')).toBeNull();
-      
-      window.removeEventListener('auth:unauthorized', mockEventListener);
-    });
-
-    it('should reschedule timer on login', () => {
-      vi.useFakeTimers();
-      
-      function LoginButton() {
-        const { login } = useContext(AuthContext);
-        return (
-          <button onClick={() => {
-            const expireInTwoSeconds = Math.floor(Date.now() / 1000) + 2;
-            const shortLivedToken = createTokenWithExp(expireInTwoSeconds);
-            login(shortLivedToken, adminUser);
-          }}>
-            Login
-          </button>
-        );
-      }
-      
-      render(
-        <AuthProvider>
-          <ContextConsumer />
-          <LoginButton />
-        </AuthProvider>
-      );
-
-      // Initially not authenticated
-      expect(screen.getByTestId('isAuthenticated').textContent).toBe('false');
-      
-      // Login with token expiring in 2 seconds
-      act(() => {
-        screen.getByRole('button', { name: 'Login' }).click();
-      });
-
-      // Should be authenticated now
-      expect(screen.getByTestId('isAuthenticated').textContent).toBe('true');
-      
-      // Fast forward past expiry time
-      act(() => {
-        vi.advanceTimersByTime(2100);
-      });
-
-      // Should auto-logout
-      expect(screen.getByTestId('isAuthenticated').textContent).toBe('false');
-    });
-
-    it('should clear timer on manual logout', async () => {
-      // Create a token that expires in 10 seconds
-      const expireInTenSeconds = Math.floor(Date.now() / 1000) + 10;
-      const token = createTokenWithExp(expireInTenSeconds);
-      
-      localStorage.setItem('token', token);
-      localStorage.setItem('user', JSON.stringify(adminUser));
-      
-      const mockEventListener = vi.fn();
-      window.addEventListener('auth:unauthorized', mockEventListener);
-
-      function LogoutButton() {
-        const { logout } = useContext(AuthContext);
-        return <button onClick={logout}>Logout</button>;
-      }
-
-      render(
-        <AuthProvider>
-          <ContextConsumer />
-          <LogoutButton />
-        </AuthProvider>
-      );
-
-      // Should be authenticated initially
-      expect(screen.getByTestId('isAuthenticated').textContent).toBe('true');
-      
-      // Manual logout
-      await act(async () => {
-        screen.getByRole('button', { name: 'Logout' }).click();
-        await Promise.resolve();
-      });
-
-      expect(screen.getByTestId('isAuthenticated').textContent).toBe('false');
-      
-      // Fast forward past original expiry time
-      act(() => {
-        vi.advanceTimersByTime(10100);
-      });
-
-      // Event should NOT fire because timer was cleared
-      expect(mockEventListener).not.toHaveBeenCalled();
-      
-      window.removeEventListener('auth:unauthorized', mockEventListener);
     });
   });
 });

--- a/client/src/contexts/AuthContext.ts
+++ b/client/src/contexts/AuthContext.ts
@@ -12,17 +12,15 @@ export interface User {
 
 export interface AuthContextType {
     isAuthenticated: boolean;
-    token: string | null;
     user: User | null;
     isAdmin: boolean;
     hasPermission: (permission: PermissionName) => boolean;
-    login: (token: string, user: User) => void;
+    login: (user: User) => void;
     logout: () => void;
 }
 
 export const AuthContext = createContext<AuthContextType>({
     isAuthenticated: false,
-    token: null,
     user: null,
     isAdmin: false,
     hasPermission: () => false,

--- a/client/src/contexts/AuthProvider.tsx
+++ b/client/src/contexts/AuthProvider.tsx
@@ -1,83 +1,18 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import type { ReactNode } from 'react';
 import { AuthContext, type User } from './AuthContext';
-
-interface JwtPayload {
-    exp?: number;
-}
-
-function decodeBase64Url(value: string): string | null {
-    try {
-        const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
-        const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
-        return atob(padded);
-    } catch {
-        return null;
-    }
-}
-
-function isTokenExpired(token: string): boolean {
-    try {
-        const parts = token.split('.');
-        if (parts.length !== 3) return true;
-
-        const payloadJson = decodeBase64Url(parts[1]);
-        if (!payloadJson) return true;
-
-        const payload = JSON.parse(payloadJson) as JwtPayload;
-        if (typeof payload.exp !== 'number') return true;
-
-        const nowInSeconds = Math.floor(Date.now() / 1000);
-        return payload.exp <= nowInSeconds;
-    } catch {
-        return true;
-    }
-}
-
-function getTokenExpiry(token: string): number | null {
-    try {
-        const parts = token.split('.');
-        if (parts.length !== 3) return null;
-
-        const payloadJson = decodeBase64Url(parts[1]);
-        if (!payloadJson) return null;
-
-        const payload = JSON.parse(payloadJson) as JwtPayload;
-        if (typeof payload.exp !== 'number') return null;
-
-        return payload.exp;
-    } catch {
-        return null;
-    }
-}
-
-function getInitialToken(): string | null {
-    const storedToken = localStorage.getItem('token');
-    if (!storedToken) return null;
-
-    if (isTokenExpired(storedToken)) {
-        sessionStorage.setItem('auth:expired', '1');
-        localStorage.removeItem('token');
-        localStorage.removeItem('user');
-        return null;
-    }
-
-    return storedToken;
-}
 
 interface AuthProviderProps {
     children: ReactNode;
 }
 
 export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
-    const [token, setToken] = useState<string | null>(getInitialToken);
     const [user, setUser] = useState<User | null>(() => {
         const savedUser = localStorage.getItem('user');
         return savedUser ? JSON.parse(savedUser) : null;
     });
-    const expiryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    const isAuthenticated = !!token;
+    const isAuthenticated = !!user;
     const isAdmin = user?.role_name === 'admin' && user?.is_system_role === true;
 
     const hasPermission = (permission: string): boolean => {
@@ -86,48 +21,6 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         return user.permissions.includes(permission as never);
     };
 
-    const clearExpiryTimer = () => {
-        if (expiryTimerRef.current !== null) {
-            clearTimeout(expiryTimerRef.current);
-            expiryTimerRef.current = null;
-        }
-    };
-
-    const scheduleExpiryTimer = (tokenToCheck: string) => {
-        clearExpiryTimer();
-        
-        const expiry = getTokenExpiry(tokenToCheck);
-        if (expiry === null) return;
-        
-        const nowInSeconds = Math.floor(Date.now() / 1000);
-        const msUntilExpiry = (expiry - nowInSeconds) * 1000;
-        
-        if (msUntilExpiry > 0) {
-            expiryTimerRef.current = setTimeout(() => {
-                setToken(null);
-                setUser(null);
-                
-                window.dispatchEvent(
-                    new CustomEvent('auth:unauthorized', {
-                        detail: { reason: 'session_expired' }
-                    })
-                );
-            }, msUntilExpiry);
-        }
-    };
-
-    useEffect(() => {
-        if (token) {
-            localStorage.setItem('token', token);
-            scheduleExpiryTimer(token);
-        } else {
-            localStorage.removeItem('token');
-            localStorage.removeItem('user');
-            clearExpiryTimer();
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [token]);
-
     useEffect(() => {
         if (user) {
             localStorage.setItem('user', JSON.stringify(user));
@@ -135,22 +28,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             localStorage.removeItem('user');
         }
     }, [user]);
-    
-    useEffect(() => {
-        return () => {
-            clearExpiryTimer();
-        };
-    }, []);
 
-    const login = (newToken: string, newUser: User) => {
-        setToken(newToken);
+    const login = (_newToken: string, newUser: User) => {
         setUser(newUser);
     };
 
     const logout = async () => {
-        clearExpiryTimer();
-
-        // Call server to revoke refresh token
         try {
             const csrfToken = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]*)/)?.[1];
             const headers: Record<string, string> = { 'Content-Type': 'application/json' };
@@ -166,12 +49,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             // Ignore network errors during logout
         }
 
-        setToken(null);
         setUser(null);
     };
 
     return (
-        <AuthContext.Provider value={{ isAuthenticated, token, user, isAdmin, hasPermission, login, logout }}>
+        <AuthContext.Provider value={{ isAuthenticated, token: null, user, isAdmin, hasPermission, login, logout }}>
             {children}
         </AuthContext.Provider>
     );

--- a/client/src/contexts/AuthProvider.tsx
+++ b/client/src/contexts/AuthProvider.tsx
@@ -11,8 +11,53 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         const savedUser = localStorage.getItem('user');
         return savedUser ? JSON.parse(savedUser) : null;
     });
+    const [sessionChecked, setSessionChecked] = useState(false);
 
-    const isAuthenticated = !!user;
+    useEffect(() => {
+        localStorage.removeItem('token');
+        sessionStorage.removeItem('auth:expired');
+    }, []);
+
+    useEffect(() => {
+        let cancelled = false;
+        async function validateSession() {
+            try {
+                const csrfToken = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]*)/)?.[1];
+                const headers: Record<string, string> = {};
+                if (csrfToken) {
+                    headers['X-CSRF-Token'] = csrfToken;
+                }
+                const res = await fetch('/api/auth/me', {
+                    method: 'GET',
+                    credentials: 'include',
+                    headers,
+                });
+                if (!res.ok) {
+                    if (!cancelled) {
+                        setUser(null);
+                        localStorage.removeItem('user');
+                    }
+                }
+            } catch {
+                if (!cancelled) {
+                    setUser(null);
+                    localStorage.removeItem('user');
+                }
+            } finally {
+                if (!cancelled) {
+                    setSessionChecked(true);
+                }
+            }
+        }
+        if (user) {
+            validateSession();
+        } else {
+            setSessionChecked(true);
+        }
+        return () => { cancelled = true; };
+    }, []);
+
+    const isAuthenticated = sessionChecked ? !!user : false;
     const isAdmin = user?.role_name === 'admin' && user?.is_system_role === true;
 
     const hasPermission = (permission: string): boolean => {
@@ -29,7 +74,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         }
     }, [user]);
 
-    const login = (_newToken: string, newUser: User) => {
+    const login = (newUser: User) => {
         setUser(newUser);
     };
 
@@ -53,7 +98,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     };
 
     return (
-        <AuthContext.Provider value={{ isAuthenticated, token: null, user, isAdmin, hasPermission, login, logout }}>
+        <AuthContext.Provider value={{ isAuthenticated, user, isAdmin, hasPermission, login, logout }}>
             {children}
         </AuthContext.Provider>
     );

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -34,8 +34,8 @@ const LoginPage: React.FC = () => {
 
             if (response.success) {
                 // API returns { success: true, data: { token, user } }
-                const { token, user } = response.data;
-                login(token, user);
+                const { user } = response.data;
+                login(user);
                 navigate(from, { replace: true });
             } else {
                 setError(response.error || 'Login failed');

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": ">=24.0.0",
+    "node": ">=24.0.0 <25.0.0",
     "npm": ">=10.0.0"
   },
   "devDependencies": {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -178,8 +178,8 @@ export function createApp() {
       
       const css = await generateThemeCSS(db);
       
-      // Generate ETag from CSS content (MD5 hash)
-      const etag = createHash('md5').update(css, 'utf8').digest('hex');
+      // Generate ETag from CSS content (SHA-256 hash)
+      const etag = createHash('sha256').update(css, 'utf8').digest('hex');
       
       // Check If-None-Match header for HTTP caching
       const clientEtag = req.headers['if-none-match'];

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -18,6 +18,11 @@ async function startServer() {
     const jwtExpiration = process.env.JWT_EXPIRES_IN || '1h';
     logger.info(`🔐 JWT expiration set to: ${jwtExpiration}`);
 
+    // Validate JWT expiry vs access token cookie maxAge
+    const { validateJwtExpirationForCookie } = await import('./utils/jwt-config.js');
+    const ACCESS_TOKEN_COOKIE_MAX_AGE_MS = 15 * 60 * 1000;
+    validateJwtExpirationForCookie(jwtExpiration, ACCESS_TOKEN_COOKIE_MAX_AGE_MS);
+
     // Initialize database
     logger.info('📦 Initializing database...');
     await initializeDatabase();

--- a/server/src/middleware/auth.test.ts
+++ b/server/src/middleware/auth.test.ts
@@ -11,6 +11,41 @@ describe('requireAuth (multi-secret verification)', () => {
     delete process.env.JWT_PREVIOUS_SECRETS;
   });
 
+  it('should accept token from access_token cookie', async () => {
+    process.env.JWT_PREVIOUS_SECRETS = OLD_SECRET;
+
+    const { requireAuth } = await import('./auth.js');
+    const token = jwt.sign({ id: 1, username: 'test' }, VALID_SECRET, { algorithm: 'HS256' });
+    const req = { headers: {}, cookies: { access_token: token } } as any;
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+    const next = vi.fn();
+
+    requireAuth(req, res as any, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.user?.id).toBe(1);
+  });
+
+  it('should prefer access_token cookie over Authorization header', async () => {
+    process.env.JWT_PREVIOUS_SECRETS = OLD_SECRET;
+
+    const { requireAuth } = await import('./auth.js');
+    const cookieToken = jwt.sign({ id: 1, username: 'cookie-user' }, VALID_SECRET, { algorithm: 'HS256' });
+    const headerToken = jwt.sign({ id: 2, username: 'header-user' }, VALID_SECRET, { algorithm: 'HS256' });
+    const req = {
+      headers: { authorization: `Bearer ${headerToken}` },
+      cookies: { access_token: cookieToken },
+    } as any;
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+    const next = vi.fn();
+
+    requireAuth(req, res as any, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.user?.id).toBe(1);
+    expect(req.user?.username).toBe('cookie-user');
+  });
+
   it('should reject request without Authorization header', async () => {
     const { requireAuth } = await import('./auth.js');
     const req = { headers: {} } as any;

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -16,18 +16,27 @@ export interface AuthRequest extends Request {
     };
 }
 
-export const requireAuth = (req: AuthRequest, res: Response, next: NextFunction): void | Response => {
+function extractToken(req: AuthRequest): string | null {
+    if (req.cookies?.access_token) {
+        return req.cookies.access_token;
+    }
     const authHeader = req.headers.authorization;
+    if (authHeader && authHeader.startsWith('Bearer ')) {
+        return authHeader.split(' ')[1];
+    }
+    return null;
+}
 
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+export const requireAuth = (req: AuthRequest, res: Response, next: NextFunction): void | Response => {
+    const token = extractToken(req);
+
+    if (!token) {
         const response: ApiResponse = {
             success: false,
             error: 'Authentication required. No token provided.',
         };
         return res.status(401).json(response);
     }
-
-    const token = authHeader.split(' ')[1];
 
     try {
         const decoded = verifyWithMultipleSecrets(token, getSecrets()) as {

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -22,7 +22,7 @@ function extractToken(req: AuthRequest): string | null {
     }
     const authHeader = req.headers.authorization;
     if (authHeader && authHeader.startsWith('Bearer ')) {
-        return authHeader.split(' ')[1];
+        return authHeader.split(' ').slice(1).join(' ').trim();
     }
     return null;
 }

--- a/server/src/routes/auth.test.ts
+++ b/server/src/routes/auth.test.ts
@@ -117,6 +117,14 @@ describe('Auth Routes', () => {
             expect(response.body.data.token).toBeDefined();
             expect(response.body.data.user.username).toBe('admin');
             expect(response.body.data.user.password_hash).toBeUndefined(); // Should not expose hash
+            // Should set access_token cookie as httpOnly
+            const setCookieHeaders = response.headers['set-cookie'];
+            expect(setCookieHeaders).toBeDefined();
+            const cookies = Array.isArray(setCookieHeaders) ? setCookieHeaders : [setCookieHeaders];
+            const accessTokenCookie = cookies.find((c: string) => c.startsWith('access_token='));
+            expect(accessTokenCookie).toBeDefined();
+            expect(accessTokenCookie).toContain('HttpOnly');
+            expect(accessTokenCookie).toContain('SameSite=Strict');
         });
 
         it('should return is_system_role in the user object for valid credentials', async () => {
@@ -548,6 +556,13 @@ describe('Auth Routes', () => {
             expect(response.body.success).toBe(true);
             expect(response.body.data.token).toBeDefined();
             expect(response.body.data.user.username).toBe('testuser');
+            // Should set access_token cookie as httpOnly
+            const setCookieHeaders = response.headers['set-cookie'];
+            const cookies = Array.isArray(setCookieHeaders) ? setCookieHeaders : [setCookieHeaders];
+            const accessTokenCookie = cookies.find((c: string) => c.startsWith('access_token='));
+            expect(accessTokenCookie).toBeDefined();
+            expect(accessTokenCookie).toContain('HttpOnly');
+            expect(accessTokenCookie).toContain('SameSite=Strict');
             expect(mockRotate).toHaveBeenCalledWith(1, 'valid-old-token');
             expect(mockGenerate).not.toHaveBeenCalled();
             expect(mockRevoke).not.toHaveBeenCalled();
@@ -575,6 +590,41 @@ describe('Auth Routes', () => {
             expect(response.status).toBe(401);
             expect(response.body.success).toBe(false);
             expect(response.body.error).toBe('Invalid or expired refresh token.');
+        });
+    });
+
+    describe('POST /api/auth/logout', () => {
+        it('should clear access_token and refresh_token cookies', async () => {
+            const refreshTokenMocks = await import('../services/refresh-token-service.js');
+            const mockRevoke = (refreshTokenMocks as any).__mockRevoke;
+            mockRevoke.mockResolvedValue(undefined);
+
+            const response = await request(app)
+                .post('/api/auth/logout')
+                .set('Cookie', 'refresh_token=some-token; access_token=some-access-token');
+
+            expect(response.status).toBe(200);
+            expect(response.body.success).toBe(true);
+
+            const setCookieHeaders = response.headers['set-cookie'];
+            const cookies = Array.isArray(setCookieHeaders) ? setCookieHeaders : [setCookieHeaders];
+
+            const accessTokenClear = cookies.find((c: string) => c.startsWith('access_token=;'));
+            expect(accessTokenClear).toBeDefined();
+
+            const refreshTokenClear = cookies.find((c: string) => c.startsWith('refresh_token=;'));
+            expect(refreshTokenClear).toBeDefined();
+
+            const csrfTokenClear = cookies.find((c: string) => c.startsWith('csrf_token=;'));
+            expect(csrfTokenClear).toBeDefined();
+        });
+
+        it('should succeed even without cookies', async () => {
+            const response = await request(app)
+                .post('/api/auth/logout');
+
+            expect(response.status).toBe(200);
+            expect(response.body.success).toBe(true);
         });
     });
 });

--- a/server/src/routes/auth.test.ts
+++ b/server/src/routes/auth.test.ts
@@ -34,6 +34,7 @@ vi.mock('../services/refresh-token-service.js', () => {
     const mockValidate = vi.fn();
     const mockRotate = vi.fn();
     const mockRevoke = vi.fn();
+    const mockRevokeAll = vi.fn().mockResolvedValue(undefined);
     const mockGenerate = vi.fn();
 
     return {
@@ -41,11 +42,13 @@ vi.mock('../services/refresh-token-service.js', () => {
             this.validate = mockValidate;
             this.rotate = mockRotate;
             this.revoke = mockRevoke;
+            this.revokeAllForUser = mockRevokeAll;
             this.generate = mockGenerate;
         }),
         __mockValidate: mockValidate,
         __mockRotate: mockRotate,
         __mockRevoke: mockRevoke,
+        __mockRevokeAll: mockRevokeAll,
         __mockGenerate: mockGenerate,
     };
 });
@@ -54,15 +57,16 @@ vi.mock('../services/refresh-token-service.js', () => {
 vi.mock('../middleware/auth.js', () => ({
     requireAuth: vi.fn((req: AuthRequest, res, next) => {
         const authHeader = req.headers.authorization as string | undefined;
+        const cookieToken = req.cookies?.access_token as string | undefined;
+        const bearerToken = authHeader?.startsWith('Bearer ') ? authHeader.split(' ')[1] : null;
+        const token = cookieToken || bearerToken;
 
-        if (!authHeader || !authHeader.startsWith('Bearer ')) {
+        if (!token) {
             return res.status(401).json({
                 success: false,
                 error: 'Authentication required. No token provided.',
             });
         }
-
-        const token = authHeader.split(' ')[1];
 
         try {
             const decoded = jwt.verify(token, TEST_JWT_SECRET, { algorithms: ['HS256'] }) as { id: number; username: string };
@@ -88,7 +92,6 @@ app.use(cookieParser());
 app.set('db', db); // Register mock db for dependency injection
 app.use('/api/auth', authRouter);
 app.use(errorHandler);
-    app.use(errorHandler);
 
 describe('Auth Routes', () => {
     beforeEach(() => {
@@ -124,7 +127,7 @@ describe('Auth Routes', () => {
             const accessTokenCookie = cookies.find((c: string) => c.startsWith('access_token='));
             expect(accessTokenCookie).toBeDefined();
             expect(accessTokenCookie).toContain('HttpOnly');
-            expect(accessTokenCookie).toContain('SameSite=Strict');
+            expect(accessTokenCookie).toContain('SameSite=Lax');
         });
 
         it('should return is_system_role in the user object for valid credentials', async () => {
@@ -562,7 +565,7 @@ describe('Auth Routes', () => {
             const accessTokenCookie = cookies.find((c: string) => c.startsWith('access_token='));
             expect(accessTokenCookie).toBeDefined();
             expect(accessTokenCookie).toContain('HttpOnly');
-            expect(accessTokenCookie).toContain('SameSite=Strict');
+            expect(accessTokenCookie).toContain('SameSite=Lax');
             expect(mockRotate).toHaveBeenCalledWith(1, 'valid-old-token');
             expect(mockGenerate).not.toHaveBeenCalled();
             expect(mockRevoke).not.toHaveBeenCalled();

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -13,6 +13,8 @@ import crypto from 'crypto';
 
 const router = express.Router();
 
+const ACCESS_TOKEN_MAX_AGE_MS = 15 * 60 * 1000; // 15 minutes
+
 export interface AuthResponse {
     token: string;
     user: {
@@ -25,14 +27,15 @@ export interface AuthResponse {
     };
 }
 
+const isSecureCookie = process.env.COOKIE_SECURE !== 'false';
+
 /**
  * Set refresh token as httpOnly cookie (7 days).
  */
 function setRefreshTokenCookie(res: Response, token: string): void {
-    const isProduction = process.env.NODE_ENV === 'production';
     res.cookie('refresh_token', token, {
         httpOnly: true,
-        secure: isProduction,
+        secure: isSecureCookie,
         sameSite: 'strict',
         maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
         path: '/api/auth',
@@ -43,10 +46,9 @@ function setRefreshTokenCookie(res: Response, token: string): void {
  * Clear refresh token cookie.
  */
 function clearRefreshTokenCookie(res: Response): void {
-    const isProduction = process.env.NODE_ENV === 'production';
     res.clearCookie('refresh_token', {
         httpOnly: true,
-        secure: isProduction,
+        secure: isSecureCookie,
         sameSite: 'strict',
         path: '/api/auth',
     });
@@ -56,12 +58,11 @@ function clearRefreshTokenCookie(res: Response): void {
  * Set access token as httpOnly cookie (15 min expiration).
  */
 function setAccessTokenCookie(res: Response, token: string): void {
-    const isProduction = process.env.NODE_ENV === 'production';
     res.cookie('access_token', token, {
         httpOnly: true,
-        secure: isProduction,
-        sameSite: 'strict',
-        maxAge: 15 * 60 * 1000, // 15 minutes
+        secure: isSecureCookie,
+        sameSite: 'lax',
+        maxAge: ACCESS_TOKEN_MAX_AGE_MS, // 15 minutes
         path: '/',
     });
 }
@@ -70,11 +71,10 @@ function setAccessTokenCookie(res: Response, token: string): void {
  * Clear access token cookie.
  */
 function clearAccessTokenCookie(res: Response): void {
-    const isProduction = process.env.NODE_ENV === 'production';
     res.clearCookie('access_token', {
         httpOnly: true,
-        secure: isProduction,
-        sameSite: 'strict',
+        secure: isSecureCookie,
+        sameSite: 'lax',
         path: '/',
     });
 }
@@ -84,10 +84,9 @@ function clearAccessTokenCookie(res: Response): void {
  */
 function setCsrfCookie(res: Response): string {
     const token = crypto.randomBytes(32).toString('hex');
-    const isProduction = process.env.NODE_ENV === 'production';
     res.cookie('csrf_token', token, {
         httpOnly: false,
-        secure: isProduction,
+        secure: isSecureCookie,
         sameSite: 'strict',
         path: '/',
     });
@@ -98,10 +97,9 @@ function setCsrfCookie(res: Response): string {
  * Clear CSRF token cookie.
  */
 function clearCsrfCookie(res: Response): void {
-    const isProduction = process.env.NODE_ENV === 'production';
     res.clearCookie('csrf_token', {
         httpOnly: false,
-        secure: isProduction,
+        secure: isSecureCookie,
         sameSite: 'strict',
         path: '/',
     });
@@ -182,6 +180,15 @@ router.post('/change-password', authLimiter, requireAuth, async (req: AuthReques
 
         await authService.changePassword(req.user!.username, currentPassword, newPassword);
 
+        const refreshTokenService = new RefreshTokenService(db);
+
+        // Revoke all refresh tokens for this user — forces re-login on all devices
+        await refreshTokenService.revokeAllForUser(req.user!.id);
+
+        // Clear auth cookies to force a fresh login
+        clearRefreshTokenCookie(res);
+        clearAccessTokenCookie(res);
+
         const response: ApiResponse = {
             success: true,
             data: {
@@ -214,6 +221,7 @@ router.post('/refresh', authLimiter, async (req: Request, res: Response, next: N
         const refreshToken = req.cookies?.refresh_token;
         if (!refreshToken) {
             clearRefreshTokenCookie(res);
+            clearAccessTokenCookie(res);
             res.status(401).json({
                 success: false,
                 error: 'No refresh token provided.',
@@ -224,6 +232,7 @@ router.post('/refresh', authLimiter, async (req: Request, res: Response, next: N
         const userId = await refreshTokenService.validate(refreshToken);
         if (userId === null) {
             clearRefreshTokenCookie(res);
+            clearAccessTokenCookie(res);
             res.status(401).json({
                 success: false,
                 error: 'Invalid or expired refresh token.',
@@ -244,6 +253,7 @@ router.post('/refresh', authLimiter, async (req: Request, res: Response, next: N
 
         if (userResult.rows.length === 0) {
             clearRefreshTokenCookie(res);
+            clearAccessTokenCookie(res);
             res.status(401).json({
                 success: false,
                 error: 'User not found.',
@@ -325,6 +335,19 @@ router.post('/logout', async (req: Request, res: Response) => {
     clearCsrfCookie(res);
 
     res.json({ success: true, data: { message: 'Logged out successfully' } });
+});
+
+// GET /api/auth/me - Validate current session (cookie-based)
+router.get('/me', requireAuth, async (req: AuthRequest, res: Response) => {
+    res.json({
+        success: true,
+        data: {
+            user: {
+                id: req.user!.id,
+                username: req.user!.username,
+            },
+        },
+    });
 });
 
 export default router;

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -53,6 +53,33 @@ function clearRefreshTokenCookie(res: Response): void {
 }
 
 /**
+ * Set access token as httpOnly cookie (15 min expiration).
+ */
+function setAccessTokenCookie(res: Response, token: string): void {
+    const isProduction = process.env.NODE_ENV === 'production';
+    res.cookie('access_token', token, {
+        httpOnly: true,
+        secure: isProduction,
+        sameSite: 'strict',
+        maxAge: 15 * 60 * 1000, // 15 minutes
+        path: '/',
+    });
+}
+
+/**
+ * Clear access token cookie.
+ */
+function clearAccessTokenCookie(res: Response): void {
+    const isProduction = process.env.NODE_ENV === 'production';
+    res.clearCookie('access_token', {
+        httpOnly: true,
+        secure: isProduction,
+        sameSite: 'strict',
+        path: '/',
+    });
+}
+
+/**
  * Set CSRF token cookie (readable by JS for double-submit pattern).
  */
 function setCsrfCookie(res: Response): string {
@@ -93,6 +120,9 @@ router.post('/login', authLimiter, async (req: Request, res: Response, next: Nex
         // Generate and set refresh token cookie
         const refreshToken = await refreshTokenService.generate(authData.user.id);
         setRefreshTokenCookie(res, refreshToken);
+
+        // Set access token as httpOnly cookie for protection against XSS
+        setAccessTokenCookie(res, authData.token);
 
         // Set CSRF token for double-submit protection
         setCsrfCookie(res);
@@ -251,6 +281,9 @@ router.post('/refresh', authLimiter, async (req: Request, res: Response, next: N
         // Set new refresh token cookie
         setRefreshTokenCookie(res, newRefreshToken);
 
+        // Set access token as httpOnly cookie for protection against XSS
+        setAccessTokenCookie(res, accessToken);
+
         // Rotate CSRF token
         setCsrfCookie(res);
 
@@ -288,6 +321,7 @@ router.post('/logout', async (req: Request, res: Response) => {
     }
 
     clearRefreshTokenCookie(res);
+    clearAccessTokenCookie(res);
     clearCsrfCookie(res);
 
     res.json({ success: true, data: { message: 'Logged out successfully' } });

--- a/server/src/utils/jwt-config.ts
+++ b/server/src/utils/jwt-config.ts
@@ -1,5 +1,37 @@
 import { logger } from './logger.js';
 
+function parseExpiryToMs(value: string): number {
+  const trimmed = value.trim();
+  const humanReadablePattern = /^(\d+)([hdms])$/;
+  const match = trimmed.match(humanReadablePattern);
+  if (match) {
+    const num = parseInt(match[1], 10);
+    switch (match[2]) {
+      case 's': return num * 1000;
+      case 'm': return num * 60 * 1000;
+      case 'h': return num * 60 * 60 * 1000;
+      case 'd': return num * 24 * 60 * 60 * 1000;
+    }
+  }
+  const numericPattern = /^(\d+)$/;
+  if (numericPattern.test(trimmed)) {
+    return parseInt(trimmed, 10) * 1000;
+  }
+  return -1;
+}
+
+export function validateJwtExpirationForCookie(jwtExpiresIn: string, cookieMaxAgeMs: number): void {
+  const jwtMs = parseExpiryToMs(jwtExpiresIn);
+  if (jwtMs > 0 && jwtMs < cookieMaxAgeMs) {
+    const cookieMin = Math.round(cookieMaxAgeMs / 60000);
+    logger.warn(
+      `⚠️  JWT_EXPIRES_IN (${jwtExpiresIn}) is shorter than access_token cookie maxAge (${cookieMin}min). ` +
+      `The JWT will expire before the browser sends the cookie, causing 401 → refresh thrashing. ` +
+      `Set JWT_EXPIRES_IN >= ${cookieMin}min.`
+    );
+  }
+}
+
 /**
  * Parses and validates JWT expiration time from environment variable.
  * 


### PR DESCRIPTION
## Summary

- Store JWT access token in httpOnly/secure/sameSite=strict cookie (15 min) instead of localStorage, preventing XSS-based token theft
- Server auth middleware reads token from cookie first, falls back to Authorization header for backward compatibility
- Remove localStorage token storage from client (AuthProvider, API client)
- Replace MD5 with SHA-256 for CSS ETag generation
- Constrain Node engine to `>=24.0.0 <25.0.0`

Closes #1103