### PR TITLE
fix(server): enable upgradeInsecureRequests in CSP

### DIFF
--- a/server/src/app.test.ts
+++ b/server/src/app.test.ts
@@ -305,6 +305,26 @@ describe('App - Theme Endpoint', () => {
       expect(cspHeader).toMatch(/font-src[^;]*https:\/\/fonts\.gstatic\.com/);
     });
 
+    it('should include upgrade-insecure-requests directive', async () => {
+      // Mock DB for health check
+      const mockQuery = vi.fn().mockResolvedValue({ rows: [{ result: 1 }] });
+      const dbWithMock: DB = { 
+        query: mockQuery,
+        end: vi.fn()
+      } as unknown as DB;
+      app.set('db', dbWithMock);
+
+      const res = await request(app)
+        .get('/api/health')
+        .expect(200);
+
+      const cspHeader = res.headers['content-security-policy'];
+      expect(cspHeader).toBeDefined();
+      
+      // CSP should include upgrade-insecure-requests to force HTTPS
+      expect(cspHeader).toContain('upgrade-insecure-requests');
+    });
+
     it('should maintain existing CSP directives', async () => {
       // Mock DB for health check
       const mockQuery = vi.fn().mockResolvedValue({ rows: [{ result: 1 }] });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -47,6 +47,7 @@ export function createApp() {
   // Security: Helmet with strict CSP (no unsafe-inline/unsafe-eval in script-src)
   // Note: style-src keeps unsafe-inline for React inline styles in 3 components
   // (ScrapeProgress, ColorPicker, FontSelector use dynamic inline styles)
+  // upgradeInsecureRequests is enabled to force HTTPS; HSTS is handled by helmet defaults.
   app.use(helmet({
       contentSecurityPolicy: {
         directives: {
@@ -61,7 +62,7 @@ export function createApp() {
           baseUri: ["'self'"], // Prevent <base> tag injection
           formAction: ["'self'"], // Restrict form submissions
           frameAncestors: ["'none'"], // Prevent clickjacking (like X-Frame-Options)
-          upgradeInsecureRequests: null,
+          upgradeInsecureRequests: [],
         },
       },
     })


### PR DESCRIPTION
## Summary
Active la directive CSP `upgrade-insecure-requests` qui était désactivée (`null`). Cette directive dit au navigateur de mettre automatiquement à niveau toutes les requêtes HTTP vers HTTPS.

Note : HSTS est déjà géré par les defaults de helmet v8 (`strictTransportSecurity` avec `max-age=15552000`). Aucun changement nécessaire de ce côté.

Closes #1099

## Why this matters
La directive était explicitement désactivée via `null`. En l'activant (`[]`), le navigateur upgrade automatiquement les requêtes HTTP en HTTPS côté client, offrant une couche de défense supplémentaire contre les attaques MITM et les mixed content.

## Technical changes
- `server/src/app.ts` : `upgradeInsecureRequests: null` → `upgradeInsecureRequests: []`
- `server/src/app.ts` : commentaire CSP mis à jour
- `server/src/app.test.ts` : nouveau test vérifiant la présence de `upgrade-insecure-requests` dans le header CSP

## Verification
- 823 tests pass, 55 test files
- Pre-push hooks (type-check + tests) OK
- 2 commits atomiques (RED → GREEN)

## What this PR does NOT change
- Ne touche pas à HSTS (déjà actif via helmet defaults)
- Ne modifie aucun autre middleware ou route
- Ne change pas le comportement de l'API ou du frontend
