### PR TITLE
chore(docker): isolate monitoring env vars in dedicated example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -320,17 +320,16 @@ REDIS_URL=redis://localhost:6379
 RUN_MODE=consumer
 
 # ============================================================================
-# LOGGING & OBSERVABILITY
+# LOGGING
 # ============================================================================
 
 # Log level for Winston (error | warn | info | debug)
 # Default: info
 LOG_LEVEL=info
 
-# OpenTelemetry – distributed tracing (Tempo)
-# Set OTEL_ENABLED=true when running the monitoring profile
-OTEL_ENABLED=false
-OTEL_EXPORTER_OTLP_ENDPOINT=http://ics-tempo:4317
+# Monitoring-related variables (OTEL_*, GRAFANA_*) have been moved to
+# .env.monitoring.example. They are only needed when running the optional
+# observability stack (docker-compose.monitoring.yml).
 
 # ============================================================================
 # CLIENT CONFIGURATION (for React frontend)

--- a/.env.monitoring.example
+++ b/.env.monitoring.example
@@ -1,0 +1,42 @@
+# ============================================================================
+# MONITORING STACK CONFIGURATION
+# ============================================================================
+#
+# These variables are only needed when running the observability stack
+# (docker-compose.monitoring.yml). They configure tracing for the application
+# services and the Grafana admin credentials.
+#
+# Usage:
+#   1. Copy this file alongside your main .env:
+#        cp .env.monitoring.example .env.monitoring
+#   2. Launch the full stack with both env files loaded:
+#        docker compose --env-file .env --env-file .env.monitoring \
+#          -f docker-compose.yml -f docker-compose.monitoring.yml up -d
+#
+# Alternative: append these variables to your main .env file. In that case
+# Docker Compose will load them automatically with no extra --env-file flag.
+# ============================================================================
+
+# ----------------------------------------------------------------------------
+# OpenTelemetry — distributed tracing exported to Tempo
+# ----------------------------------------------------------------------------
+
+# Enable trace emission from ics-web, ics-scraper and ics-scraper-cron.
+# Set to true ONLY when the monitoring stack is running (Tempo must be reachable).
+# Default: false (no traces emitted)
+OTEL_ENABLED=true
+
+# OTLP gRPC endpoint Tempo listens on (resolved via Docker network DNS).
+# Default: http://ics-tempo:4317
+OTEL_EXPORTER_OTLP_ENDPOINT=http://ics-tempo:4317
+
+# ----------------------------------------------------------------------------
+# Grafana admin credentials
+# ----------------------------------------------------------------------------
+#
+# Used to create the Grafana admin account on first start. Change them before
+# exposing Grafana to anything other than localhost.
+# Default: admin / admin
+
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=admin

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ client/dist/
 .env
 .env.*
 !.env.example
+!.env.monitoring.example
 .env-*
 *.bak
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@
   Prometheus :9090 → Grafana :3001
   Loki + Promtail (logs) → Grafana
   Tempo :3200 (traces, OTLP :4317) → Grafana
-  Start with: docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d
+  Start with: docker compose --env-file .env --env-file .env.monitoring \
+                -f docker-compose.yml -f docker-compose.monitoring.yml up -d
+  (see .env.monitoring.example for required variables)
 ```
 
 **Data Flow:**

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -2,10 +2,20 @@
 # Monitoring stack (Loki + Promtail + Prometheus + Grafana + Tempo + exporters)
 #
 # Usage:
-#   - Main stack only:        docker compose up -d
-#   - Main stack + monitoring: docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d
+#   - Main stack only:
+#       docker compose up -d
+#   - Main stack + monitoring (recommended):
+#       docker compose --env-file .env --env-file .env.monitoring \
+#         -f docker-compose.yml -f docker-compose.monitoring.yml up -d
 #   - Monitoring only (main stack already running):
-#                              docker compose -f docker-compose.monitoring.yml up -d
+#       docker compose --env-file .env --env-file .env.monitoring \
+#         -f docker-compose.monitoring.yml up -d
+#
+# Required env vars (see .env.monitoring.example):
+#   - OTEL_ENABLED, OTEL_EXPORTER_OTLP_ENDPOINT (tracing from app services)
+#   - GRAFANA_ADMIN_USER, GRAFANA_ADMIN_PASSWORD (Grafana credentials)
+#   - POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB (from main .env, used by
+#     the postgres-exporter)
 #
 # This file is separate from docker-compose.yml so deployment platforms that
 # ignore Compose profiles (e.g. Coolify) do not surface monitoring services

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -240,11 +240,17 @@ These variables are **required** for the application to function properly.
 
 ### Monitoring & Observability
 
+> The variables below belong to the optional observability stack
+> (`docker-compose.monitoring.yml`) and are documented in
+> [`.env.monitoring.example`](../../.env.monitoring.example), **not** in the
+> main `.env`. Copy that file to `.env.monitoring` (or append its content to
+> your existing `.env`) before starting the monitoring stack.
+
 #### `OTEL_ENABLED`
 - **Description**: Enable OpenTelemetry distributed tracing
 - **Default**: `false`
 - **Values**: `true`, `false`
-- **Notes**: Requires Tempo instance (included in monitoring profile)
+- **Notes**: Requires Tempo (provided by `docker-compose.monitoring.yml`)
 
 #### `OTEL_EXPORTER_OTLP_ENDPOINT`
 - **Description**: OTLP gRPC endpoint for Tempo
@@ -428,7 +434,7 @@ SCRAPE_DAYS=14
 APP_NAME=My Theater Portal
 VITE_APP_NAME=My Theater Portal
 
-# Optional: Monitoring
+# Optional: Monitoring (put these in .env.monitoring, not .env)
 OTEL_ENABLED=true
 OTEL_EXPORTER_OTLP_ENDPOINT=http://ics-tempo:4317
 GRAFANA_ADMIN_USER=admin

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -273,7 +273,7 @@ Now that you're up and running:
 - **Hot Reload**: Code changes in `server/` and `client/` automatically reload
 - **Database GUI**: Use [pgAdmin](https://www.pgadmin.org/) or [DBeaver](https://dbeaver.io/) to connect to `localhost:5432`
 - **API Testing**: Use [Postman](https://www.postman.com/) or [HTTPie](https://httpie.io/) for API exploration
-- **Monitoring**: Enable the monitoring stack with `docker compose --profile monitoring up -d`
+- **Monitoring**: Enable the monitoring stack with `docker compose --env-file .env --env-file .env.monitoring -f docker-compose.yml -f docker-compose.monitoring.yml up -d`
 
 ---
 

--- a/docs/guides/deployment/docker.md
+++ b/docs/guides/deployment/docker.md
@@ -210,10 +210,10 @@ docker compose up -d
 docker compose --profile scraper up -d
 
 # With full observability stack (Prometheus, Grafana, Loki, Tempo)
-docker compose --profile monitoring up -d
+docker compose --env-file .env --env-file .env.monitoring -f docker-compose.yml -f docker-compose.monitoring.yml up -d
 
 # Everything
-docker compose --profile monitoring --profile scraper up -d
+docker compose --env-file .env --env-file .env.monitoring -f docker-compose.yml -f docker-compose.monitoring.yml up -d
 ```
 
 **Base services (`docker compose up -d`):**
@@ -225,11 +225,14 @@ docker compose --profile monitoring --profile scraper up -d
 - `ics-scraper`: Scraper microservice (job consumer)
 - `ics-scraper-cron`: Cron-triggered scraper
 
-**`--profile monitoring` adds:**
+**`docker-compose.monitoring.yml` adds:**
 - `ics-prometheus`: Metrics (port 9090)
 - `ics-grafana`: Dashboards (port 3001, default admin/admin)
 - `ics-loki` + `ics-promtail`: Log aggregation
 - `ics-tempo`: Distributed tracing (OTLP port 4317)
+- `ics-postgres-exporter`, `ics-redis-exporter`: data-store metrics
+
+Configure it via `.env.monitoring` (copy from `.env.monitoring.example`).
 - `ics-postgres-exporter`, `ics-redis-exporter`: DB/Redis metrics
 
 > See [Monitoring](./monitoring.md) for full observability setup instructions.
@@ -282,7 +285,7 @@ docker compose --profile scraper up -d
 ### Monitoring Profile
 
 ```bash
-docker compose --profile monitoring up -d
+docker compose --env-file .env --env-file .env.monitoring -f docker-compose.yml -f docker-compose.monitoring.yml up -d
 ```
 
 **Adds:**
@@ -556,7 +559,7 @@ docker inspect ics-web | jq '.[0].State.Health'
 
 - Uses pre-built images from GHCR
 - Includes base services (db, redis, web)
-- Supports `--profile scraper` and `--profile monitoring`
+- Supports the optional monitoring stack via `docker-compose.monitoring.yml`
 - Optimized for production
 
 ### docker-compose.dev.yml (Development)

--- a/docs/guides/deployment/monitoring.md
+++ b/docs/guides/deployment/monitoring.md
@@ -36,7 +36,7 @@ Complete guide to the observability stack shipped with Allo-Scrapper.
 | **postgres-exporter** | PostgreSQL → Prometheus | — |
 | **redis-exporter** | Redis → Prometheus | — |
 
-All monitoring services run under the `monitoring` Docker Compose profile.
+All monitoring services live in a dedicated Compose file (`docker-compose.monitoring.yml`), separate from the main application stack. Their environment variables are documented in `.env.monitoring.example`.
 
 ---
 
@@ -44,7 +44,7 @@ All monitoring services run under the `monitoring` Docker Compose profile.
 
 ```bash
 # Start monitoring alongside the main app
-docker compose --profile monitoring up -d
+docker compose --env-file .env --env-file .env.monitoring -f docker-compose.yml -f docker-compose.monitoring.yml up -d
 
 # Open Grafana
 open http://localhost:3001   # user: admin / password: admin
@@ -60,16 +60,16 @@ open http://localhost:3001   # user: admin / password: admin
 
 ```bash
 # Start only monitoring (assumes ics-db, ics-redis, ics-web are already up)
-docker compose --profile monitoring up -d
+docker compose --env-file .env --env-file .env.monitoring -f docker-compose.yml -f docker-compose.monitoring.yml up -d
 
 # Start everything (app + scraper + monitoring)
-docker compose --profile monitoring --profile scraper up -d
+docker compose --env-file .env --env-file .env.monitoring -f docker-compose.yml -f docker-compose.monitoring.yml up -d
 
 # Stop monitoring only
-docker compose --profile monitoring down
+docker compose -f docker-compose.monitoring.yml down
 
 # Stop everything
-docker compose --profile monitoring --profile scraper down
+docker compose -f docker-compose.yml -f docker-compose.monitoring.yml down
 ```
 
 **Note:** The monitoring stack requires the base application services (ics-db, ics-redis, ics-web) to be running.
@@ -477,7 +477,7 @@ docker compose restart ics-postgres-exporter ics-redis-exporter
 
 Always run the monitoring stack in production:
 ```bash
-docker compose --profile monitoring --profile scraper up -d
+docker compose --env-file .env --env-file .env.monitoring -f docker-compose.yml -f docker-compose.monitoring.yml up -d
 ```
 
 ### 2. Set Appropriate Log Levels

--- a/docs/guides/deployment/production.md
+++ b/docs/guides/deployment/production.md
@@ -601,7 +601,7 @@ For production monitoring with Prometheus, Grafana, Loki, and Tempo:
 
 ```bash
 # Start with monitoring profile
-docker compose --profile monitoring up -d
+docker compose --env-file .env --env-file .env.monitoring -f docker-compose.yml -f docker-compose.monitoring.yml up -d
 ```
 
 See [Monitoring Guide](./monitoring.md) for complete setup.

--- a/docs/project/agents.md
+++ b/docs/project/agents.md
@@ -350,8 +350,8 @@ cd scraper && npm test
 docker compose build                                          # Build all images
 docker compose up -d                                         # Base stack (app + DB + Redis)
 docker compose --profile scraper up -d                       # With scraper microservice
-docker compose --profile monitoring up -d                    # With Prometheus/Grafana/Loki/Tempo
-docker compose --profile monitoring --profile scraper up -d  # Everything
+docker compose --env-file .env --env-file .env.monitoring -f docker-compose.yml -f docker-compose.monitoring.yml up -d                    # With Prometheus/Grafana/Loki/Tempo
+docker compose --env-file .env --env-file .env.monitoring -f docker-compose.yml -f docker-compose.monitoring.yml up -d  # Everything
 ```
 
 ### Git

--- a/docs/reference/performance.md
+++ b/docs/reference/performance.md
@@ -275,7 +275,7 @@ OTEL_ENABLED=true
 OTEL_EXPORTER_OTLP_ENDPOINT=http://ics-tempo:4317
 
 # Start with monitoring
-docker compose --profile monitoring up -d
+docker compose --env-file .env --env-file .env.monitoring -f docker-compose.yml -f docker-compose.monitoring.yml up -d
 
 # View traces in Grafana
 open http://localhost:3001

--- a/docs/troubleshooting/docker.md
+++ b/docs/troubleshooting/docker.md
@@ -553,7 +553,7 @@ docker builder prune -a
 docker compose up -d
 
 # Start with profiles
-docker compose --profile scraper --profile monitoring up -d
+docker compose --env-file .env --env-file .env.monitoring -f docker-compose.yml -f docker-compose.monitoring.yml up -d
 
 # Stop all services
 docker compose down


### PR DESCRIPTION
## Summary

Follow-up of #1116. The monitoring stack now lives in `docker-compose.monitoring.yml`, so its environment variables shouldn't pollute the main `.env.example`.

## Changes

- **`.env.example`** — removed `OTEL_ENABLED` and `OTEL_EXPORTER_OTLP_ENDPOINT`; added a pointer to the new file
- **`.env.monitoring.example`** (new) — `OTEL_*` + `GRAFANA_ADMIN_*` with usage instructions
- **`.gitignore`** — whitelist the new example file
- **`docker-compose.monitoring.yml`** — header documents the required env vars and the new `--env-file` invocation
- **Docs** — `README.md`, configuration guide, monitoring/docker/production guides, quick-start, performance reference, troubleshooting, project/agents: replace `docker compose --profile monitoring up -d` with `docker compose --env-file .env --env-file .env.monitoring -f docker-compose.yml -f docker-compose.monitoring.yml up -d`
- `docs/project/changelog.md` left untouched (historical record)

## Verification

```
docker compose -f docker-compose.yml config --quiet                                    # OK
docker compose -f docker-compose.yml -f docker-compose.monitoring.yml config --quiet   # OK
grep -rn 'profile monitoring' docs/  # only docs/project/changelog.md remains (intentional)
```

Closes #1117