### PR TITLE
chore(docker): split monitoring stack into dedicated compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,11 @@
               │   Redis  (mandatory)    │  Job queue + progress pub/sub
               └─────────────────────────┘
 
-  Monitoring (--profile monitoring):
+  Monitoring (separate compose file — docker-compose.monitoring.yml):
   Prometheus :9090 → Grafana :3001
   Loki + Promtail (logs) → Grafana
   Tempo :3200 (traces, OTLP :4317) → Grafana
+  Start with: docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d
 ```
 
 **Data Flow:**

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,0 +1,128 @@
+# ---------------------------------------------------------------------------
+# Monitoring stack (Loki + Promtail + Prometheus + Grafana + Tempo + exporters)
+#
+# Usage:
+#   - Main stack only:        docker compose up -d
+#   - Main stack + monitoring: docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d
+#   - Monitoring only (main stack already running):
+#                              docker compose -f docker-compose.monitoring.yml up -d
+#
+# This file is separate from docker-compose.yml so deployment platforms that
+# ignore Compose profiles (e.g. Coolify) do not surface monitoring services
+# for the application deployment.
+# ---------------------------------------------------------------------------
+
+services:
+  # Loki – log aggregation backend
+  ics-loki:
+    image: grafana/loki:2.9.0
+    restart: unless-stopped
+    command: -config.file=/etc/loki/config.yml
+    volumes:
+      - ./docker/loki-config.yml:/etc/loki/config.yml:ro
+      - loki-data:/tmp/loki
+    ports:
+      - "3100:3100"
+    networks:
+      - ics-network
+
+  # Promtail – log shipper (collects Docker container stdout/stderr → Loki)
+  ics-promtail:
+    image: grafana/promtail:2.9.0
+    restart: unless-stopped
+    command: -config.file=/etc/promtail/config.yml
+    volumes:
+      - ./docker/promtail-config.yml:/etc/promtail/config.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    depends_on:
+      - ics-loki
+    networks:
+      - ics-network
+
+  # Prometheus – metrics scraping and storage
+  ics-prometheus:
+    image: prom/prometheus:v2.51.0
+    restart: unless-stopped
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=15d'
+      - '--web.enable-lifecycle'
+    volumes:
+      - ./docker/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    ports:
+      - "9090:9090"
+    networks:
+      - ics-network
+
+  # PostgreSQL exporter – exposes pg metrics for Prometheus
+  ics-postgres-exporter:
+    image: prometheuscommunity/postgres-exporter:v0.15.0
+    restart: unless-stopped
+    environment:
+      DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@ics-db:5432/${POSTGRES_DB:-ics}?sslmode=disable"
+    networks:
+      - ics-network
+
+  # Redis exporter – exposes Redis metrics for Prometheus
+  ics-redis-exporter:
+    image: oliver006/redis_exporter:v1.60.0
+    restart: unless-stopped
+    environment:
+      REDIS_ADDR: redis://ics-redis:6379
+    networks:
+      - ics-network
+
+  # Tempo – distributed tracing backend (receives OTLP from scraper and server)
+  ics-tempo:
+    image: grafana/tempo:2.3.0
+    restart: unless-stopped
+    command: -config.file=/etc/tempo/config.yml
+    volumes:
+      - ./docker/tempo.yml:/etc/tempo/config.yml:ro
+      - tempo-data:/tmp/tempo
+    ports:
+      - "3200:3200" # Tempo HTTP API
+      - "4317:4317" # OTLP gRPC receiver
+      - "4318:4318" # OTLP HTTP receiver
+    networks:
+      - ics-network
+
+  # Grafana – dashboards for metrics (Prometheus), logs (Loki) and traces (Tempo)
+  ics-grafana:
+    image: grafana/grafana:10.4.0
+    restart: unless-stopped
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: "Viewer"
+      GF_AUTH_DISABLE_LOGIN_FORM: "false"
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_SERVER_ROOT_URL: "%(protocol)s://%(domain)s:%(http_port)s/grafana/"
+    volumes:
+      - ./docker/grafana/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./docker/grafana/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    ports:
+      - "3001:3000"
+    depends_on:
+      - ics-prometheus
+      - ics-loki
+      - ics-tempo
+    networks:
+      - ics-network
+
+networks:
+  # Shared with the main application stack (docker-compose.yml).
+  # When running this file alone, the network must already exist
+  # (start the main stack first, or use -f to merge both files).
+  ics-network:
+    name: ics-network
+    external: true
+
+volumes:
+  loki-data:
+  prometheus-data:
+  tempo-data:
+  grafana-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,138 +147,19 @@ services:
     networks:
       - ics-network
 
-  # ---------------------------------------------------------------------------
-  # Monitoring stack (Loki + Promtail + Prometheus + Grafana)
-  # Start with: docker compose --profile monitoring up -d
-  # ---------------------------------------------------------------------------
-
-  # Loki – log aggregation backend
-  ics-loki:
-    image: grafana/loki:2.9.0
-    restart: unless-stopped
-    command: -config.file=/etc/loki/config.yml
-    volumes:
-      - ./docker/loki-config.yml:/etc/loki/config.yml:ro
-      - loki-data:/tmp/loki
-    ports:
-      - "3100:3100"
-    networks:
-      - ics-network
-    profiles:
-      - monitoring
-
-  # Promtail – log shipper (collects Docker container stdout/stderr → Loki)
-  ics-promtail:
-    image: grafana/promtail:2.9.0
-    restart: unless-stopped
-    command: -config.file=/etc/promtail/config.yml
-    volumes:
-      - ./docker/promtail-config.yml:/etc/promtail/config.yml:ro
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-    depends_on:
-      - ics-loki
-    networks:
-      - ics-network
-    profiles:
-      - monitoring
-
-  # Prometheus – metrics scraping and storage
-  ics-prometheus:
-    image: prom/prometheus:v2.51.0
-    restart: unless-stopped
-    command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--storage.tsdb.retention.time=15d'
-      - '--web.enable-lifecycle'
-    volumes:
-      - ./docker/prometheus.yml:/etc/prometheus/prometheus.yml:ro
-      - prometheus-data:/prometheus
-    ports:
-      - "9090:9090"
-    networks:
-      - ics-network
-    profiles:
-      - monitoring
-
-  # PostgreSQL exporter – exposes pg metrics for Prometheus
-  ics-postgres-exporter:
-    image: prometheuscommunity/postgres-exporter:v0.15.0
-    restart: unless-stopped
-    environment:
-      DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@ics-db:5432/${POSTGRES_DB:-ics}?sslmode=disable"
-    depends_on:
-      ics-db:
-        condition: service_healthy
-    networks:
-      - ics-network
-    profiles:
-      - monitoring
-
-  # Redis exporter – exposes Redis metrics for Prometheus
-  ics-redis-exporter:
-    image: oliver006/redis_exporter:v1.60.0
-    restart: unless-stopped
-    environment:
-      REDIS_ADDR: redis://ics-redis:6379
-    depends_on:
-      ics-redis:
-        condition: service_healthy
-    networks:
-      - ics-network
-    profiles:
-      - monitoring
-
-  # Tempo – distributed tracing backend (receives OTLP from scraper and server)
-  ics-tempo:
-    image: grafana/tempo:2.3.0
-    restart: unless-stopped
-    command: -config.file=/etc/tempo/config.yml
-    volumes:
-      - ./docker/tempo.yml:/etc/tempo/config.yml:ro
-      - tempo-data:/tmp/tempo
-    ports:
-      - "3200:3200" # Tempo HTTP API
-      - "4317:4317" # OTLP gRPC receiver
-      - "4318:4318" # OTLP HTTP receiver
-    networks:
-      - ics-network
-    profiles:
-      - monitoring
-
-  # Grafana – dashboards for metrics (Prometheus), logs (Loki) and traces (Tempo)
-  ics-grafana:
-    image: grafana/grafana:10.4.0
-    restart: unless-stopped
-    environment:
-      GF_AUTH_ANONYMOUS_ENABLED: "true"
-      GF_AUTH_ANONYMOUS_ORG_ROLE: "Viewer"
-      GF_AUTH_DISABLE_LOGIN_FORM: "false"
-      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
-      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
-      GF_SERVER_ROOT_URL: "%(protocol)s://%(domain)s:%(http_port)s/grafana/"
-    volumes:
-      - ./docker/grafana/datasources:/etc/grafana/provisioning/datasources:ro
-      - ./docker/grafana/dashboards:/etc/grafana/provisioning/dashboards:ro
-      - grafana-data:/var/lib/grafana
-    ports:
-      - "3001:3000"
-    depends_on:
-      - ics-prometheus
-      - ics-loki
-      - ics-tempo
-    networks:
-      - ics-network
-    profiles:
-      - monitoring
+# ---------------------------------------------------------------------------
+# Monitoring stack (Loki, Promtail, Prometheus, Grafana, Tempo, exporters)
+# has been moved to docker-compose.monitoring.yml so deployment platforms
+# that ignore Compose profiles (e.g. Coolify) don't deploy it by default.
+#
+# Run together with:
+#   docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d
+# ---------------------------------------------------------------------------
 
 networks:
   ics-network:
+    name: ics-network
     driver: bridge
 
 volumes:
   postgres-data:
-  loki-data:
-  prometheus-data:
-  tempo-data:
-  grafana-data:


### PR DESCRIPTION
## Summary

Move the observability stack (Loki, Promtail, Prometheus, Grafana, Tempo, postgres-exporter, redis-exporter) from `docker-compose.yml` to a dedicated `docker-compose.monitoring.yml`.

## Why

Compose profiles already kept these services from starting with a default `docker compose up`, but deployment platforms like **Coolify** ignore profiles and surface every service declared in the file. Splitting the stack means Coolify (and similar PaaS) only deploys the 5 application services.

## Changes

- New `docker-compose.monitoring.yml` (7 services + 4 volumes, attaches to the external `ics-network`)
- `docker-compose.yml` trimmed to application services + the `postgres-data` volume
- Network now declared with a stable name `ics-network` so the monitoring file can reference it as external
- README.md updated with the new command

## Verification

```
docker compose config --services         # 5 services (db, redis, web, scraper, scraper-cron)
docker compose -f docker-compose.yml -f docker-compose.monitoring.yml config --services  # 12 services
```

Both pass `docker compose config --quiet`.

Closes #1115