### PR TITLE
refactor(client): rename cinema→theater and film→movie across frontend

### DIFF
--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -105,9 +105,9 @@ describe('App.tsx - Phase 5: Route refactoring', () => {
   });
 
   describe('Old routes verification', () => {
-    it('should confirm /admin/cinemas route has been removed', () => {
-      // After refactoring, /admin/cinemas should NOT have its own route
-      // It should be handled by /admin?tab=cinemas instead
+    it('should confirm /admin/theaters route has been removed', () => {
+      // After refactoring, /admin/theaters should NOT have its own route
+      // It should be handled by /admin?tab=theaters instead
       expect(true).toBe(true); // Tests pass after implementation
     });
 
@@ -139,10 +139,10 @@ describe('App.tsx - Phase 5: Route refactoring', () => {
       expect(ADMIN_PERMISSIONS).toContain('roles:create');
       expect(ADMIN_PERMISSIONS).toContain('roles:update');
       expect(ADMIN_PERMISSIONS).toContain('roles:delete');
-      expect(ADMIN_PERMISSIONS).toContain('cinemas:read');
-      expect(ADMIN_PERMISSIONS).toContain('cinemas:create');
-      expect(ADMIN_PERMISSIONS).toContain('cinemas:update');
-      expect(ADMIN_PERMISSIONS).toContain('cinemas:delete');
+      expect(ADMIN_PERMISSIONS).toContain('theaters:read');
+      expect(ADMIN_PERMISSIONS).toContain('theaters:create');
+      expect(ADMIN_PERMISSIONS).toContain('theaters:update');
+      expect(ADMIN_PERMISSIONS).toContain('theaters:delete');
       expect(ADMIN_PERMISSIONS).toContain('users:list');
       expect(ADMIN_PERMISSIONS).toContain('users:read');
       expect(ADMIN_PERMISSIONS).toContain('users:create');

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,7 +2,7 @@ import { BrowserRouter, Routes, Route, useNavigate } from 'react-router-dom';
 import { useEffect, useContext, Suspense, lazy } from 'react';
 import Layout from './components/Layout';
 import HomePage from './pages/HomePage';
-import CinemaPage from './pages/CinemaPage';
+import TheaterPage from './pages/TheaterPage';
 import MoviePage from './pages/MoviePage';
 import LoginPage from './pages/LoginPage';
 import ChangePasswordPage from './pages/ChangePasswordPage';
@@ -103,7 +103,7 @@ function AppRoutes() {
             </ProtectedRoute>
           }
         />
-        <Route path="/theater/:id" element={<CinemaPage />} />
+        <Route path="/theater/:id" element={<TheaterPage />} />
         <Route path="/movie/:id" element={<MoviePage />} />
         <Route
           path="/admin"

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -2,7 +2,7 @@ import type {
   ApiResponse,
   MovieWithShowtimes,
   Movie,
-  Cinema,
+  Theater,
   ShowtimeWithMovie,
   ScrapeReport,
   PaginatedResponse,
@@ -271,8 +271,8 @@ export async function searchMovies(query: string): Promise<Movie[]> {
 // THEATERS API
 // ============================================================================
 
-export async function getTheaters(): Promise<Cinema[]> {
-  const response = await apiClient.get<ApiResponse<Cinema[]>>('/theaters');
+export async function getTheaters(): Promise<Theater[]> {
+  const response = await apiClient.get<ApiResponse<Theater[]>>('/theaters');
   if (!response.success || !response.data) {
     throw new Error(response.error || 'Failed to fetch theaters');
   }
@@ -291,8 +291,8 @@ export async function getTheaterSchedule(
   return response.data;
 }
 
-export async function addTheater(url: string): Promise<Cinema> {
-  const response = await apiClient.post<ApiResponse<Cinema>>('/theaters', { url });
+export async function addTheater(url: string): Promise<Theater> {
+  const response = await apiClient.post<ApiResponse<Theater>>('/theaters', { url });
   if (!response.success || !response.data) {
     throw new Error(response.error || 'Failed to add theater');
   }

--- a/client/src/api/system.ts
+++ b/client/src/api/system.ts
@@ -57,7 +57,7 @@ export interface MigrationsInfo {
 export interface ScraperStatus {
   activeJobs: number;
   lastScrapeTime: string | null;
-  totalCinemas: number;
+  totalTheaters: number;
 }
 
 export interface SystemHealth {

--- a/client/src/api/theaters.ts
+++ b/client/src/api/theaters.ts
@@ -1,6 +1,6 @@
 import apiClient from './client';
 import type { ApiResponse } from '../types';
-import type { Cinema } from '../types';
+import type { Theater } from '../types';
 
 // ============================================================================
 // THEATER ADMIN TYPES
@@ -30,8 +30,8 @@ export interface TheaterUpdate {
 /**
  * Get all theaters (public)
  */
-export async function getTheaters(): Promise<Cinema[]> {
-  const response = await apiClient.get<ApiResponse<Cinema[]>>('/theaters');
+export async function getTheaters(): Promise<Theater[]> {
+  const response = await apiClient.get<ApiResponse<Theater[]>>('/theaters');
 
   if (!response.success || !response.data) {
     throw new Error(response.error || 'Failed to fetch theaters');
@@ -44,8 +44,8 @@ export async function getTheaters(): Promise<Cinema[]> {
  * Add a new theater (admin only).
  * Pass { url } for smart add (auto-scrape), or { id, name } for manual add.
  */
-export async function createTheater(data: TheaterCreate): Promise<Cinema> {
-  const response = await apiClient.post<ApiResponse<Cinema>>('/theaters', data);
+export async function createTheater(data: TheaterCreate): Promise<Theater> {
+  const response = await apiClient.post<ApiResponse<Theater>>('/theaters', data);
 
   if (!response.success || !response.data) {
     throw new Error(response.error || 'Failed to create theater');
@@ -57,8 +57,8 @@ export async function createTheater(data: TheaterCreate): Promise<Cinema> {
 /**
  * Update a theater's name and/or URL (admin only).
  */
-export async function updateTheater(id: string, data: TheaterUpdate): Promise<Cinema> {
-  const response = await apiClient.put<ApiResponse<Cinema>>(`/theaters/${id}`, data);
+export async function updateTheater(id: string, data: TheaterUpdate): Promise<Theater> {
+  const response = await apiClient.put<ApiResponse<Theater>>(`/theaters/${id}`, data);
 
   if (!response.success || !response.data) {
     throw new Error(response.error || 'Failed to update theater');

--- a/client/src/components/CalendarPopover.test.tsx
+++ b/client/src/components/CalendarPopover.test.tsx
@@ -1,14 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import CalendarPopover from './CalendarPopover';
-import type { Showtime, Movie, Cinema } from '../types';
+import type { Showtime, Movie, Theater } from '../types';
 
 const { mockBuildGoogleCalendarUrl, mockDownloadIcsFile } = vi.hoisted(() => ({
   mockBuildGoogleCalendarUrl: vi.fn<
-    (showtime: Showtime, movie: Movie, cinema: Cinema) => string
+    (showtime: Showtime, movie: Movie, theater: Theater) => string
   >(() => 'https://calendar.google.com/calendar/render?action=TEMPLATE'),
   mockDownloadIcsFile: vi.fn<
-    (showtime: Showtime, movie: Movie, cinema: Cinema) => void
+    (showtime: Showtime, movie: Movie, theater: Theater) => void
   >(),
 }));
 
@@ -20,7 +20,7 @@ vi.mock('../utils/calendar', () => ({
 const showtime: Showtime = {
   id: 'st-1',
   movie_id: 1,
-  cinema_id: 'C1',
+  theater_id: 'C1',
   date: '2026-05-20',
   time: '20:30',
   datetime_iso: '2026-05-20T20:30:00',
@@ -36,9 +36,9 @@ const movie: Movie = {
   source_url: 'https://example.com',
 };
 
-const cinema: Cinema = {
+const theater: Theater = {
   id: 'C1',
-  name: 'Cinema Test',
+  name: 'Theater Test',
   city: 'Paris',
 };
 
@@ -75,7 +75,7 @@ describe('CalendarPopover', () => {
       <CalendarPopover
         showtime={showtime}
         movie={movie}
-        cinema={cinema}
+        theater={theater}
         anchorRef={{ current: anchorButton }}
         onClose={onClose}
       />
@@ -91,7 +91,7 @@ describe('CalendarPopover', () => {
       <CalendarPopover
         showtime={showtime}
         movie={movie}
-        cinema={cinema}
+        theater={theater}
         anchorRef={{ current: anchorButton }}
         onClose={onClose}
       />
@@ -99,7 +99,7 @@ describe('CalendarPopover', () => {
 
     fireEvent.click(screen.getByRole('menuitem', { name: /google calendar/i }));
 
-    expect(mockBuildGoogleCalendarUrl).toHaveBeenCalledWith(showtime, movie, cinema);
+    expect(mockBuildGoogleCalendarUrl).toHaveBeenCalledWith(showtime, movie, theater);
     expect(openSpy).toHaveBeenCalledWith(
       'https://calendar.google.com/calendar/render?action=TEMPLATE',
       '_blank',
@@ -113,7 +113,7 @@ describe('CalendarPopover', () => {
       <CalendarPopover
         showtime={showtime}
         movie={movie}
-        cinema={cinema}
+        theater={theater}
         anchorRef={{ current: anchorButton }}
         onClose={onClose}
       />
@@ -121,7 +121,7 @@ describe('CalendarPopover', () => {
 
     fireEvent.click(screen.getByRole('menuitem', { name: /apple \/ outlook/i }));
 
-    expect(mockDownloadIcsFile).toHaveBeenCalledWith(showtime, movie, cinema);
+    expect(mockDownloadIcsFile).toHaveBeenCalledWith(showtime, movie, theater);
     expect(onClose).toHaveBeenCalledOnce();
   });
 });

--- a/client/src/components/CalendarPopover.tsx
+++ b/client/src/components/CalendarPopover.tsx
@@ -1,17 +1,17 @@
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import type { Showtime, Movie, Cinema } from '../types';
+import type { Showtime, Movie, Theater } from '../types';
 import { buildGoogleCalendarUrl, downloadIcsFile } from '../utils/calendar';
 
 interface CalendarPopoverProps {
   showtime: Showtime;
   movie: Movie;
-  cinema: Cinema;
+  theater: Theater;
   anchorRef: React.RefObject<HTMLButtonElement | null>;
   onClose: () => void;
 }
 
-export default function CalendarPopover({ showtime, movie, cinema, anchorRef, onClose }: CalendarPopoverProps) {
+export default function CalendarPopover({ showtime, movie, theater, anchorRef, onClose }: CalendarPopoverProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
   const [style, setStyle] = useState<React.CSSProperties>({ visibility: 'hidden' });
 
@@ -52,13 +52,13 @@ export default function CalendarPopover({ showtime, movie, cinema, anchorRef, on
   }, [onClose]);
 
   function handleGoogleCalendar() {
-    const url = buildGoogleCalendarUrl(showtime, movie, cinema);
+    const url = buildGoogleCalendarUrl(showtime, movie, theater);
     window.open(url, '_blank', 'noopener,noreferrer');
     onClose();
   }
 
   function handleDownloadIcs() {
-    downloadIcsFile(showtime, movie, cinema);
+    downloadIcsFile(showtime, movie, theater);
     onClose();
   }
 

--- a/client/src/components/Layout.test.tsx
+++ b/client/src/components/Layout.test.tsx
@@ -12,7 +12,7 @@ const mockAuthContext = {
   isAdmin: true,
   hasPermission: vi.fn<(p: PermissionName) => boolean>(() => true),
   token: 'mock-token',
-  user: { id: 1, username: 'admin', role_id: 1, role_name: 'admin', is_system_role: true, permissions: ['scraper:trigger', 'cinemas:create'] as PermissionName[] },
+  user: { id: 1, username: 'admin', role_id: 1, role_name: 'admin', is_system_role: true, permissions: ['scraper:trigger', 'theaters:create'] as PermissionName[] },
   login: vi.fn(),
   logout: vi.fn(),
 };
@@ -29,7 +29,7 @@ const mockNonAdminAuthContext = {
 
 const mockSettingsContext = {
       publicSettings: {
-        site_name: 'Test Cinema App',
+        site_name: 'Test Theater App',
         logo_base64: null,
         favicon_base64: null,
         color_primary: '#1976d2',
@@ -79,7 +79,7 @@ describe('Layout - Header navigation changes', () => {
       // Should have Admin link
       const adminLink = screen.getByRole('link', { name: /admin/i });
       expect(adminLink).toBeInTheDocument();
-      expect(adminLink).toHaveAttribute('href', '/admin?tab=cinemas');
+      expect(adminLink).toHaveAttribute('href', '/admin?tab=theaters');
     });
 
     it('should NOT display "Admin" link for non-admin users', () => {
@@ -113,7 +113,7 @@ describe('Layout - Header navigation changes', () => {
   });
 
   describe('Phase 4: Remove admin links from dropdown', () => {
-    it('should NOT display Cinemas link in dropdown menu', async () => {
+    it('should NOT display Theaters link in dropdown menu', async () => {
       const user = userEvent.setup();
       renderWithProviders(mockAuthContext);
       
@@ -121,8 +121,8 @@ describe('Layout - Header navigation changes', () => {
       const userMenuButton = screen.getByTestId('user-menu-button');
       await user.click(userMenuButton);
       
-      // Cinemas link should NOT exist in dropdown
-      expect(screen.queryByTestId('admin-cinemas-link')).not.toBeInTheDocument();
+      // Theaters link should NOT exist in dropdown
+      expect(screen.queryByTestId('admin-theaters-link')).not.toBeInTheDocument();
     });
 
     it('should NOT display Settings link in dropdown menu', async () => {

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -120,7 +120,7 @@ export default function Layout({ children, title }: LayoutProps) {
                 Accueil
               </Link>
               {hasAdminAccess && (
-                <Link to="/admin?tab=cinemas" className="hover:text-primary transition">
+                <Link to="/admin?tab=theaters" className="hover:text-primary transition">
                   Admin
                 </Link>
               )}

--- a/client/src/components/MovieCard.tsx
+++ b/client/src/components/MovieCard.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 import { useState, memo } from 'react';
 import type { MovieWithShowtimes } from '../types';
-import CinemaShowtimes from './CinemaShowtimes';
+import TheaterShowtimes from './TheaterShowtimes';
 
 interface MovieCardProps {
   movie: MovieWithShowtimes;
@@ -127,7 +127,7 @@ function MovieCard({ movie, isNew = false, initialAfterTime }: MovieCardProps) {
 
           {showSchedule && (
             <div className="mt-2 animate-in fade-in slide-in-from-top-2 duration-300">
-              <CinemaShowtimes cinemas={movie.theaters} movie={movie} initialAfterTime={initialAfterTime} />
+              <TheaterShowtimes theaters={movie.theaters} movie={movie} initialAfterTime={initialAfterTime} />
             </div>
           )}
         </div>

--- a/client/src/components/ScrapeProgress.test.tsx
+++ b/client/src/components/ScrapeProgress.test.tsx
@@ -156,7 +156,7 @@ describe('ScrapeProgress', () => {
     expect(mockUseScrapeProgress).toHaveBeenCalledWith(onComplete);
   });
 
-  it('should show current cinema being processed', () => {
+  it('should show current theater being processed', () => {
     const mockState: ProgressState = {
       isConnected: true,
       events: [
@@ -196,7 +196,7 @@ describe('ScrapeProgress', () => {
       isConnected: false, // SSE connection closed
       events: [
         { type: 'started', total_theaters: 1, total_dates: 7 },
-        { type: 'theater_completed', theater_name: 'Test Cinema', total_movies: 5 },
+        { type: 'theater_completed', theater_name: 'Test Theater', total_movies: 5 },
         { type: 'completed', summary: { 
           total_theaters: 1, 
           successful_theaters: 1, 

--- a/client/src/components/ScrapeProgress.tsx
+++ b/client/src/components/ScrapeProgress.tsx
@@ -78,7 +78,7 @@ export default function ScrapeProgress({ onComplete }: ScrapeProgressProps = {})
         )}
       </div>
 
-      {/* Cinema Progress */}
+      {/* Theater Progress */}
       <div className="mb-4">
         <div className="flex justify-between items-center mb-1">
           <p className="text-sm font-medium text-gray-700">

--- a/client/src/components/ShowtimeList.tsx
+++ b/client/src/components/ShowtimeList.tsx
@@ -1,14 +1,14 @@
 import { useMemo, memo, useState, useCallback, useRef } from 'react';
-import type { Showtime, Movie, Cinema } from '../types';
+import type { Showtime, Movie, Theater } from '../types';
 import CalendarPopover from './CalendarPopover';
 
 interface ShowtimeListProps {
   showtimes: Showtime[];
   movie: Movie;
-  cinema: Cinema;
+  theater: Theater;
 }
 
-function ShowtimeList({ showtimes, movie, cinema }: ShowtimeListProps) {
+function ShowtimeList({ showtimes, movie, theater }: ShowtimeListProps) {
   const [openKey, setOpenKey] = useState<string | null>(null);
   const buttonRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
 
@@ -70,7 +70,7 @@ function ShowtimeList({ showtimes, movie, cinema }: ShowtimeListProps) {
                     <CalendarPopover
                       showtime={showtime}
                       movie={movie}
-                      cinema={cinema}
+                      theater={theater}
                       anchorRef={anchorRef}
                       onClose={handleClose}
                     />

--- a/client/src/components/StickyElements.test.tsx
+++ b/client/src/components/StickyElements.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import HomePage from '../pages/HomePage';
-import CinemaPage from '../pages/CinemaPage';
+import TheaterPage from '../pages/TheaterPage';
 import { AuthContext } from '../contexts/AuthContext';
 import * as clientApi from '../api/client';
 
@@ -24,7 +24,7 @@ const mockAuthContext = {
     role_id: 1, 
     role_name: 'admin', 
     is_system_role: true, 
-    permissions: ['cinemas:create', 'scraper:trigger'] as any[] 
+    permissions: ['theaters:create', 'scraper:trigger'] as any[] 
   },
   logout: vi.fn(),
   login: vi.fn(),
@@ -77,13 +77,13 @@ describe('Sticky Elements Stickiness', () => {
     expect(stickySection).toHaveStyle({ top: 'var(--layout-header-offset, 64px)' });
   });
 
-  it('CinemaPage date selector should be sticky with offset', async () => {
-    (clientApi.getTheaters as any).mockResolvedValue([{ id: '1', name: 'Test Cinema' }]);
+  it('TheaterPage date selector should be sticky with offset', async () => {
+    (clientApi.getTheaters as any).mockResolvedValue([{ id: '1', name: 'Test Theater' }]);
     (clientApi.getTheaterSchedule as any).mockResolvedValue({ showtimes: [] });
     
     (useParams as any).mockReturnValue({ id: '1' });
 
-    renderWithProviders(<CinemaPage />);
+    renderWithProviders(<TheaterPage />);
 
     const dateSelectorContainer = await screen.findByTestId('sticky-date-selector-container');
     expect(dateSelectorContainer).toBeInTheDocument();

--- a/client/src/components/TheaterDateSelector.test.tsx
+++ b/client/src/components/TheaterDateSelector.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import CinemaDateSelector from './CinemaDateSelector';
+import TheaterDateSelector from './TheaterDateSelector';
 import type { ShowtimeWithMovie } from '../types';
 
 const FIXED_TODAY = '2026-03-30';
@@ -17,7 +17,7 @@ const mockFormatDateLabel = (dateStr: string) => {
 const makeShowtime = (date: string, time = '14:00'): ShowtimeWithMovie => ({
   id: `${date}-${time}`,
   movie_id: 1,
-  cinema_id: 'C1',
+  theater_id: 'C1',
   date,
   time,
   datetime_iso: `${date}T${time}:00.000Z`,
@@ -26,7 +26,7 @@ const makeShowtime = (date: string, time = '14:00'): ShowtimeWithMovie => ({
   movie: { id: 1, title: 'Film Test', source_url: '' } as any,
 });
 
-describe('CinemaDateSelector — bouton Maintenant', () => {
+describe('TheaterDateSelector — bouton Maintenant', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(FIXED_NOW);
@@ -41,7 +41,7 @@ describe('CinemaDateSelector — bouton Maintenant', () => {
     const showtimes = [makeShowtime(FIXED_TODAY), makeShowtime('2026-03-31')];
 
     render(
-      <CinemaDateSelector
+      <TheaterDateSelector
         dates={dates}
         selectedDate={FIXED_TODAY}
         showtimes={showtimes}
@@ -59,7 +59,7 @@ describe('CinemaDateSelector — bouton Maintenant', () => {
     const showtimes = [makeShowtime(FIXED_TODAY)];
 
     render(
-      <CinemaDateSelector
+      <TheaterDateSelector
         dates={dates}
         selectedDate={FIXED_TODAY}
         showtimes={showtimes}
@@ -77,7 +77,7 @@ describe('CinemaDateSelector — bouton Maintenant', () => {
     const showtimes = [makeShowtime('2026-03-31'), makeShowtime('2026-04-01')];
 
     render(
-      <CinemaDateSelector
+      <TheaterDateSelector
         dates={dates}
         selectedDate='2026-03-31'
         showtimes={showtimes}
@@ -96,7 +96,7 @@ describe('CinemaDateSelector — bouton Maintenant', () => {
     const showtimes = [makeShowtime(FIXED_TODAY)];
 
     render(
-      <CinemaDateSelector
+      <TheaterDateSelector
         dates={dates}
         selectedDate={FIXED_TODAY}
         showtimes={showtimes}
@@ -117,7 +117,7 @@ describe('CinemaDateSelector — bouton Maintenant', () => {
     const showtimes = [makeShowtime(FIXED_TODAY)];
 
     render(
-      <CinemaDateSelector
+      <TheaterDateSelector
         dates={dates}
         selectedDate={FIXED_TODAY}
         showtimes={showtimes}
@@ -136,7 +136,7 @@ describe('CinemaDateSelector — bouton Maintenant', () => {
     const showtimes = [makeShowtime(FIXED_TODAY)];
 
     render(
-      <CinemaDateSelector
+      <TheaterDateSelector
         dates={dates}
         selectedDate={FIXED_TODAY}
         showtimes={showtimes}

--- a/client/src/components/TheaterDateSelector.tsx
+++ b/client/src/components/TheaterDateSelector.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react';
 import type { ShowtimeWithMovie } from '../types';
 
-interface CinemaDateSelectorProps {
+interface TheaterDateSelectorProps {
   dates: string[];
   selectedDate: string;
   showtimes: ShowtimeWithMovie[];
@@ -11,7 +11,7 @@ interface CinemaDateSelectorProps {
   isNowActive?: boolean;
 }
 
-function CinemaDateSelector({ dates, selectedDate, showtimes, onSelectDate, formatDateLabel, onNow, isNowActive = false }: CinemaDateSelectorProps) {
+function TheaterDateSelector({ dates, selectedDate, showtimes, onSelectDate, formatDateLabel, onNow, isNowActive = false }: TheaterDateSelectorProps) {
   if (dates.length === 0) return null;
 
   const today = new Date().toISOString().split('T')[0];
@@ -89,4 +89,4 @@ function CinemaDateSelector({ dates, selectedDate, showtimes, onSelectDate, form
 
 // ⚡ PERFORMANCE: Memoize component to prevent re-renders when parent re-renders
 // but selectedDate and showtimes haven't changed.
-export default memo(CinemaDateSelector);
+export default memo(TheaterDateSelector);

--- a/client/src/components/TheaterShowtimes.test.tsx
+++ b/client/src/components/TheaterShowtimes.test.tsx
@@ -2,8 +2,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
-import CinemaShowtimes from './CinemaShowtimes';
-import type { CinemaWithShowtimes, Movie } from '../types';
+import TheaterShowtimes from './TheaterShowtimes';
+import type { TheaterWithShowtimes, Movie } from '../types';
 
 const mockMovie: Movie = {
   id: 1,
@@ -13,10 +13,10 @@ const mockMovie: Movie = {
   source_url: 'https://example.com',
 };
 
-const mockCinemas: CinemaWithShowtimes[] = [
+const mockTheaters: TheaterWithShowtimes[] = [
   {
     id: 'C1',
-    name: 'Cinema 1',
+    name: 'Theater 1',
     address: 'Address 1',
     city: 'Paris',
     showtimes: [
@@ -26,7 +26,7 @@ const mockCinemas: CinemaWithShowtimes[] = [
   } as any,
   {
     id: 'C2',
-    name: 'Cinema 2',
+    name: 'Theater 2',
     address: 'Address 2',
     city: 'Paris',
     showtimes: [
@@ -39,25 +39,25 @@ const renderWithRouter = (ui: React.ReactElement) => {
   return render(ui, { wrapper: BrowserRouter });
 };
 
-describe('CinemaShowtimes Component', () => {
-  it('renders empty state when no cinemas provided', () => {
-    renderWithRouter(<CinemaShowtimes cinemas={[]} movie={mockMovie} />);
+describe('TheaterShowtimes Component', () => {
+  it('renders empty state when no theaters provided', () => {
+    renderWithRouter(<TheaterShowtimes theaters={[]} movie={mockMovie} />);
     expect(screen.getByText(/Aucune séance disponible/i)).toBeInTheDocument();
   });
 
-  it('renders cinemas and showtimes for the default date', () => {
+  it('renders theaters and showtimes for the default date', () => {
     // Set fixed today date for tests if needed, but here we can just rely on the first date in the list
-    renderWithRouter(<CinemaShowtimes cinemas={mockCinemas} movie={mockMovie} />);
+    renderWithRouter(<TheaterShowtimes theaters={mockTheaters} movie={mockMovie} />);
     
-    expect(screen.getByText('Cinema 1')).toBeInTheDocument();
-    expect(screen.getByText('Cinema 2')).toBeInTheDocument();
+    expect(screen.getByText('Theater 1')).toBeInTheDocument();
+    expect(screen.getByText('Theater 2')).toBeInTheDocument();
     expect(screen.getByText('14:00')).toBeInTheDocument();
     expect(screen.getByText('20:00')).toBeInTheDocument();
     expect(screen.queryByText('16:00')).not.toBeInTheDocument(); // different date
   });
 
   it('changes showtimes when a different date is selected', () => {
-    renderWithRouter(<CinemaShowtimes cinemas={mockCinemas} movie={mockMovie} />);
+    renderWithRouter(<TheaterShowtimes theaters={mockTheaters} movie={mockMovie} />);
     
     // Find the button for Feb 19
     const dateButton = screen.getByText('19').closest('button');
@@ -65,24 +65,24 @@ describe('CinemaShowtimes Component', () => {
     
     fireEvent.click(dateButton!);
     
-    expect(screen.getByText('Cinema 1')).toBeInTheDocument();
-    expect(screen.queryByText('Cinema 2')).not.toBeInTheDocument(); // Cinema 2 has no showtimes on Feb 19
+    expect(screen.getByText('Theater 1')).toBeInTheDocument();
+    expect(screen.queryByText('Theater 2')).not.toBeInTheDocument(); // Theater 2 has no showtimes on Feb 19
     expect(screen.getByText('16:00')).toBeInTheDocument();
     expect(screen.queryByText('14:00')).not.toBeInTheDocument();
   });
 
   it('renders initialDate if provided', () => {
-    renderWithRouter(<CinemaShowtimes cinemas={mockCinemas} movie={mockMovie} initialDate="2026-02-19" />);
+    renderWithRouter(<TheaterShowtimes theaters={mockTheaters} movie={mockMovie} initialDate="2026-02-19" />);
     
     expect(screen.getByText('16:00')).toBeInTheDocument();
     expect(screen.queryByText('14:00')).not.toBeInTheDocument();
   });
 
   it('displays date selector even when there is only one date', () => {
-    const singleDateCinemas: CinemaWithShowtimes[] = [
+    const singleDateTheaters: TheaterWithShowtimes[] = [
       {
         id: 'C1',
-        name: 'Cinema 1',
+        name: 'Theater 1',
         address: 'Address 1',
         city: 'Paris',
         showtimes: [
@@ -92,7 +92,7 @@ describe('CinemaShowtimes Component', () => {
       } as any
     ];
 
-    renderWithRouter(<CinemaShowtimes cinemas={singleDateCinemas} movie={mockMovie} />);
+    renderWithRouter(<TheaterShowtimes theaters={singleDateTheaters} movie={mockMovie} />);
     
     // Date selector should be visible
     expect(screen.getByText('18')).toBeInTheDocument(); // Day number
@@ -103,10 +103,10 @@ describe('CinemaShowtimes Component', () => {
   });
 
   it('displays the correct date label when there is only one date', () => {
-    const singleDateCinemas: CinemaWithShowtimes[] = [
+    const singleDateTheaters: TheaterWithShowtimes[] = [
       {
         id: 'C1',
-        name: 'Cinema 1',
+        name: 'Theater 1',
         address: 'Address 1',
         city: 'Paris',
         showtimes: [
@@ -115,7 +115,7 @@ describe('CinemaShowtimes Component', () => {
       } as any
     ];
 
-    renderWithRouter(<CinemaShowtimes cinemas={singleDateCinemas} movie={mockMovie} />);
+    renderWithRouter(<TheaterShowtimes theaters={singleDateTheaters} movie={mockMovie} />);
     
     // Should display the date button with correct format
     const dateButton = screen.getByText('18').closest('button');
@@ -126,15 +126,15 @@ describe('CinemaShowtimes Component', () => {
   });
 });
 
-describe('CinemaShowtimes — bouton Maintenant', () => {
+describe('TheaterShowtimes — bouton Maintenant', () => {
   const FIXED_TODAY = '2026-02-18';
   // Current time 15:00 — showtimes at 14:00 are past, 16:00 and 20:00 are future
   const FIXED_NOW = new Date('2026-02-18T15:00:00');
 
-  const cinemasWithToday: CinemaWithShowtimes[] = [
+  const theatersWithToday: TheaterWithShowtimes[] = [
     {
       id: 'C1',
-      name: 'Cinema 1',
+      name: 'Theater 1',
       address: 'Address 1',
       city: 'Paris',
       showtimes: [
@@ -145,7 +145,7 @@ describe('CinemaShowtimes — bouton Maintenant', () => {
     } as any,
     {
       id: 'C2',
-      name: 'Cinema 2',
+      name: 'Theater 2',
       address: 'Address 2',
       city: 'Paris',
       showtimes: [
@@ -164,16 +164,16 @@ describe('CinemaShowtimes — bouton Maintenant', () => {
   });
 
   it('renders the Maintenant button as the first button', () => {
-    renderWithRouter(<CinemaShowtimes cinemas={cinemasWithToday} movie={mockMovie} />);
+    renderWithRouter(<TheaterShowtimes theaters={theatersWithToday} movie={mockMovie} />);
     const buttons = screen.getAllByRole('button');
     expect(buttons[0]).toHaveTextContent(/maintenant/i);
   });
 
   it('Maintenant button is disabled when today has no showtimes in the list', () => {
-    const notoday: CinemaWithShowtimes[] = [
+    const notoday: TheaterWithShowtimes[] = [
       {
         id: 'C1',
-        name: 'Cinema 1',
+        name: 'Theater 1',
         address: 'Address 1',
         city: 'Paris',
         showtimes: [
@@ -181,12 +181,12 @@ describe('CinemaShowtimes — bouton Maintenant', () => {
         ],
       } as any,
     ];
-    renderWithRouter(<CinemaShowtimes cinemas={notoday} movie={mockMovie} />);
+    renderWithRouter(<TheaterShowtimes theaters={notoday} movie={mockMovie} />);
     expect(screen.getByRole('button', { name: /maintenant/i })).toBeDisabled();
   });
 
   it('filters out showtimes before current time when Maintenant is clicked', () => {
-    renderWithRouter(<CinemaShowtimes cinemas={cinemasWithToday} movie={mockMovie} />);
+    renderWithRouter(<TheaterShowtimes theaters={theatersWithToday} movie={mockMovie} />);
 
     // Initially today is selected — all three today's showtimes visible
     expect(screen.getByText('14:00')).toBeInTheDocument();
@@ -202,7 +202,7 @@ describe('CinemaShowtimes — bouton Maintenant', () => {
   });
 
   it('resets time filter when another date button is clicked after Maintenant', () => {
-    renderWithRouter(<CinemaShowtimes cinemas={cinemasWithToday} movie={mockMovie} />);
+    renderWithRouter(<TheaterShowtimes theaters={theatersWithToday} movie={mockMovie} />);
 
     fireEvent.click(screen.getByRole('button', { name: /maintenant/i }));
     expect(screen.queryByText('14:00')).not.toBeInTheDocument();

--- a/client/src/components/TheaterShowtimes.tsx
+++ b/client/src/components/TheaterShowtimes.tsx
@@ -1,20 +1,20 @@
 import { useState, useMemo, useCallback } from 'react';
-import type { CinemaWithShowtimes, Movie } from '../types';
+import type { TheaterWithShowtimes, Movie } from '../types';
 import ShowtimeList from './ShowtimeList';
 import { Link } from 'react-router-dom';
 import { getUniqueDates, formatDateLabel } from '../utils/date';
 
-interface CinemaShowtimesProps {
-  cinemas: CinemaWithShowtimes[];
+interface TheaterShowtimesProps {
+  theaters: TheaterWithShowtimes[];
   movie: Movie;
   initialDate?: string;
   initialAfterTime?: string | null;
 }
 
-export default function CinemaShowtimes({ cinemas, movie, initialDate, initialAfterTime }: CinemaShowtimesProps) {
+export default function TheaterShowtimes({ theaters, movie, initialDate, initialAfterTime }: TheaterShowtimesProps) {
   const allShowtimes = useMemo(() => 
-    cinemas.flatMap(c => c.showtimes),
-    [cinemas]
+    theaters.flatMap(c => c.showtimes),
+    [theaters]
   );
 
   const dates = useMemo(() => getUniqueDates(allShowtimes), [allShowtimes]);
@@ -46,20 +46,20 @@ export default function CinemaShowtimes({ cinemas, movie, initialDate, initialAf
   }, [todayInDates, today]);
 
   // ⚡ PERFORMANCE: Use reduce instead of map().filter() to avoid allocating intermediate
-  // objects for cinemas with no showtimes on the selected date, reducing GC pressure and iteration overhead.
-  const displayedCinemas = useMemo(() => {
-    return cinemas.reduce((acc, cinema) => {
-      const filteredShowtimes = cinema.showtimes.filter(
+  // objects for theaters with no showtimes on the selected date, reducing GC pressure and iteration overhead.
+  const displayedTheaters = useMemo(() => {
+    return theaters.reduce((acc, theater) => {
+      const filteredShowtimes = theater.showtimes.filter(
         s => s.date === selectedDate && (!afterTime || s.time >= afterTime)
       );
       if (filteredShowtimes.length > 0) {
-        acc.push({ cinema, showtimes: filteredShowtimes });
+        acc.push({ theater, showtimes: filteredShowtimes });
       }
       return acc;
-    }, [] as Array<{ cinema: CinemaWithShowtimes; showtimes: CinemaWithShowtimes['showtimes'] }>);
-  }, [cinemas, selectedDate, afterTime]);
+    }, [] as Array<{ theater: TheaterWithShowtimes; showtimes: TheaterWithShowtimes['showtimes'] }>);
+  }, [theaters, selectedDate, afterTime]);
 
-  if (cinemas.length === 0) {
+  if (theaters.length === 0) {
     return (
       <div className="text-center py-8 bg-gray-50 rounded-lg border-2 border-dashed border-gray-200">
         <p className="text-gray-500">Aucune séance disponible cette semaine</p>
@@ -125,25 +125,25 @@ export default function CinemaShowtimes({ cinemas, movie, initialDate, initialAf
         </div>
       </div>
 
-      {/* Cinemas List */}
+      {/* Theaters List */}
       <div className="space-y-4">
-        {displayedCinemas.map(({ cinema, showtimes }) => (
-          <div key={cinema.id} className="bg-white rounded-xl border border-gray-100 p-4 shadow-sm hover:shadow-md transition">
+        {displayedTheaters.map(({ theater, showtimes }) => (
+          <div key={theater.id} className="bg-white rounded-xl border border-gray-100 p-4 shadow-sm hover:shadow-md transition">
             <div className="flex justify-between items-start mb-4">
               <div>
                 <h3 className="text-lg font-bold">
-                  <Link to={`/theater/${cinema.id}`} className="hover:text-primary transition">
-                    {cinema.name}
+                  <Link to={`/theater/${theater.id}`} className="hover:text-primary transition">
+                    {theater.name}
                   </Link>
                 </h3>
-                {cinema.address && (
+                {theater.address && (
                   <p className="text-sm text-gray-500">
-                    {cinema.address}, {cinema.city}
+                    {theater.address}, {theater.city}
                   </p>
                 )}
               </div>
               <Link
-                to={`/theater/${cinema.id}`}
+                to={`/theater/${theater.id}`}
                 className="text-xs font-semibold text-primary-dark hover:underline bg-yellow-100 px-2 py-1 rounded"
               >
                 Fiche cinéma
@@ -151,12 +151,12 @@ export default function CinemaShowtimes({ cinemas, movie, initialDate, initialAf
             </div>
 
             <div className="pt-3 border-t border-gray-50">
-              <ShowtimeList showtimes={showtimes} movie={movie} cinema={cinema} />
+              <ShowtimeList showtimes={showtimes} movie={movie} theater={theater} />
             </div>
           </div>
         ))}
 
-        {displayedCinemas.length === 0 && (
+        {displayedTheaters.length === 0 && (
           <div className="text-center py-12 bg-gray-50 rounded-lg border-2 border-dashed border-gray-200">
             <p className="text-gray-500 font-medium">Aucune séance ce jour-là</p>
           </div>

--- a/client/src/components/TheatersQuickLinks.test.tsx
+++ b/client/src/components/TheatersQuickLinks.test.tsx
@@ -1,55 +1,55 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { vi, describe, it, expect } from 'vitest';
-import CinemasQuickLinks from './CinemasQuickLinks';
+import TheatersQuickLinks from './TheatersQuickLinks';
 
-const mockCinemas = [
+const mockTheaters = [
   { id: 'C0001', name: 'UGC Opéra', city: 'Paris', screen_count: 5 },
   { id: 'C0002', name: 'Pathé Wepler', city: 'Paris', screen_count: 8 },
 ];
 
-const renderComponent = (props: Partial<React.ComponentProps<typeof CinemasQuickLinks>> = {}) =>
+const renderComponent = (props: Partial<React.ComponentProps<typeof TheatersQuickLinks>> = {}) =>
   render(
     <MemoryRouter>
-      <CinemasQuickLinks
-        cinemas={mockCinemas}
-        canAddCinema={false}
-        onAddCinema={vi.fn()}
+      <TheatersQuickLinks
+        theaters={mockTheaters}
+        canAddTheater={false}
+        onAddTheater={vi.fn()}
         {...props}
       />
     </MemoryRouter>
   );
 
-describe('CinemasQuickLinks', () => {
-  it('renders a link for each cinema', () => {
+describe('TheatersQuickLinks', () => {
+  it('renders a link for each theater', () => {
     renderComponent();
 
     expect(screen.getByText('UGC Opéra')).toBeInTheDocument();
     expect(screen.getByText('Pathé Wepler')).toBeInTheDocument();
   });
 
-  it('shows "+ Ajouter un cinéma" button when canAddCinema is true', () => {
-    renderComponent({ canAddCinema: true });
+  it('shows "+ Ajouter un cinéma" button when canAddTheater is true', () => {
+    renderComponent({ canAddTheater: true });
 
     expect(screen.getByText('+ Ajouter un cinéma')).toBeInTheDocument();
   });
 
-  it('hides "+ Ajouter un cinéma" button when canAddCinema is false', () => {
-    renderComponent({ canAddCinema: false });
+  it('hides "+ Ajouter un cinéma" button when canAddTheater is false', () => {
+    renderComponent({ canAddTheater: false });
 
     expect(screen.queryByText('+ Ajouter un cinéma')).not.toBeInTheDocument();
   });
 
-  it('calls onAddCinema when the button is clicked', () => {
-    const onAddCinema = vi.fn();
-    renderComponent({ canAddCinema: true, onAddCinema });
+  it('calls onAddTheater when the button is clicked', () => {
+    const onAddTheater = vi.fn();
+    renderComponent({ canAddTheater: true, onAddTheater });
 
     fireEvent.click(screen.getByText('+ Ajouter un cinéma'));
 
-    expect(onAddCinema).toHaveBeenCalledTimes(1);
+    expect(onAddTheater).toHaveBeenCalledTimes(1);
   });
 
-  it('renders cinema links with correct href', () => {
+  it('renders theater links with correct href', () => {
     renderComponent();
 
     const ugcLink = screen.getByText('UGC Opéra').closest('a');

--- a/client/src/components/TheatersQuickLinks.tsx
+++ b/client/src/components/TheatersQuickLinks.tsx
@@ -1,29 +1,29 @@
 import { memo } from 'react';
 import { Link } from 'react-router-dom';
-import type { Cinema } from '../types';
+import type { Theater } from '../types';
 
-interface CinemasQuickLinksProps {
-  cinemas: Cinema[];
-  canAddCinema: boolean;
-  onAddCinema: () => void;
+interface TheatersQuickLinksProps {
+  theaters: Theater[];
+  canAddTheater: boolean;
+  onAddTheater: () => void;
 }
 
-function CinemasQuickLinks({ cinemas, canAddCinema, onAddCinema }: CinemasQuickLinksProps) {
+function TheatersQuickLinks({ theaters, canAddTheater, onAddTheater }: TheatersQuickLinksProps) {
   return (
     <div className="bg-white rounded-xl border border-gray-100 p-3 shadow-sm mb-6">
       <div className="flex flex-wrap gap-2">
-        {cinemas.map((cinema) => (
+        {theaters.map((theater) => (
           <Link
-            key={cinema.id}
-            to={`/theater/${cinema.id}`}
+            key={theater.id}
+            to={`/theater/${theater.id}`}
             className="px-3 py-1.5 bg-gray-50 text-gray-700 text-sm rounded-lg hover:bg-primary hover:text-black transition font-semibold"
           >
-            {cinema.name}
+            {theater.name}
           </Link>
         ))}
-        {canAddCinema && (
+        {canAddTheater && (
           <button
-            onClick={onAddCinema}
+            onClick={onAddTheater}
             className="px-3 py-1.5 bg-white border border-dashed border-gray-300 text-gray-500 text-sm rounded-lg hover:border-primary hover:text-primary transition font-semibold cursor-pointer active:scale-95"
           >
             + Ajouter un cinéma
@@ -35,5 +35,5 @@ function CinemasQuickLinks({ cinemas, canAddCinema, onAddCinema }: CinemasQuickL
 }
 
 // ⚡ PERFORMANCE: Memoize component to prevent re-renders when parent re-renders
-// but cinemas and canAddCinema haven't changed.
-export default memo(CinemasQuickLinks);
+// but theaters and canAddTheater haven't changed.
+export default memo(TheatersQuickLinks);

--- a/client/src/components/admin/AddTheaterModal.tsx
+++ b/client/src/components/admin/AddTheaterModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import type { TheaterCreate } from '../../api/theaters';
 
-interface AddCinemaModalProps {
+interface AddTheaterModalProps {
   isOpen: boolean;
   onClose: () => void;
   onAdd: (data: TheaterCreate) => Promise<void>;
@@ -28,7 +28,7 @@ interface ManualErrors {
   submit?: string;
 }
 
-const AddCinemaModal: React.FC<AddCinemaModalProps> = ({ isOpen, onClose, onAdd }) => {
+const AddTheaterModal: React.FC<AddTheaterModalProps> = ({ isOpen, onClose, onAdd }) => {
   const [activeTab, setActiveTab] = useState<Tab>('smart');
 
   // Smart Add state
@@ -88,7 +88,7 @@ const AddCinemaModal: React.FC<AddCinemaModalProps> = ({ isOpen, onClose, onAdd 
       await onAdd({ url: smartUrl });
       resetForm();
     } catch (err) {
-      setSmartErrors({ submit: err instanceof Error ? err.message : 'Failed to add cinema' });
+      setSmartErrors({ submit: err instanceof Error ? err.message : 'Failed to add theater' });
     } finally {
       setIsSubmitting(false);
     }
@@ -133,7 +133,7 @@ const AddCinemaModal: React.FC<AddCinemaModalProps> = ({ isOpen, onClose, onAdd 
       await onAdd({ id: manualId, name: manualName.trim(), url: manualUrl });
       resetForm();
     } catch (err) {
-      setManualErrors({ submit: err instanceof Error ? err.message : 'Failed to add cinema' });
+      setManualErrors({ submit: err instanceof Error ? err.message : 'Failed to add theater' });
     } finally {
       setIsSubmitting(false);
     }
@@ -149,13 +149,13 @@ const AddCinemaModal: React.FC<AddCinemaModalProps> = ({ isOpen, onClose, onAdd 
   return (
     <div
       className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
-      data-testid="add-cinema-modal-backdrop"
+      data-testid="add-theater-modal-backdrop"
       onClick={handleBackdropClick}
     >
       <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4">
         {/* Header */}
         <div className="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
-          <h2 className="text-xl font-semibold text-gray-900">Add Cinema</h2>
+          <h2 className="text-xl font-semibold text-gray-900">Add Theater</h2>
           <button
             type="button"
             onClick={handleClose}
@@ -199,7 +199,7 @@ const AddCinemaModal: React.FC<AddCinemaModalProps> = ({ isOpen, onClose, onAdd 
         {activeTab === 'smart' && (
           <form onSubmit={handleSmartSubmit} className="px-6 py-4">
             <p className="text-sm text-gray-500 mb-4">
-              The cinema metadata and showtimes will be automatically scraped. This can take 30+ seconds.
+              The theater metadata and showtimes will be automatically scraped. This can take 30+ seconds.
             </p>
             <div className="mb-4">
               <label htmlFor="smart-url" className="block text-sm font-medium text-gray-700 mb-1">
@@ -237,7 +237,7 @@ const AddCinemaModal: React.FC<AddCinemaModalProps> = ({ isOpen, onClose, onAdd 
                 disabled={isSubmitting}
                 className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                {isSubmitting ? 'Adding...' : 'Add Cinema'}
+                {isSubmitting ? 'Adding...' : 'Add Theater'}
               </button>
             </div>
           </form>
@@ -248,7 +248,7 @@ const AddCinemaModal: React.FC<AddCinemaModalProps> = ({ isOpen, onClose, onAdd 
           <form onSubmit={handleManualSubmit} className="px-6 py-4">
             <div className="mb-4">
               <label htmlFor="manual-id" className="block text-sm font-medium text-gray-700 mb-1">
-                Cinema ID
+                Theater ID
               </label>
               <input
                 id="manual-id"
@@ -316,7 +316,7 @@ const AddCinemaModal: React.FC<AddCinemaModalProps> = ({ isOpen, onClose, onAdd 
                 disabled={isSubmitting}
                 className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                {isSubmitting ? 'Adding...' : 'Add Cinema'}
+                {isSubmitting ? 'Adding...' : 'Add Theater'}
               </button>
             </div>
           </form>
@@ -326,4 +326,4 @@ const AddCinemaModal: React.FC<AddCinemaModalProps> = ({ isOpen, onClose, onAdd 
   );
 };
 
-export default AddCinemaModal;
+export default AddTheaterModal;

--- a/client/src/components/admin/DeleteTheaterDialog.tsx
+++ b/client/src/components/admin/DeleteTheaterDialog.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
-import type { Cinema } from '../../types';
+import type { Theater } from '../../types';
 
-interface DeleteCinemaDialogProps {
+interface DeleteTheaterDialogProps {
   isOpen: boolean;
-  cinema: Cinema;
+  theater: Theater;
   onClose: () => void;
-  onConfirm: (cinemaId: string) => void;
+  onConfirm: (theaterId: string) => void;
   isDeleting?: boolean;
   error?: string | null;
 }
 
-const DeleteCinemaDialog: React.FC<DeleteCinemaDialogProps> = ({
+const DeleteTheaterDialog: React.FC<DeleteTheaterDialogProps> = ({
   isOpen,
-  cinema,
+  theater,
   onClose,
   onConfirm,
   isDeleting = false,
@@ -25,31 +25,31 @@ const DeleteCinemaDialog: React.FC<DeleteCinemaDialogProps> = ({
   };
 
   const handleConfirm = () => {
-    onConfirm(cinema.id);
+    onConfirm(theater.id);
   };
 
   return (
     <div
       className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
-      data-testid="delete-cinema-dialog-backdrop"
+      data-testid="delete-theater-dialog-backdrop"
       onClick={handleBackdropClick}
     >
       <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4">
         {/* Header */}
         <div className="px-6 py-4 border-b border-gray-200">
-          <h2 className="text-xl font-semibold text-gray-900">Delete Cinema</h2>
+          <h2 className="text-xl font-semibold text-gray-900">Delete Theater</h2>
         </div>
 
         {/* Content */}
         <div className="px-6 py-4">
           <p className="text-gray-700 mb-4">
-            Are you sure you want to delete cinema{' '}
-            <span className="font-semibold">{cinema.name}</span>{' '}
-            <span className="text-gray-500">({cinema.id})</span>?
+            Are you sure you want to delete theater{' '}
+            <span className="font-semibold">{theater.name}</span>{' '}
+            <span className="text-gray-500">({theater.id})</span>?
           </p>
 
-          {cinema.city && (
-            <p className="text-sm text-gray-500 mb-4">{cinema.city}</p>
+          {theater.city && (
+            <p className="text-sm text-gray-500 mb-4">{theater.city}</p>
           )}
 
           <div className="bg-red-50 border border-red-200 rounded-md p-3">
@@ -57,7 +57,7 @@ const DeleteCinemaDialog: React.FC<DeleteCinemaDialogProps> = ({
               ⚠️ This action cannot be undone
             </p>
             <p className="text-sm text-red-700 mt-1">
-              All showtimes and weekly programs associated with this cinema will be permanently deleted.
+              All showtimes and weekly programs associated with this theater will be permanently deleted.
             </p>
           </div>
 
@@ -75,7 +75,7 @@ const DeleteCinemaDialog: React.FC<DeleteCinemaDialogProps> = ({
             type="button"
             onClick={onClose}
             disabled={isDeleting}
-            data-testid="delete-cinema-cancel-button"
+            data-testid="delete-theater-cancel-button"
             className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Cancel
@@ -84,7 +84,7 @@ const DeleteCinemaDialog: React.FC<DeleteCinemaDialogProps> = ({
             type="button"
             onClick={handleConfirm}
             disabled={isDeleting}
-            data-testid="delete-cinema-confirm-button"
+            data-testid="delete-theater-confirm-button"
             className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isDeleting ? 'Deleting...' : 'Delete'}
@@ -95,4 +95,4 @@ const DeleteCinemaDialog: React.FC<DeleteCinemaDialogProps> = ({
   );
 };
 
-export default DeleteCinemaDialog;
+export default DeleteTheaterDialog;

--- a/client/src/components/admin/EditTheaterModal.tsx
+++ b/client/src/components/admin/EditTheaterModal.tsx
@@ -1,29 +1,29 @@
 import React, { useState } from 'react';
-import type { Cinema } from '../../types';
+import type { Theater } from '../../types';
 import type { TheaterUpdate } from '../../api/theaters';
 
 /**
- * Modal for editing a cinema's information.
+ * Modal for editing a theater's information.
  *
- * IMPORTANT: The parent must supply `key={cinema.id}` when rendering this
- * component so React remounts it whenever the selected cinema changes.
+ * IMPORTANT: The parent must supply `key={theater.id}` when rendering this
+ * component so React remounts it whenever the selected theater changes.
  * Without this, useState initial values are only applied on first mount,
- * causing stale data when switching between cinemas without closing:
+ * causing stale data when switching between theaters without closing:
  *
- *   {cinemaToEdit && (
- *     <EditCinemaModal
- *       key={cinemaToEdit.id}
+ *   {theaterToEdit && (
+ *     <EditTheaterModal
+ *       key={theaterToEdit.id}
  *       isOpen={true}
- *       cinema={cinemaToEdit}
- *       onClose={() => setCinemaToEdit(null)}
- *       onSave={handleUpdateCinema}
+ *       theater={theaterToEdit}
+ *       onClose={() => setTheaterToEdit(null)}
+ *       onSave={handleUpdateTheater}
  *     />
  *   )}
  */
 
-interface EditCinemaModalProps {
+interface EditTheaterModalProps {
   isOpen: boolean;
-  cinema: Cinema;
+  theater: Theater;
   onClose: () => void;
   onSave: (id: string, updates: TheaterUpdate) => Promise<void>;
 }
@@ -34,14 +34,14 @@ function isAllocineUrl(url: string): boolean {
   return url.startsWith(ALLOCINE_URL_PREFIX);
 }
 
-const EditCinemaModal: React.FC<EditCinemaModalProps> = ({ isOpen, cinema, onClose, onSave }) => {
-  const [name, setName] = useState(cinema.name);
-  const [url, setUrl] = useState(cinema.url ?? '');
-  const [address, setAddress] = useState(cinema.address ?? '');
-  const [postalCode, setPostalCode] = useState(cinema.postal_code ?? '');
-  const [city, setCity] = useState(cinema.city ?? '');
+const EditTheaterModal: React.FC<EditTheaterModalProps> = ({ isOpen, theater, onClose, onSave }) => {
+  const [name, setName] = useState(theater.name);
+  const [url, setUrl] = useState(theater.url ?? '');
+  const [address, setAddress] = useState(theater.address ?? '');
+  const [postalCode, setPostalCode] = useState(theater.postal_code ?? '');
+  const [city, setCity] = useState(theater.city ?? '');
   const [screenCount, setScreenCount] = useState<string>(
-    cinema.screen_count != null ? String(cinema.screen_count) : ''
+    theater.screen_count != null ? String(theater.screen_count) : ''
   );
 
   const [nameError, setNameError] = useState<string | undefined>();
@@ -56,12 +56,12 @@ const EditCinemaModal: React.FC<EditCinemaModalProps> = ({ isOpen, cinema, onClo
   if (!isOpen) return null;
 
   const hasChanges =
-    name.trim() !== cinema.name.trim() ||
-    url.trim() !== (cinema.url ?? '').trim() ||
-    address.trim() !== (cinema.address ?? '').trim() ||
-    postalCode.trim() !== (cinema.postal_code ?? '').trim() ||
-    city.trim() !== (cinema.city ?? '').trim() ||
-    screenCount.trim() !== (cinema.screen_count != null ? String(cinema.screen_count) : '');
+    name.trim() !== theater.name.trim() ||
+    url.trim() !== (theater.url ?? '').trim() ||
+    address.trim() !== (theater.address ?? '').trim() ||
+    postalCode.trim() !== (theater.postal_code ?? '').trim() ||
+    city.trim() !== (theater.city ?? '').trim() ||
+    screenCount.trim() !== (theater.screen_count != null ? String(theater.screen_count) : '');
 
   const validateName = (value: string): string | undefined => {
     if (!value.trim()) return 'Name is required';
@@ -129,21 +129,21 @@ const EditCinemaModal: React.FC<EditCinemaModalProps> = ({ isOpen, cinema, onClo
     try {
       const updates: TheaterUpdate = {};
 
-      if (name.trim() !== cinema.name.trim()) updates.name = name.trim();
-      if (url.trim() !== (cinema.url ?? '').trim()) updates.url = url.trim() || undefined;
-      if (address.trim() !== (cinema.address ?? '').trim()) updates.address = address.trim() || undefined;
-      if (postalCode.trim() !== (cinema.postal_code ?? '').trim())
+      if (name.trim() !== theater.name.trim()) updates.name = name.trim();
+      if (url.trim() !== (theater.url ?? '').trim()) updates.url = url.trim() || undefined;
+      if (address.trim() !== (theater.address ?? '').trim()) updates.address = address.trim() || undefined;
+      if (postalCode.trim() !== (theater.postal_code ?? '').trim())
         updates.postal_code = postalCode.trim() || undefined;
-      if (city.trim() !== (cinema.city ?? '').trim()) updates.city = city.trim() || undefined;
+      if (city.trim() !== (theater.city ?? '').trim()) updates.city = city.trim() || undefined;
 
-      const currentScreenCount = cinema.screen_count != null ? String(cinema.screen_count) : '';
+      const currentScreenCount = theater.screen_count != null ? String(theater.screen_count) : '';
       if (screenCount.trim() !== currentScreenCount) {
         updates.screen_count = screenCount.trim() ? Number(screenCount.trim()) : undefined;
       }
 
-      await onSave(cinema.id, updates);
+      await onSave(theater.id, updates);
     } catch (err) {
-      setSubmitError(err instanceof Error ? err.message : 'Failed to save cinema');
+      setSubmitError(err instanceof Error ? err.message : 'Failed to save theater');
     } finally {
       setIsSaving(false);
     }
@@ -161,13 +161,13 @@ const EditCinemaModal: React.FC<EditCinemaModalProps> = ({ isOpen, cinema, onClo
   return (
     <div
       className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
-      data-testid="edit-cinema-modal-backdrop"
+      data-testid="edit-theater-modal-backdrop"
       onClick={handleBackdropClick}
     >
       <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4">
         {/* Header */}
         <div className="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
-          <h2 className="text-xl font-semibold text-gray-900">Edit Cinema</h2>
+          <h2 className="text-xl font-semibold text-gray-900">Edit Theater</h2>
           <button
             type="button"
             onClick={onClose}
@@ -185,7 +185,7 @@ const EditCinemaModal: React.FC<EditCinemaModalProps> = ({ isOpen, cinema, onClo
         <div className="px-6 pt-4 pb-2 bg-gray-50 border-b border-gray-200">
           <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
             <dt className="text-gray-500 font-medium">ID</dt>
-            <dd className="font-mono text-gray-900">{cinema.id}</dd>
+            <dd className="font-mono text-gray-900">{theater.id}</dd>
           </dl>
         </div>
 
@@ -317,4 +317,4 @@ const EditCinemaModal: React.FC<EditCinemaModalProps> = ({ isOpen, cinema, onClo
   );
 };
 
-export default EditCinemaModal;
+export default EditTheaterModal;

--- a/client/src/contexts/AuthContext.test.tsx
+++ b/client/src/contexts/AuthContext.test.tsx
@@ -19,7 +19,7 @@ const operatorUser: User = {
   role_id: 2,
   role_name: 'operator',
   is_system_role: true,
-  permissions: ['scraper:trigger', 'cinemas:create'],
+  permissions: ['scraper:trigger', 'theaters:create'],
 };
 
 // Helper component to expose context values
@@ -126,7 +126,7 @@ describe('AuthContext', () => {
         role_id: 99,
         role_name: 'admin',
         is_system_role: false,
-        permissions: ['cinemas:create'],
+        permissions: ['theaters:create'],
       };
       localStorage.setItem('user', JSON.stringify(fakeAdmin));
 

--- a/client/src/hooks/useTheme.test.tsx
+++ b/client/src/hooks/useTheme.test.tsx
@@ -52,7 +52,7 @@ describe('useTheme', () => {
 
   it('should update favicon when publicSettings includes favicon_base64', async () => {
     const mockSettings: AppSettingsPublic = {
-      site_name: 'My Cinema',
+      site_name: 'My Theater',
       favicon_base64: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
       logo_base64: null,
       color_primary: '#FECC00',
@@ -81,7 +81,7 @@ describe('useTheme', () => {
 
   it('should update document title when publicSettings includes site_name', async () => {
     const mockSettings: AppSettingsPublic = {
-      site_name: 'My Custom Cinema Site',
+      site_name: 'My Custom Theater Site',
       favicon_base64: null,
       logo_base64: null,
       color_primary: '#FECC00',
@@ -102,7 +102,7 @@ describe('useTheme', () => {
     renderHook(() => useTheme(), { wrapper: createWrapper(mockSettings) });
 
     await waitFor(() => {
-      expect(document.title).toBe('My Custom Cinema Site');
+      expect(document.title).toBe('My Custom Theater Site');
     });
   });
 

--- a/client/src/pages/HomePage.test.tsx
+++ b/client/src/pages/HomePage.test.tsx
@@ -10,7 +10,7 @@ import { AuthContext } from '../contexts/AuthContext';
 // Mock the API client
 const mockAuthContext = {
   isAuthenticated: true,
-  user: { id: 1, username: 'testuser', role_id: 1, role_name: 'admin', is_system_role: true, permissions: ['cinemas:create', 'scraper:trigger'] as any[] },
+  user: { id: 1, username: 'testuser', role_id: 1, role_name: 'admin', is_system_role: true, permissions: ['theaters:create', 'scraper:trigger'] as any[] },
   logout: vi.fn(),
   login: vi.fn(),
   isAdmin: false,
@@ -124,7 +124,7 @@ describe('HomePage — bouton Maintenant', () => {
         theaters: [
           {
             id: 'C1',
-            name: 'Cinema 1',
+            name: 'Theater 1',
             address: '',
             city: 'Paris',
             showtimes: [{ id: 's1', date: FIXED_TODAY, time: '12:00', experiences: [] }],
@@ -140,7 +140,7 @@ describe('HomePage — bouton Maintenant', () => {
         theaters: [
           {
             id: 'C1',
-            name: 'Cinema 1',
+            name: 'Theater 1',
             address: '',
             city: 'Paris',
             showtimes: [{ id: 's2', date: FIXED_TODAY, time: '14:00', experiences: [] }],

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -6,7 +6,7 @@ import DaySelector from '../components/DaySelector';
 import MovieSearchBar from '../components/MovieSearchBar';
 import ScrollToTop from '../components/ScrollToTop';
 import { AuthContext } from '../contexts/AuthContext';
-import CinemasQuickLinks from '../components/CinemasQuickLinks';
+import TheatersQuickLinks from '../components/TheatersQuickLinks';
 
 export default function HomePage() {
   const queryClient = useQueryClient();
@@ -14,7 +14,7 @@ export default function HomePage() {
   const [afterTime, setAfterTime] = useState<string | null>(null);
   const { isAuthenticated, hasPermission } = useContext(AuthContext);
 
-  const { data: cinemas = [], isLoading: isLoadingCinemas } = useQuery({
+  const { data: theaters = [], isLoading: isLoadingTheaters } = useQuery({
     queryKey: ['theaters'],
     queryFn: getTheaters,
   });
@@ -35,7 +35,7 @@ export default function HomePage() {
   }, [allMovies, afterTime]);
   const weekStart = moviesData?.weekStart || '';
 
-  const isLoading = isLoadingCinemas || isLoadingMovies;
+  const isLoading = isLoadingTheaters || isLoadingMovies;
   const error = moviesError instanceof Error ? moviesError.message : null;
 
   const handleDateSelect = useCallback((date: string | null) => {
@@ -79,7 +79,7 @@ export default function HomePage() {
     }
   });
 
-  const handleAddCinema = useCallback(async () => {
+  const handleAddTheater = useCallback(async () => {
     const url = window.prompt("Entrez l'URL Allociné du cinéma à ajouter (ex: https://www.allocine.fr/seance/salle_affich-salle=C0013.html):");
     if (!url) return;
 
@@ -151,11 +151,11 @@ export default function HomePage() {
         </div>
       </div>
 
-      {/* Quick Cinema Links - Below sticky header */}
-      <CinemasQuickLinks
-        cinemas={cinemas}
-        canAddCinema={isAuthenticated && hasPermission('cinemas:create')}
-        onAddCinema={handleAddCinema}
+      {/* Quick Theater Links - Below sticky header */}
+      <TheatersQuickLinks
+        theaters={theaters}
+        canAddTheater={isAuthenticated && hasPermission('theaters:create')}
+        onAddTheater={handleAddTheater}
       />
 
       {/* Movies List */}

--- a/client/src/pages/MoviePage.tsx
+++ b/client/src/pages/MoviePage.tsx
@@ -1,7 +1,7 @@
 import { useParams, Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { getMovieById } from '../api/client';
-import CinemaShowtimes from '../components/CinemaShowtimes';
+import TheaterShowtimes from '../components/TheaterShowtimes';
 
 export default function MoviePage() {
   const { id } = useParams<{ id: string }>();
@@ -129,7 +129,7 @@ export default function MoviePage() {
             <h2 className="text-2xl font-bold mb-4 flex items-center gap-2">
               <span>📅 Horaires et Cinémas</span>
             </h2>
-            <CinemaShowtimes cinemas={movie.theaters} movie={movie} />
+            <TheaterShowtimes theaters={movie.theaters} movie={movie} />
           </section>
 
           {/* Synopsis Section */}

--- a/client/src/pages/ReportsPage.tsx
+++ b/client/src/pages/ReportsPage.tsx
@@ -266,11 +266,11 @@ export default function ReportsPage() {
               </div>
             </div>
 
-            {/* Per-cinema breakdown */}
+            {/* Per-theater breakdown */}
             <div className="space-y-4">
-              {Object.entries(reportDetails.attempts).map(([cinemaId, attempts]) => (
-                <div key={cinemaId} className="border border-gray-200 rounded-lg p-4">
-                  <h3 className="font-semibold mb-3">Cinéma {cinemaId}</h3>
+              {Object.entries(reportDetails.attempts).map(([theaterId, attempts]) => (
+                <div key={theaterId} className="border border-gray-200 rounded-lg p-4">
+                  <h3 className="font-semibold mb-3">Cinéma {theaterId}</h3>
                   <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
                     {attempts.map((attempt) => {
                       const statusColors = {

--- a/client/src/pages/TheaterPage.test.tsx
+++ b/client/src/pages/TheaterPage.test.tsx
@@ -2,9 +2,9 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { vi, describe, it, beforeEach, afterEach, expect } from 'vitest';
-import CinemaPage from './CinemaPage';
+import TheaterPage from './TheaterPage';
 import * as clientApi from '../api/client';
-import type { Cinema } from '../types';
+import type { Theater } from '../types';
 
 vi.mock('../api/client', () => ({
   getTheaters: vi.fn(),
@@ -16,7 +16,7 @@ import { AuthContext } from '../contexts/AuthContext';
 
 const mockAuthContext = {
   isAuthenticated: true,
-  user: { id: 1, username: 'testuser', role_id: 1, role_name: 'admin', is_system_role: true, permissions: ['cinemas:create', 'scraper:trigger'] as any[] },
+  user: { id: 1, username: 'testuser', role_id: 1, role_name: 'admin', is_system_role: true, permissions: ['theaters:create', 'scraper:trigger'] as any[] },
   logout: vi.fn(),
   login: vi.fn(),
   isAdmin: false,
@@ -41,8 +41,8 @@ const renderWithClient = (ui: React.ReactElement) => {
   );
 };
 
-describe('CinemaPage - renders cinema details', () => {
-  const mockCinema: Cinema = {
+describe('TheaterPage - renders theater details', () => {
+  const mockTheater: Theater = {
     id: 'C0153',
     name: 'UGC Test',
     city: 'Paris',
@@ -55,15 +55,15 @@ describe('CinemaPage - renders cinema details', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(clientApi.getTheaters).mockResolvedValue([mockCinema]);
+    vi.mocked(clientApi.getTheaters).mockResolvedValue([mockTheater]);
     vi.mocked(clientApi.getTheaterSchedule).mockResolvedValue(mockSchedule);
   });
 
-  it('renders the cinema name heading', async () => {
+  it('renders the theater name heading', async () => {
     renderWithClient(
       <MemoryRouter initialEntries={['/theater/C0153']}>
         <Routes>
-          <Route path="/theater/:id" element={<CinemaPage />} />
+          <Route path="/theater/:id" element={<TheaterPage />} />
         </Routes>
       </MemoryRouter>
     );
@@ -76,22 +76,22 @@ describe('CinemaPage - renders cinema details', () => {
     renderWithClient(
       <MemoryRouter initialEntries={['/theater/C0153']}>
         <Routes>
-          <Route path="/theater/:id" element={<CinemaPage />} />
+          <Route path="/theater/:id" element={<TheaterPage />} />
         </Routes>
       </MemoryRouter>
     );
 
     await screen.findByRole('heading', { name: 'UGC Test' });
 
-    // Scraping controls have been moved to admin CinemasPage
+    // Scraping controls have been moved to admin TheatersPage
     expect(screen.queryByText(/Scraper uniquement ce cinéma/i)).not.toBeInTheDocument();
   });
 
-  it('calls getCinemas and getCinemaSchedule on mount', async () => {
+  it('calls getTheaters and getTheaterSchedule on mount', async () => {
     renderWithClient(
       <MemoryRouter initialEntries={['/theater/C0153']}>
         <Routes>
-          <Route path="/theater/:id" element={<CinemaPage />} />
+          <Route path="/theater/:id" element={<TheaterPage />} />
         </Routes>
       </MemoryRouter>
     );
@@ -102,19 +102,19 @@ describe('CinemaPage - renders cinema details', () => {
     expect(clientApi.getTheaterSchedule).toHaveBeenCalledWith('C0153');
   });
 
-  it('shows error message when cinema is not found', async () => {
+  it('shows error message when theater is not found', async () => {
     vi.mocked(clientApi.getTheaters).mockResolvedValue([]);
 
     renderWithClient(
       <MemoryRouter initialEntries={['/theater/C0153']}>
         <Routes>
-          <Route path="/theater/:id" element={<CinemaPage />} />
+          <Route path="/theater/:id" element={<TheaterPage />} />
         </Routes>
       </MemoryRouter>
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/Cinema not found/i)).toBeInTheDocument();
+      expect(screen.getByText(/Theater not found/i)).toBeInTheDocument();
     });
   });
 
@@ -125,7 +125,7 @@ describe('CinemaPage - renders cinema details', () => {
         {
           id: 'st-1',
           movie_id: 101,
-          cinema_id: 'C0153',
+          theater_id: 'C0153',
           date: '2026-02-24',
           time: '14:30',
           datetime_iso: '2026-02-24T14:30:00.000Z',
@@ -147,7 +147,7 @@ describe('CinemaPage - renders cinema details', () => {
     renderWithClient(
       <MemoryRouter initialEntries={['/theater/C0153']}>
         <Routes>
-          <Route path="/theater/:id" element={<CinemaPage />} />
+          <Route path="/theater/:id" element={<TheaterPage />} />
         </Routes>
       </MemoryRouter>
     );
@@ -158,12 +158,12 @@ describe('CinemaPage - renders cinema details', () => {
   });
 });
 
-describe('CinemaPage — bouton Maintenant', () => {
+describe('TheaterPage — bouton Maintenant', () => {
   const FIXED_TODAY = '2026-03-30';
   // Current time set to 13:00 so that showtimes at 12:00 are past and 14:00 is future
   const FIXED_NOW = new Date('2026-03-30T13:00:00');
 
-  const mockCinema: Cinema = {
+  const mockTheater: Theater = {
     id: 'C0153',
     name: 'UGC Test',
     city: 'Paris',
@@ -178,7 +178,7 @@ describe('CinemaPage — bouton Maintenant', () => {
       {
         id: 'st-past',
         movie_id: 101,
-        cinema_id: 'C0153',
+        theater_id: 'C0153',
         date: FIXED_TODAY,
         time: '12:00',
         datetime_iso: `${FIXED_TODAY}T12:00:00.000Z`,
@@ -191,7 +191,7 @@ describe('CinemaPage — bouton Maintenant', () => {
       {
         id: 'st-future',
         movie_id: 102,
-        cinema_id: 'C0153',
+        theater_id: 'C0153',
         date: FIXED_TODAY,
         time: '14:00',
         datetime_iso: `${FIXED_TODAY}T14:00:00.000Z`,
@@ -209,7 +209,7 @@ describe('CinemaPage — bouton Maintenant', () => {
     vi.useFakeTimers({ toFake: ['Date'] });
     vi.setSystemTime(FIXED_NOW);
     vi.clearAllMocks();
-    vi.mocked(clientApi.getTheaters).mockResolvedValue([mockCinema]);
+    vi.mocked(clientApi.getTheaters).mockResolvedValue([mockTheater]);
     vi.mocked(clientApi.getTheaterSchedule).mockResolvedValue(makeSchedule());
   });
 
@@ -217,23 +217,23 @@ describe('CinemaPage — bouton Maintenant', () => {
     vi.useRealTimers();
   });
 
-  const renderCinemaPage = () =>
+  const renderTheaterPage = () =>
     renderWithClient(
       <MemoryRouter initialEntries={['/theater/C0153']}>
         <Routes>
-          <Route path="/theater/:id" element={<CinemaPage />} />
+          <Route path="/theater/:id" element={<TheaterPage />} />
         </Routes>
       </MemoryRouter>
     );
 
   it('renders the Maintenant button in the date selector', async () => {
-    renderCinemaPage();
+    renderTheaterPage();
     await screen.findByRole('heading', { name: 'UGC Test' });
     expect(screen.getByRole('button', { name: /maintenant/i })).toBeInTheDocument();
   });
 
   it('filters out past showtimes when Maintenant is clicked', async () => {
-    renderCinemaPage();
+    renderTheaterPage();
     await screen.findByText('Film Passé');
 
     // Both films visible initially
@@ -257,7 +257,7 @@ describe('CinemaPage — bouton Maintenant', () => {
         {
           id: 'st-tomorrow',
           movie_id: 103,
-          cinema_id: 'C0153',
+          theater_id: 'C0153',
           date: '2026-03-31',
           time: '10:00',
           datetime_iso: '2026-03-31T10:00:00.000Z',
@@ -270,7 +270,7 @@ describe('CinemaPage — bouton Maintenant', () => {
       ],
     });
 
-    renderCinemaPage();
+    renderTheaterPage();
     await screen.findByText('Film Passé');
 
     // Activate "Now" mode

--- a/client/src/pages/TheaterPage.tsx
+++ b/client/src/pages/TheaterPage.tsx
@@ -4,17 +4,17 @@ import { useQuery } from '@tanstack/react-query';
 import { getTheaters, getTheaterSchedule } from '../api/client';
 import type { ShowtimeWithMovie, Movie } from '../types';
 import ShowtimeList from '../components/ShowtimeList';
-import CinemaDateSelector from '../components/CinemaDateSelector';
+import TheaterDateSelector from '../components/TheaterDateSelector';
 
 interface MovieGroup {
   movie: Movie;
   showtimes: ShowtimeWithMovie[];
 }
 
-export default function CinemaPage() {
+export default function TheaterPage() {
   const { id } = useParams<{ id: string }>();
 
-  const { data: cinemasData, isLoading: cinemasLoading, error: cinemasError } = useQuery({
+  const { data: theatersData, isLoading: theatersLoading, error: theatersError } = useQuery({
     queryKey: ['theaters'],
     queryFn: getTheaters
   });
@@ -25,17 +25,17 @@ export default function CinemaPage() {
     enabled: !!id
   });
 
-  const isLoading = cinemasLoading || scheduleLoading;
-  const queryError = cinemasError || scheduleError;
-  const error = queryError instanceof Error ? queryError.message : (queryError ? 'Failed to load cinema data' : null);
+  const isLoading = theatersLoading || scheduleLoading;
+  const queryError = theatersError || scheduleError;
+  const error = queryError instanceof Error ? queryError.message : (queryError ? 'Failed to load theater data' : null);
 
-  // Validate if cinema was not found in cinemasData
-  if (!isLoading && cinemasData && !cinemasData.some(c => c.id === id)) {
-    // Setting an error message similar to before if cinema is not found
-    // however returning 'Cinema not found' directly in JSX handles it below
+  // Validate if theater was not found in theatersData
+  if (!isLoading && theatersData && !theatersData.some(c => c.id === id)) {
+    // Setting an error message similar to before if theater is not found
+    // however returning 'Theater not found' directly in JSX handles it below
   }
 
-  const cinema = cinemasData?.find(c => c.id === id) || null;
+  const theater = theatersData?.find(c => c.id === id) || null;
   const showtimes = useMemo(() => scheduleData?.showtimes || [], [scheduleData?.showtimes]);
 
   const getInitialSelectedDate = (showtimes: ShowtimeWithMovie[]): string => {
@@ -119,11 +119,11 @@ export default function CinemaPage() {
     );
   }
 
-  if (error || !cinema) {
+  if (error || !theater) {
     return (
       <div className="bg-red-50 border border-red-200 rounded-lg p-6">
         <h2 className="text-xl font-bold text-red-800 mb-2">Erreur</h2>
-        <p className="text-red-600">{error || 'Cinema not found'}</p>
+        <p className="text-red-600">{error || 'Theater not found'}</p>
       </div>
     );
   }
@@ -134,22 +134,22 @@ export default function CinemaPage() {
       <div className="flex items-center gap-2 text-sm text-gray-500 mb-4">
         <Link to="/" className="hover:text-primary hover:underline">← Accueil</Link>
         <span>/</span>
-        <span>{cinema.name}</span>
+        <span>{theater.name}</span>
       </div>
 
-      {/* Cinema Header */}
+      {/* Theater Header */}
       <div className="mb-6">
-        <h1 className="text-3xl md:text-4xl font-bold mb-2">{cinema.name}</h1>
+        <h1 className="text-3xl md:text-4xl font-bold mb-2">{theater.name}</h1>
         
-        {cinema.address && (
+        {theater.address && (
           <p className="text-gray-600 mb-1">
-            📍 {cinema.address}, {cinema.postal_code} {cinema.city}
+            📍 {theater.address}, {theater.postal_code} {theater.city}
           </p>
         )}
         
-        {cinema.screen_count != null && cinema.screen_count > 0 && (
+        {theater.screen_count != null && theater.screen_count > 0 && (
           <p className="text-gray-600">
-            🎬 {cinema.screen_count} salle{cinema.screen_count > 1 ? 's' : ''}
+            🎬 {theater.screen_count} salle{theater.screen_count > 1 ? 's' : ''}
           </p>
         )}
       </div>
@@ -160,7 +160,7 @@ export default function CinemaPage() {
         style={{ top: 'var(--layout-header-offset, 64px)' }}
         data-testid="sticky-date-selector-container"
       >
-        <CinemaDateSelector
+        <TheaterDateSelector
           dates={dates}
           selectedDate={effectiveSelectedDate}
           showtimes={showtimes}
@@ -234,7 +234,7 @@ export default function CinemaPage() {
                     </div>
 
                     <div className="pt-2 border-t border-gray-100">
-                      <ShowtimeList showtimes={showtimes} movie={movie} cinema={cinema} />
+                      <ShowtimeList showtimes={showtimes} movie={movie} theater={theater} />
                     </div>
                   </div>
                 </div>

--- a/client/src/pages/admin/AdminPage.test.tsx
+++ b/client/src/pages/admin/AdminPage.test.tsx
@@ -7,8 +7,8 @@ import type { User } from '../../contexts/AuthContext';
 import type { PermissionName } from '../../types/role';
 
 // Mock child pages
-vi.mock('./CinemasPage', () => ({
-  default: () => <div data-testid="cinemas-content">Cinemas Page</div>,
+vi.mock('./TheatersPage', () => ({
+  default: () => <div data-testid="theaters-content">Theaters Page</div>,
 }));
 
 vi.mock('./SettingsPage', () => ({
@@ -49,9 +49,9 @@ const operatorUser: User = {
   permissions: [
     'scraper:trigger',
     'scraper:trigger_single',
-    'cinemas:create',
-    'cinemas:update',
-    'cinemas:delete',
+    'theaters:create',
+    'theaters:update',
+    'theaters:delete',
     'reports:list',
     'reports:view',
   ] as PermissionName[],
@@ -64,7 +64,7 @@ const fakeAdminUser: User = {
   role_id: 99,
   role_name: 'admin',
   is_system_role: false,
-  permissions: ['cinemas:create', 'reports:list'] as PermissionName[],
+  permissions: ['theaters:create', 'reports:list'] as PermissionName[],
 };
 
 const makeAuthContext = (user: User) => ({
@@ -97,15 +97,15 @@ describe('AdminPage', () => {
   });
 
   describe('Default tab display', () => {
-    it('should display Cinemas tab by default when no tab param is provided', () => {
+    it('should display Theaters tab by default when no tab param is provided', () => {
       renderWithRouter('/admin');
 
-      // Cinemas tab should be active
-      const cinemasTab = screen.getByRole('tab', { name: 'Cinemas' });
-      expect(cinemasTab).toHaveClass('border-primary');
+      // Theaters tab should be active
+      const theatersTab = screen.getByRole('tab', { name: 'Theaters' });
+      expect(theatersTab).toHaveClass('border-primary');
 
-      // Cinemas content should be visible
-      expect(screen.getByTestId('cinemas-content')).toBeInTheDocument();
+      // Theaters content should be visible
+      expect(screen.getByTestId('theaters-content')).toBeInTheDocument();
     });
   });
 
@@ -150,12 +150,12 @@ describe('AdminPage', () => {
       expect(screen.getByTestId('system-content')).toBeInTheDocument();
     });
 
-    it('should fallback to Cinemas tab when invalid tab param is provided', () => {
+    it('should fallback to Theaters tab when invalid tab param is provided', () => {
       renderWithRouter('/admin?tab=invalid');
 
-      const cinemasTab = screen.getByRole('tab', { name: 'Cinemas' });
-      expect(cinemasTab).toHaveClass('border-primary');
-      expect(screen.getByTestId('cinemas-content')).toBeInTheDocument();
+      const theatersTab = screen.getByRole('tab', { name: 'Theaters' });
+      expect(theatersTab).toHaveClass('border-primary');
+      expect(screen.getByTestId('theaters-content')).toBeInTheDocument();
     });
   });
 
@@ -184,8 +184,8 @@ describe('AdminPage', () => {
     it('should display correct content after clicking tab', () => {
       renderWithRouter('/admin');
 
-      // Initially shows Cinemas
-      expect(screen.getByTestId('cinemas-content')).toBeInTheDocument();
+      // Initially shows Theaters
+      expect(screen.getByTestId('theaters-content')).toBeInTheDocument();
 
       // Click on Settings tab
       const settingsTab = screen.getByRole('tab', { name: 'Settings' });
@@ -193,7 +193,7 @@ describe('AdminPage', () => {
 
       // Should now show Settings
       expect(screen.getByTestId('settings-content')).toBeInTheDocument();
-      expect(screen.queryByTestId('cinemas-content')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('theaters-content')).not.toBeInTheDocument();
     });
   });
 
@@ -201,7 +201,7 @@ describe('AdminPage', () => {
     it('should display icons for each tab', () => {
       renderWithRouter('/admin');
 
-      const cinemasTab = screen.getByRole('tab', { name: 'Cinemas' });
+      const theatersTab = screen.getByRole('tab', { name: 'Theaters' });
       const rapportsTab = screen.getByRole('tab', { name: 'Rapports' });
       const usersTab = screen.getByRole('tab', { name: 'Users' });
       const rolesTab = screen.getByRole('tab', { name: 'Roles' });
@@ -209,7 +209,7 @@ describe('AdminPage', () => {
       const systemTab = screen.getByRole('tab', { name: 'System' });
 
       // Each tab should have an SVG icon
-      expect(cinemasTab.querySelector('svg')).toBeInTheDocument();
+      expect(theatersTab.querySelector('svg')).toBeInTheDocument();
       expect(rapportsTab.querySelector('svg')).toBeInTheDocument();
       expect(usersTab.querySelector('svg')).toBeInTheDocument();
       expect(rolesTab.querySelector('svg')).toBeInTheDocument();
@@ -223,24 +223,24 @@ describe('AdminPage', () => {
       renderWithRouter('/admin?tab=settings');
 
       const settingsTab = screen.getByRole('tab', { name: 'Settings' });
-      const cinemasTab = screen.getByRole('tab', { name: 'Cinemas' });
+      const theatersTab = screen.getByRole('tab', { name: 'Theaters' });
 
       // Settings tab should have active classes
       expect(settingsTab).toHaveClass('border-primary', 'text-primary');
 
       // Other tabs should have inactive classes
-      expect(cinemasTab).toHaveClass('text-gray-500');
-      expect(cinemasTab).not.toHaveClass('border-primary');
+      expect(theatersTab).toHaveClass('text-gray-500');
+      expect(theatersTab).not.toHaveClass('border-primary');
     });
   });
 
   describe('Tab order (admin)', () => {
-    it('should display all 8 tabs in correct order for admin: Cinemas, Schedules, Rapports, Users, Roles, Settings, Rate Limits, System', () => {
+    it('should display all 8 tabs in correct order for admin: Theaters, Schedules, Rapports, Users, Roles, Settings, Rate Limits, System', () => {
       renderWithRouter('/admin');
 
       const tabs = screen.getAllByRole('tab');
 
-      expect(tabs[0]).toHaveTextContent('Cinemas');
+      expect(tabs[0]).toHaveTextContent('Theaters');
       expect(tabs[1]).toHaveTextContent('Schedules');
       expect(tabs[2]).toHaveTextContent('Rapports');
       expect(tabs[3]).toHaveTextContent('Users');
@@ -252,12 +252,12 @@ describe('AdminPage', () => {
   });
 
   describe('Operator role - tab visibility', () => {
-    it('should only show Cinemas and Rapports tabs for operator', () => {
+    it('should only show Theaters and Rapports tabs for operator', () => {
       renderWithRouter('/admin', operatorUser);
 
       const tabs = screen.getAllByRole('tab');
       expect(tabs).toHaveLength(2);
-      expect(tabs[0]).toHaveTextContent('Cinemas');
+      expect(tabs[0]).toHaveTextContent('Theaters');
       expect(tabs[1]).toHaveTextContent('Rapports');
     });
 
@@ -285,38 +285,38 @@ describe('AdminPage', () => {
       expect(screen.queryByRole('tab', { name: 'System' })).not.toBeInTheDocument();
     });
 
-    it('should show Cinemas content by default for operator', () => {
+    it('should show Theaters content by default for operator', () => {
       renderWithRouter('/admin', operatorUser);
 
-      expect(screen.getByTestId('cinemas-content')).toBeInTheDocument();
+      expect(screen.getByTestId('theaters-content')).toBeInTheDocument();
     });
 
-    it('should redirect operator from a forbidden tab (users) to cinemas', () => {
+    it('should redirect operator from a forbidden tab (users) to theaters', () => {
       renderWithRouter('/admin?tab=users', operatorUser);
 
-      // Should fall back to cinemas content since users tab is not allowed
-      expect(screen.getByTestId('cinemas-content')).toBeInTheDocument();
+      // Should fall back to theaters content since users tab is not allowed
+      expect(screen.getByTestId('theaters-content')).toBeInTheDocument();
       expect(screen.queryByTestId('users-content')).not.toBeInTheDocument();
     });
 
-    it('should redirect operator from a forbidden tab (roles) to cinemas', () => {
+    it('should redirect operator from a forbidden tab (roles) to theaters', () => {
       renderWithRouter('/admin?tab=roles', operatorUser);
 
-      expect(screen.getByTestId('cinemas-content')).toBeInTheDocument();
+      expect(screen.getByTestId('theaters-content')).toBeInTheDocument();
       expect(screen.queryByTestId('roles-content')).not.toBeInTheDocument();
     });
 
-    it('should redirect operator from a forbidden tab (settings) to cinemas', () => {
+    it('should redirect operator from a forbidden tab (settings) to theaters', () => {
       renderWithRouter('/admin?tab=settings', operatorUser);
 
-      expect(screen.getByTestId('cinemas-content')).toBeInTheDocument();
+      expect(screen.getByTestId('theaters-content')).toBeInTheDocument();
       expect(screen.queryByTestId('settings-content')).not.toBeInTheDocument();
     });
 
-    it('should redirect operator from a forbidden tab (system) to cinemas', () => {
+    it('should redirect operator from a forbidden tab (system) to theaters', () => {
       renderWithRouter('/admin?tab=system', operatorUser);
 
-      expect(screen.getByTestId('cinemas-content')).toBeInTheDocument();
+      expect(screen.getByTestId('theaters-content')).toBeInTheDocument();
       expect(screen.queryByTestId('system-content')).not.toBeInTheDocument();
     });
 
@@ -473,10 +473,10 @@ describe('AdminPage', () => {
       renderWithRouter('/admin', fakeAdminUser);
 
       // Only tabs matching fakeAdminUser.permissions should be visible
-      // fakeAdminUser has cinemas:create and reports:list
+      // fakeAdminUser has theaters:create and reports:list
       const tabs = screen.getAllByRole('tab');
       const tabLabels = tabs.map((t) => t.textContent);
-      expect(tabLabels).toContain('Cinemas');
+      expect(tabLabels).toContain('Theaters');
       expect(tabLabels).toContain('Rapports');
       // Should NOT have all-access tabs like Users, Roles, Settings, System
       expect(tabLabels).not.toContain('Users');
@@ -489,14 +489,14 @@ describe('AdminPage', () => {
       renderWithRouter('/admin?tab=users', fakeAdminUser);
 
       expect(screen.queryByTestId('users-content')).not.toBeInTheDocument();
-      expect(screen.getByTestId('cinemas-content')).toBeInTheDocument();
+      expect(screen.getByTestId('theaters-content')).toBeInTheDocument();
     });
 
     it('should redirect a non-system "admin" role away from roles tab', () => {
       renderWithRouter('/admin?tab=roles', fakeAdminUser);
 
       expect(screen.queryByTestId('roles-content')).not.toBeInTheDocument();
-      expect(screen.getByTestId('cinemas-content')).toBeInTheDocument();
+      expect(screen.getByTestId('theaters-content')).toBeInTheDocument();
     });
   });
 });

--- a/client/src/pages/admin/AdminPage.tsx
+++ b/client/src/pages/admin/AdminPage.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import CinemasPage from './CinemasPage';
+import TheatersPage from './TheatersPage';
 import SettingsPage from './SettingsPage';
 import UsersPage from './UsersPage';
 import SystemPage from './SystemPage';
@@ -11,7 +11,7 @@ import RateLimitsPage from './RateLimitsPage';
 import { AuthContext } from '../../contexts/AuthContext';
 import type { PermissionName } from '../../types/role';
 
-type TabId = 'cinemas' | 'schedules' | 'rapports' | 'users' | 'roles' | 'settings' | 'ratelimits' | 'system';
+type TabId = 'theaters' | 'schedules' | 'rapports' | 'users' | 'roles' | 'settings' | 'ratelimits' | 'system';
 
 interface Tab {
   id: TabId;
@@ -26,10 +26,10 @@ interface Tab {
 
 const tabs: Tab[] = [
   {
-    id: 'cinemas',
-    label: 'Cinemas',
-    // Cinemas tab is visible to anyone with at least one cinema/scraper permissions
-    anyPermissions: ['cinemas:create', 'cinemas:read', 'cinemas:update', 'cinemas:delete', 'scraper:trigger', 'scraper:trigger_single'],
+    id: 'theaters',
+    label: 'Theaters',
+    // Theaters tab is visible to anyone with at least one theater/scraper permissions
+    anyPermissions: ['theaters:create', 'theaters:read', 'theaters:update', 'theaters:delete', 'scraper:trigger', 'scraper:trigger_single'],
     icon: (
       <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 4v16M17 4v16M3 8h4m10 0h4M3 12h18M3 16h4m10 0h4M4 20h16a1 1 0 001-1V5a1 1 0 00-1-1H4a1 1 0 00-1 1v14a1 1 0 001 1z" />
@@ -112,7 +112,7 @@ const tabs: Tab[] = [
 const AdminPage: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const { hasPermission } = useContext(AuthContext);
-  const currentTab = searchParams.get('tab') || 'cinemas';
+  const currentTab = searchParams.get('tab') || 'theaters';
 
   // Filter tabs to only those the user has permission to see
   const visibleTabs = useMemo(() => {
@@ -129,8 +129,8 @@ const AdminPage: React.FC = () => {
 
   const visibleTabIds = useMemo(() => visibleTabs.map((t) => t.id), [visibleTabs]);
 
-  // Validate tab and fallback to first visible tab (or 'cinemas')
-  const fallbackTab: TabId = visibleTabIds[0] ?? 'cinemas';
+  // Validate tab and fallback to first visible tab (or 'theaters')
+  const fallbackTab: TabId = visibleTabIds[0] ?? 'theaters';
   const activeTab: TabId = visibleTabIds.includes(currentTab as TabId)
     ? (currentTab as TabId)
     : fallbackTab;
@@ -180,7 +180,7 @@ const AdminPage: React.FC = () => {
 
       {/* Tab content */}
       <div role="tabpanel">
-        {activeTab === 'cinemas' && <CinemasPage />}
+        {activeTab === 'theaters' && <TheatersPage />}
         {activeTab === 'schedules' && <SchedulesPage />}
         {activeTab === 'rapports' && <ReportsPage />}
         {activeTab === 'users' && <UsersPage />}

--- a/client/src/pages/admin/SettingsPage.test.tsx
+++ b/client/src/pages/admin/SettingsPage.test.tsx
@@ -34,7 +34,7 @@ const mockAuthContext = {
 
 const mockSettingsContext = {
   publicSettings: {
-    site_name: 'Test Cinema',
+    site_name: 'Test Theater',
     logo_base64: null,
     favicon_base64: null,
     color_primary: '#FECC00',
@@ -48,12 +48,12 @@ const mockSettingsContext = {
     color_error: '#EF4444',
     font_family_heading: 'Playfair Display',
     font_family_body: 'Roboto',
-    footer_text: '© 2024 Test Cinema',
+    footer_text: '© 2024 Test Theater',
     footer_links: [],
   },
   adminSettings: {
     id: 1,
-    site_name: 'Test Cinema',
+    site_name: 'Test Theater',
     logo_base64: null,
     favicon_base64: null,
     color_primary: '#FECC00',
@@ -67,9 +67,9 @@ const mockSettingsContext = {
     color_error: '#EF4444',
     font_family_heading: 'Playfair Display',
     font_family_body: 'Roboto',
-    footer_text: '© 2024 Test Cinema',
+    footer_text: '© 2024 Test Theater',
     footer_links: [],
-    email_from_name: 'Test Cinema',
+    email_from_name: 'Test Theater',
     email_from_address: 'noreply@test.com',
     email_logo_base64: null,
     updated_at: '2024-01-01T00:00:00.000Z',
@@ -195,7 +195,7 @@ describe('SettingsPage - Permission-based button visibility', () => {
     await screen.findByText('White-Label Settings');
 
     // Check text input is disabled
-    const siteNameInput = screen.getByPlaceholderText('My Cinema Site') as HTMLInputElement;
+    const siteNameInput = screen.getByPlaceholderText('My Theater Site') as HTMLInputElement;
     expect(siteNameInput.disabled).toBe(true);
   });
 
@@ -207,7 +207,7 @@ describe('SettingsPage - Permission-based button visibility', () => {
     await screen.findByText('White-Label Settings');
 
     // Check text input is enabled
-    const siteNameInput = screen.getByPlaceholderText('My Cinema Site') as HTMLInputElement;
+    const siteNameInput = screen.getByPlaceholderText('My Theater Site') as HTMLInputElement;
     expect(siteNameInput.disabled).toBe(false);
   });
 
@@ -228,7 +228,7 @@ describe('SettingsPage - Permission-based button visibility', () => {
     expect(screen.queryByTestId('save-settings-button')).not.toBeInTheDocument();
 
     // And all inputs should be disabled
-    const siteNameInput = screen.getByPlaceholderText('My Cinema Site') as HTMLInputElement;
+    const siteNameInput = screen.getByPlaceholderText('My Theater Site') as HTMLInputElement;
     expect(siteNameInput.disabled).toBe(true);
   });
 });

--- a/client/src/pages/admin/SettingsPage.tsx
+++ b/client/src/pages/admin/SettingsPage.tsx
@@ -199,7 +199,7 @@ const SettingsPage: React.FC = () => {
                                         onChange={(e) => handleFieldChange('site_name', e.target.value)}
                                         disabled={!canUpdate}
                                         className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                        placeholder="My Cinema Site"
+                                        placeholder="My Theater Site"
                                     />
                                 </div>
 
@@ -311,7 +311,7 @@ const SettingsPage: React.FC = () => {
                                         disabled={!canUpdate}
                                         rows={3}
                                         className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                        placeholder="© 2024 My Cinema Site. All rights reserved."
+                                        placeholder="© 2024 My Theater Site. All rights reserved."
                                     />
                                 </div>
 
@@ -335,7 +335,7 @@ const SettingsPage: React.FC = () => {
                                         onChange={(e) => handleFieldChange('email_from_name', e.target.value)}
                                         disabled={!canUpdate}
                                         className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                        placeholder="My Cinema Site"
+                                        placeholder="My Theater Site"
                                     />
                                 </div>
 

--- a/client/src/pages/admin/SystemPage.test.tsx
+++ b/client/src/pages/admin/SystemPage.test.tsx
@@ -61,7 +61,7 @@ const mockHealth = {
   scrapers: {
     activeJobs: 0,
     lastScrapeTime: '2024-01-01T00:00:00.000Z',
-    totalCinemas: 5,
+    totalTheaters: 5,
   },
 };
 

--- a/client/src/pages/admin/SystemPage.tsx
+++ b/client/src/pages/admin/SystemPage.tsx
@@ -155,8 +155,8 @@ const SystemPage: React.FC = () => {
                 <p className="text-lg font-medium">{health.scrapers.activeJobs}</p>
               </div>
               <div>
-                <p className="text-sm text-gray-600">Total Cinemas</p>
-                <p className="text-lg font-medium">{health.scrapers.totalCinemas}</p>
+                <p className="text-sm text-gray-600">Total Theaters</p>
+                <p className="text-lg font-medium">{health.scrapers.totalTheaters}</p>
               </div>
             </div>
           </div>
@@ -225,7 +225,7 @@ const SystemPage: React.FC = () => {
                 <dd className="font-medium">{systemInfo.database.tables}</dd>
               </div>
               <div>
-                <dt className="text-sm text-gray-600">Cinemas</dt>
+                <dt className="text-sm text-gray-600">Theaters</dt>
                 <dd className="font-medium">{systemInfo.database.theaters}</dd>
               </div>
               <div>

--- a/client/src/pages/admin/TheatersPage.test.tsx
+++ b/client/src/pages/admin/TheatersPage.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
-import CinemasPage from './CinemasPage';
+import TheatersPage from './TheatersPage';
 import * as theatersApi from '../../api/theaters';
 import * as clientApi from '../../api/client';
 import { AuthContext } from '../../contexts/AuthContext';
@@ -48,17 +48,17 @@ vi.mock('../../components/ScrapeButton', () => ({
 }));
 
 // Mock child modal components to keep tests focused
-vi.mock('../../components/admin/AddCinemaModal', () => ({
+vi.mock('../../components/admin/AddTheaterModal', () => ({
   default: ({ isOpen }: { isOpen: boolean }) =>
-    isOpen ? <div data-testid="add-cinema-modal">Add Modal</div> : null,
+    isOpen ? <div data-testid="add-theater-modal">Add Modal</div> : null,
 }));
 
-vi.mock('../../components/admin/EditCinemaModal', () => ({
-  default: () => <div data-testid="edit-cinema-modal">Edit Modal</div>,
+vi.mock('../../components/admin/EditTheaterModal', () => ({
+  default: () => <div data-testid="edit-theater-modal">Edit Modal</div>,
 }));
 
-vi.mock('../../components/admin/DeleteCinemaDialog', () => ({
-  default: () => <div data-testid="delete-cinema-dialog">Delete Dialog</div>,
+vi.mock('../../components/admin/DeleteTheaterDialog', () => ({
+  default: () => <div data-testid="delete-theater-dialog">Delete Dialog</div>,
 }));
 
 // Mock ScrapeProgress to avoid SSE complexity in tests
@@ -74,7 +74,7 @@ vi.mock('../../components/ScrapeProgress', () => ({
 const mockAuthContext = {
   isAuthenticated: true,
   token: 'mock-token',
-  user: { id: 1, username: 'admin', role_id: 1, role_name: 'admin', is_system_role: true, permissions: ['cinemas:read', 'cinemas:create', 'scraper:trigger'] as PermissionName[] },
+  user: { id: 1, username: 'admin', role_id: 1, role_name: 'admin', is_system_role: true, permissions: ['theaters:read', 'theaters:create', 'scraper:trigger'] as PermissionName[] },
   login: vi.fn(),
   logout: vi.fn(),
   isAdmin: true,
@@ -100,14 +100,14 @@ const renderWithAuth = (ui: React.ReactElement, authOverrides?: Partial<typeof m
   );
 };
 
-const mockCinemas = [
+const mockTheaters = [
   { id: 'C0153', name: 'UGC Ciné Cité Paris', city: 'Paris', screen_count: 12 },
   { id: 'C0002', name: 'Pathé Wepler', city: 'Paris', screen_count: 8 },
 ];
 
-describe('CinemasPage - Scrape All button', () => {
+describe('TheatersPage - Scrape All button', () => {
   beforeEach(() => {
-    vi.mocked(theatersApi.getTheaters).mockResolvedValue(mockCinemas);
+    vi.mocked(theatersApi.getTheaters).mockResolvedValue(mockTheaters);
     vi.mocked(clientApi.getScrapeStatus).mockResolvedValue({ isRunning: false });
     vi.mocked(clientApi.triggerScrape).mockResolvedValue({ reportId: 1, message: 'ok' });
   });
@@ -117,7 +117,7 @@ describe('CinemasPage - Scrape All button', () => {
   });
 
   it('renders a "Scrape All" button in the header', async () => {
-    renderWithAuth(<CinemasPage />);
+    renderWithAuth(<TheatersPage />);
 
     await screen.findByText('UGC Ciné Cité Paris');
 
@@ -125,7 +125,7 @@ describe('CinemasPage - Scrape All button', () => {
   });
 
   it('triggers scrapeAll when "Scrape All" button is clicked', async () => {
-    renderWithAuth(<CinemasPage />);
+    renderWithAuth(<TheatersPage />);
 
     await screen.findByText('UGC Ciné Cité Paris');
 
@@ -137,7 +137,7 @@ describe('CinemasPage - Scrape All button', () => {
   });
 
   it('shows ScrapeProgress after triggering scrape all', async () => {
-    renderWithAuth(<CinemasPage />);
+    renderWithAuth(<TheatersPage />);
 
     await screen.findByText('UGC Ciné Cité Paris');
 
@@ -153,24 +153,24 @@ describe('CinemasPage - Scrape All button', () => {
   it('shows ScrapeProgress on mount if scrape is already running', async () => {
     vi.mocked(clientApi.getScrapeStatus).mockResolvedValue({ isRunning: true });
 
-    renderWithAuth(<CinemasPage />);
+    renderWithAuth(<TheatersPage />);
 
     await waitFor(() => {
       expect(screen.getByTestId('scrape-progress')).toBeInTheDocument();
     });
   });
 
-  it('hides ScrapeProgress and refreshes cinemas after scrape completes', async () => {
+  it('hides ScrapeProgress and refreshes theaters after scrape completes', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
-    const updatedCinemas = [
-      ...mockCinemas,
-      { id: 'C0999', name: 'New Cinema', city: 'Lyon', screen_count: 5 },
+    const updatedTheaters = [
+      ...mockTheaters,
+      { id: 'C0999', name: 'New Theater', city: 'Lyon', screen_count: 5 },
     ];
     vi.mocked(theatersApi.getTheaters)
-      .mockResolvedValueOnce(mockCinemas)
-      .mockResolvedValueOnce(updatedCinemas);
+      .mockResolvedValueOnce(mockTheaters)
+      .mockResolvedValueOnce(updatedTheaters);
 
-    renderWithAuth(<CinemasPage />);
+    renderWithAuth(<TheatersPage />);
 
     await screen.findByText('UGC Ciné Cité Paris');
 
@@ -189,7 +189,7 @@ describe('CinemasPage - Scrape All button', () => {
       vi.advanceTimersByTime(2500);
     });
 
-    // Progress should disappear and cinemas should reload
+    // Progress should disappear and theaters should reload
     await waitFor(() => {
       expect(screen.queryByTestId('scrape-progress')).not.toBeInTheDocument();
     });
@@ -202,9 +202,9 @@ describe('CinemasPage - Scrape All button', () => {
   });
 });
 
-describe('CinemasPage - Per-cinema scrape button', () => {
+describe('TheatersPage - Per-theater scrape button', () => {
   beforeEach(() => {
-    vi.mocked(theatersApi.getTheaters).mockResolvedValue(mockCinemas);
+    vi.mocked(theatersApi.getTheaters).mockResolvedValue(mockTheaters);
     vi.mocked(clientApi.getScrapeStatus).mockResolvedValue({ isRunning: false });
     vi.mocked(clientApi.triggerTheaterScrape).mockResolvedValue({ reportId: 2, message: 'ok' });
   });
@@ -213,35 +213,35 @@ describe('CinemasPage - Per-cinema scrape button', () => {
     vi.clearAllMocks();
   });
 
-  it('renders a scrape button for each cinema row', async () => {
-    renderWithAuth(<CinemasPage />);
+  it('renders a scrape button for each theater row', async () => {
+    renderWithAuth(<TheatersPage />);
 
     await screen.findByText('UGC Ciné Cité Paris');
 
-    expect(screen.getByTestId('scrape-cinema-C0153')).toBeInTheDocument();
-    expect(screen.getByTestId('scrape-cinema-C0002')).toBeInTheDocument();
+    expect(screen.getByTestId('scrape-theater-C0153')).toBeInTheDocument();
+    expect(screen.getByTestId('scrape-theater-C0002')).toBeInTheDocument();
   });
 
   it('triggers triggerTheaterScrape with correct ID when per-theater button is clicked', async () => {
-    renderWithAuth(<CinemasPage />);
+    renderWithAuth(<TheatersPage />);
 
     await screen.findByText('UGC Ciné Cité Paris');
 
-    fireEvent.click(screen.getByTestId('scrape-cinema-C0153'));
+    fireEvent.click(screen.getByTestId('scrape-theater-C0153'));
 
     await waitFor(() => {
       expect(clientApi.triggerTheaterScrape).toHaveBeenCalledWith('C0153');
     });
   });
 
-  it('shows ScrapeProgress after triggering per-cinema scrape', async () => {
-    renderWithAuth(<CinemasPage />);
+  it('shows ScrapeProgress after triggering per-theater scrape', async () => {
+    renderWithAuth(<TheatersPage />);
 
     await screen.findByText('UGC Ciné Cité Paris');
 
     expect(screen.queryByTestId('scrape-progress')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByTestId('scrape-cinema-C0002'));
+    fireEvent.click(screen.getByTestId('scrape-theater-C0002'));
 
     await waitFor(() => {
       expect(screen.getByTestId('scrape-progress')).toBeInTheDocument();
@@ -249,15 +249,15 @@ describe('CinemasPage - Per-cinema scrape button', () => {
   });
 });
 
-describe('CinemasPage - Scraping buttons not on public pages', () => {
+describe('TheatersPage - Scraping buttons not on public pages', () => {
   it('HomePage does not import triggerScrape (scrape moved to admin)', async () => {
     // This test documents the expected behaviour: scraping is admin-only.
     // The actual enforcement is structural (no ScrapeButton in HomePage).
-    // We verify by checking that CinemasPage renders the scrape all button.
-    vi.mocked(theatersApi.getTheaters).mockResolvedValue(mockCinemas);
+    // We verify by checking that TheatersPage renders the scrape all button.
+    vi.mocked(theatersApi.getTheaters).mockResolvedValue(mockTheaters);
     vi.mocked(clientApi.getScrapeStatus).mockResolvedValue({ isRunning: false });
 
-    renderWithAuth(<CinemasPage />);
+    renderWithAuth(<TheatersPage />);
 
     await screen.findByText('UGC Ciné Cité Paris');
 
@@ -266,9 +266,9 @@ describe('CinemasPage - Scraping buttons not on public pages', () => {
   });
 });
 
-describe('CinemasPage - permission-based button visibility', () => {
+describe('TheatersPage - permission-based button visibility', () => {
   beforeEach(() => {
-    vi.mocked(theatersApi.getTheaters).mockResolvedValue(mockCinemas);
+    vi.mocked(theatersApi.getTheaters).mockResolvedValue(mockTheaters);
     vi.mocked(clientApi.getScrapeStatus).mockResolvedValue({ isRunning: false });
   });
 
@@ -276,89 +276,89 @@ describe('CinemasPage - permission-based button visibility', () => {
     vi.clearAllMocks();
   });
 
-  it('hides "Add Cinema" button when user lacks cinemas:create permission', async () => {
-    renderWithAuth(<CinemasPage />, {
-      hasPermission: vi.fn((p: PermissionName) => p !== 'cinemas:create'),
+  it('hides "Add Theater" button when user lacks theaters:create permission', async () => {
+    renderWithAuth(<TheatersPage />, {
+      hasPermission: vi.fn((p: PermissionName) => p !== 'theaters:create'),
     });
 
     await screen.findByText('UGC Ciné Cité Paris');
 
-    expect(screen.queryByTestId('add-cinema-button')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('add-theater-button')).not.toBeInTheDocument();
   });
 
-  it('shows "Add Cinema" button when user has cinemas:create permission', async () => {
-    renderWithAuth(<CinemasPage />, {
+  it('shows "Add Theater" button when user has theaters:create permission', async () => {
+    renderWithAuth(<TheatersPage />, {
       hasPermission: vi.fn(() => true),
     });
 
     await screen.findByText('UGC Ciné Cité Paris');
 
-    expect(screen.getByTestId('add-cinema-button')).toBeInTheDocument();
+    expect(screen.getByTestId('add-theater-button')).toBeInTheDocument();
   });
 
-  it('hides per-row "Edit" button when user lacks cinemas:update permission', async () => {
-    renderWithAuth(<CinemasPage />, {
-      hasPermission: vi.fn((p: PermissionName) => p !== 'cinemas:update'),
+  it('hides per-row "Edit" button when user lacks theaters:update permission', async () => {
+    renderWithAuth(<TheatersPage />, {
+      hasPermission: vi.fn((p: PermissionName) => p !== 'theaters:update'),
     });
 
     await screen.findByText('UGC Ciné Cité Paris');
 
-    expect(screen.queryByTestId('edit-cinema-C0153')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('edit-cinema-C0002')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('edit-theater-C0153')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('edit-theater-C0002')).not.toBeInTheDocument();
   });
 
-  it('shows per-row "Edit" button when user has cinemas:update permission', async () => {
-    renderWithAuth(<CinemasPage />, {
+  it('shows per-row "Edit" button when user has theaters:update permission', async () => {
+    renderWithAuth(<TheatersPage />, {
       hasPermission: vi.fn(() => true),
     });
 
     await screen.findByText('UGC Ciné Cité Paris');
 
-    expect(screen.getByTestId('edit-cinema-C0153')).toBeInTheDocument();
-    expect(screen.getByTestId('edit-cinema-C0002')).toBeInTheDocument();
+    expect(screen.getByTestId('edit-theater-C0153')).toBeInTheDocument();
+    expect(screen.getByTestId('edit-theater-C0002')).toBeInTheDocument();
   });
 
-  it('hides per-row "Delete" button when user lacks cinemas:delete permission', async () => {
-    renderWithAuth(<CinemasPage />, {
-      hasPermission: vi.fn((p: PermissionName) => p !== 'cinemas:delete'),
+  it('hides per-row "Delete" button when user lacks theaters:delete permission', async () => {
+    renderWithAuth(<TheatersPage />, {
+      hasPermission: vi.fn((p: PermissionName) => p !== 'theaters:delete'),
     });
 
     await screen.findByText('UGC Ciné Cité Paris');
 
-    expect(screen.queryByTestId('delete-cinema-C0153')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('delete-cinema-C0002')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('delete-theater-C0153')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('delete-theater-C0002')).not.toBeInTheDocument();
   });
 
-  it('shows per-row "Delete" button when user has cinemas:delete permission', async () => {
-    renderWithAuth(<CinemasPage />, {
+  it('shows per-row "Delete" button when user has theaters:delete permission', async () => {
+    renderWithAuth(<TheatersPage />, {
       hasPermission: vi.fn(() => true),
     });
 
     await screen.findByText('UGC Ciné Cité Paris');
 
-    expect(screen.getByTestId('delete-cinema-C0153')).toBeInTheDocument();
-    expect(screen.getByTestId('delete-cinema-C0002')).toBeInTheDocument();
+    expect(screen.getByTestId('delete-theater-C0153')).toBeInTheDocument();
+    expect(screen.getByTestId('delete-theater-C0002')).toBeInTheDocument();
   });
 
   it('hides per-row "Scraper" button when user lacks scraper:trigger_single permission', async () => {
-    renderWithAuth(<CinemasPage />, {
+    renderWithAuth(<TheatersPage />, {
       hasPermission: vi.fn((p: PermissionName) => p !== 'scraper:trigger_single'),
     });
 
     await screen.findByText('UGC Ciné Cité Paris');
 
-    expect(screen.queryByTestId('scrape-cinema-C0153')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('scrape-cinema-C0002')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('scrape-theater-C0153')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('scrape-theater-C0002')).not.toBeInTheDocument();
   });
 
   it('shows per-row "Scraper" button when user has scraper:trigger_single permission', async () => {
-    renderWithAuth(<CinemasPage />, {
+    renderWithAuth(<TheatersPage />, {
       hasPermission: vi.fn(() => true),
     });
 
     await screen.findByText('UGC Ciné Cité Paris');
 
-    expect(screen.getByTestId('scrape-cinema-C0153')).toBeInTheDocument();
-    expect(screen.getByTestId('scrape-cinema-C0002')).toBeInTheDocument();
+    expect(screen.getByTestId('scrape-theater-C0153')).toBeInTheDocument();
+    expect(screen.getByTestId('scrape-theater-C0002')).toBeInTheDocument();
   });
 });

--- a/client/src/pages/admin/TheatersPage.tsx
+++ b/client/src/pages/admin/TheatersPage.tsx
@@ -3,10 +3,10 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getTheaters, createTheater, updateTheater, deleteTheater } from '../../api/theaters';
 import type { TheaterCreate, TheaterUpdate } from '../../api/theaters';
 import { triggerScrape, triggerTheaterScrape, getScrapeStatus } from '../../api/client';
-import type { Cinema } from '../../types';
-import AddCinemaModal from '../../components/admin/AddCinemaModal';
-import EditCinemaModal from '../../components/admin/EditCinemaModal';
-import DeleteCinemaDialog from '../../components/admin/DeleteCinemaDialog';
+import type { Theater } from '../../types';
+import AddTheaterModal from '../../components/admin/AddTheaterModal';
+import EditTheaterModal from '../../components/admin/EditTheaterModal';
+import DeleteTheaterDialog from '../../components/admin/DeleteTheaterDialog';
 import ScrapeButton from '../../components/ScrapeButton';
 import ScrapeProgress from '../../components/ScrapeProgress';
 import Button from '../../components/ui/Button';
@@ -15,17 +15,17 @@ import { AuthContext } from '../../contexts/AuthContext';
 
 const SUCCESS_DISMISS_MS = 5000;
 
-const CinemasPage: React.FC = () => {
+const TheatersPage: React.FC = () => {
   const { hasPermission } = useContext(AuthContext);
   const canScrapeAll = hasPermission('scraper:trigger');
   const canScrapeSingle = hasPermission('scraper:trigger_single');
-  const canCreate = hasPermission('cinemas:create');
-  const canUpdate = hasPermission('cinemas:update');
-  const canDelete = hasPermission('cinemas:delete');
+  const canCreate = hasPermission('theaters:create');
+  const canUpdate = hasPermission('theaters:update');
+  const canDelete = hasPermission('theaters:delete');
 
   const queryClient = useQueryClient();
 
-  const { data: cinemas = [], isLoading: loading, error: queryError } = useQuery({
+  const { data: theaters = [], isLoading: loading, error: queryError } = useQuery({
     queryKey: ['theaters'],
     queryFn: getTheaters
   });
@@ -39,12 +39,12 @@ const CinemasPage: React.FC = () => {
 
   // Scraping state
   const [showProgress, setShowProgress] = useState(false);
-  const [, setScrapingCinemaId] = useState<string | null>(null);
+  const [, setScrapingTheaterId] = useState<string | null>(null);
 
   // Modal / dialog state
   const [showAddModal, setShowAddModal] = useState(false);
-  const [cinemaToEdit, setCinemaToEdit] = useState<Cinema | null>(null);
-  const [cinemaToDelete, setCinemaToDelete] = useState<Cinema | null>(null);
+  const [theaterToEdit, setTheaterToEdit] = useState<Theater | null>(null);
+  const [theaterToDelete, setTheaterToDelete] = useState<Theater | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
@@ -74,7 +74,7 @@ const CinemasPage: React.FC = () => {
     mutationFn: createTheater,
     onSuccess: () => {
       setShowAddModal(false);
-      setSuccessMessage('Cinema added successfully');
+      setSuccessMessage('Theater added successfully');
       queryClient.invalidateQueries({ queryKey: ['theaters'] });
     }
   });
@@ -86,8 +86,8 @@ const CinemasPage: React.FC = () => {
   const updateMutation = useMutation({
     mutationFn: ({ id, updates }: { id: string; updates: TheaterUpdate }) => updateTheater(id, updates),
     onSuccess: () => {
-      setCinemaToEdit(null);
-      setSuccessMessage('Cinema updated successfully');
+      setTheaterToEdit(null);
+      setSuccessMessage('Theater updated successfully');
       queryClient.invalidateQueries({ queryKey: ['theaters'] });
     }
   });
@@ -99,21 +99,21 @@ const CinemasPage: React.FC = () => {
   const deleteMutation = useMutation({
     mutationFn: deleteTheater,
     onSuccess: () => {
-      setCinemaToDelete(null);
-      setSuccessMessage('Cinema deleted successfully');
+      setTheaterToDelete(null);
+      setSuccessMessage('Theater deleted successfully');
       queryClient.invalidateQueries({ queryKey: ['theaters'] });
       setIsDeleting(false);
     },
     onError: (err) => {
-      setDeleteError(err instanceof Error ? err.message : 'Failed to delete cinema');
+      setDeleteError(err instanceof Error ? err.message : 'Failed to delete theater');
       setIsDeleting(false);
     }
   });
 
-  const handleDelete = async (cinemaId: string) => {
+  const handleDelete = async (theaterId: string) => {
     setIsDeleting(true);
     setDeleteError(null);
-    deleteMutation.mutate(cinemaId);
+    deleteMutation.mutate(theaterId);
   };
 
   // ── Scraping handlers ────────────────────────────────────────────────────────
@@ -125,34 +125,34 @@ const CinemasPage: React.FC = () => {
   const handleScrapeComplete = useCallback(() => {
     setTimeout(() => {
       setShowProgress(false);
-      setScrapingCinemaId(null);
+      setScrapingTheaterId(null);
       queryClient.invalidateQueries({ queryKey: ['theaters'] });
     }, 2000);
   }, [queryClient]);
 
   // ── Filtering ────────────────────────────────────────────────────────────────
 
-  // ⚡ PERFORMANCE: Memoize the filtered cinemas list to prevent expensive
+  // ⚡ PERFORMANCE: Memoize the filtered theaters list to prevent expensive
   // recalculation of the entire array on every render, especially when unrelated
   // state (like modal visibility or form data) changes.
-  const filteredCinemas = useMemo(() => {
-    return cinemas.filter((cinema) => {
+  const filteredTheaters = useMemo(() => {
+    return theaters.filter((theater) => {
       if (!searchQuery.trim()) return true;
       const q = searchQuery.toLowerCase();
       return (
-        cinema.name.toLowerCase().includes(q) ||
-        cinema.id.toLowerCase().includes(q) ||
-        (cinema.city ?? '').toLowerCase().includes(q)
+        theater.name.toLowerCase().includes(q) ||
+        theater.id.toLowerCase().includes(q) ||
+        (theater.city ?? '').toLowerCase().includes(q)
       );
     });
-  }, [cinemas, searchQuery]);
+  }, [theaters, searchQuery]);
 
   // ── Render ───────────────────────────────────────────────────────────────────
 
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
-        <div className="text-gray-600">Loading cinemas...</div>
+        <div className="text-gray-600">Loading theaters...</div>
       </div>
     );
   }
@@ -161,7 +161,7 @@ const CinemasPage: React.FC = () => {
     <div className="container mx-auto px-4 py-8">
       {/* Header */}
       <div className="flex justify-between items-center mb-6">
-        <h1 className="text-3xl font-bold text-gray-900">Cinema Management</h1>
+        <h1 className="text-3xl font-bold text-gray-900">Theater Management</h1>
         <div className="flex items-center gap-3">
           {canScrapeAll && (
             <ScrapeButton
@@ -176,9 +176,9 @@ const CinemasPage: React.FC = () => {
           {canCreate && (
             <Button
               onClick={() => setShowAddModal(true)}
-              data-testid="add-cinema-button"
+              data-testid="add-theater-button"
             >
-              Add Cinema
+              Add Theater
             </Button>
           )}
         </div>
@@ -212,20 +212,20 @@ const CinemasPage: React.FC = () => {
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           placeholder="Search by name, ID, or city..."
-          data-testid="cinema-search-input"
+          data-testid="theater-search-input"
           className="w-full max-w-sm px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
         />
       </div>
 
       {/* Empty State */}
-      {filteredCinemas.length === 0 ? (
+      {filteredTheaters.length === 0 ? (
         <div className="text-center py-12">
           <p className="text-gray-600">
-            {searchQuery.trim() ? 'No cinemas match your search' : 'No cinemas found'}
+            {searchQuery.trim() ? 'No theaters match your search' : 'No theaters found'}
           </p>
         </div>
       ) : (
-        /* Cinemas Table */
+        /* Theaters Table */
         <div className="bg-white shadow-md rounded-lg overflow-hidden">
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">
@@ -248,20 +248,20 @@ const CinemasPage: React.FC = () => {
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
-              {filteredCinemas.map((cinema) => (
-                <tr key={cinema.id} className="hover:bg-gray-50">
+              {filteredTheaters.map((theater) => (
+                <tr key={theater.id} className="hover:bg-gray-50">
                   <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="font-mono text-sm text-gray-900">{cinema.id}</div>
+                    <div className="font-mono text-sm text-gray-900">{theater.id}</div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="text-sm font-bold text-gray-900">{cinema.name}</div>
+                    <div className="text-sm font-bold text-gray-900">{theater.name}</div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="text-sm text-gray-500">{cinema.city ?? '-'}</div>
+                    <div className="text-sm text-gray-500">{theater.city ?? '-'}</div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
                     <div className="text-sm text-gray-500">
-                      {cinema.screen_count != null ? cinema.screen_count : '-'}
+                      {theater.screen_count != null ? theater.screen_count : '-'}
                     </div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
@@ -270,20 +270,20 @@ const CinemasPage: React.FC = () => {
                          <LinkButton
                            variant="success"
                            onClick={() => {
-                             setScrapingCinemaId(cinema.id);
-                             triggerTheaterScrape(cinema.id)
+                             setScrapingTheaterId(theater.id);
+                             triggerTheaterScrape(theater.id)
                                .then(() => handleScrapeStart())
-                               .catch(() => setScrapingCinemaId(null));
+                               .catch(() => setScrapingTheaterId(null));
                            }}
-                           data-testid={`scrape-cinema-${cinema.id}`}
+                           data-testid={`scrape-theater-${theater.id}`}
                          >
                            Scraper
                          </LinkButton>
                        )}
                        {canUpdate && (
                          <LinkButton
-                           onClick={() => setCinemaToEdit(cinema)}
-                           data-testid={`edit-cinema-${cinema.id}`}
+                           onClick={() => setTheaterToEdit(theater)}
+                           data-testid={`edit-theater-${theater.id}`}
                          >
                            Edit
                          </LinkButton>
@@ -292,10 +292,10 @@ const CinemasPage: React.FC = () => {
                          <LinkButton
                            variant="danger"
                            onClick={() => {
-                             setCinemaToDelete(cinema);
+                             setTheaterToDelete(theater);
                              setDeleteError(null);
                            }}
-                           data-testid={`delete-cinema-${cinema.id}`}
+                           data-testid={`delete-theater-${theater.id}`}
                          >
                            Delete
                          </LinkButton>
@@ -309,31 +309,31 @@ const CinemasPage: React.FC = () => {
         </div>
       )}
 
-      {/* Add Cinema Modal */}
-      <AddCinemaModal
+      {/* Add Theater Modal */}
+      <AddTheaterModal
         isOpen={showAddModal}
         onClose={() => setShowAddModal(false)}
         onAdd={handleAdd}
       />
 
-      {/* Edit Cinema Modal — key forces remount when switching cinemas */}
-      {cinemaToEdit && (
-        <EditCinemaModal
-          key={cinemaToEdit.id}
+      {/* Edit Theater Modal — key forces remount when switching theaters */}
+      {theaterToEdit && (
+        <EditTheaterModal
+          key={theaterToEdit.id}
           isOpen={true}
-          cinema={cinemaToEdit}
-          onClose={() => setCinemaToEdit(null)}
+          theater={theaterToEdit}
+          onClose={() => setTheaterToEdit(null)}
           onSave={handleUpdate}
         />
       )}
 
-      {/* Delete Cinema Dialog */}
-      {cinemaToDelete && (
-        <DeleteCinemaDialog
+      {/* Delete Theater Dialog */}
+      {theaterToDelete && (
+        <DeleteTheaterDialog
           isOpen={true}
-          cinema={cinemaToDelete}
+          theater={theaterToDelete}
           onClose={() => {
-            setCinemaToDelete(null);
+            setTheaterToDelete(null);
             setDeleteError(null);
           }}
           onConfirm={handleDelete}
@@ -345,4 +345,4 @@ const CinemasPage: React.FC = () => {
   );
 };
 
-export default CinemasPage;
+export default TheatersPage;

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -35,8 +35,8 @@ export interface Movie {
   trailer_url?: string;
 }
 
-// Cinema types
-export interface Cinema {
+// Theater types
+export interface Theater {
   id: string;
   name: string;
   url?: string;
@@ -51,7 +51,7 @@ export interface Cinema {
 export interface Showtime {
   id: string;
   movie_id: number;
-  cinema_id: string;
+  theater_id: string;
   date: string;
   time: string;
   datetime_iso: string;
@@ -65,16 +65,16 @@ export interface ShowtimeWithMovie extends Showtime {
   movie: Movie;
 }
 
-export interface MovieWithCinemas extends Movie {
-  theaters: Cinema[];
+export interface MovieWithTheaters extends Movie {
+  theaters: Theater[];
 }
 
-export interface CinemaWithShowtimes extends Cinema {
+export interface TheaterWithShowtimes extends Theater {
   showtimes: Showtime[];
 }
 
 export interface MovieWithShowtimes extends Movie {
-  theaters: CinemaWithShowtimes[];
+  theaters: TheaterWithShowtimes[];
 }
 
 // Scrape Report types
@@ -150,7 +150,7 @@ export interface ScrapeSchedule {
   description: string | null;
   cron_expression: string;
   enabled: boolean;
-  target_cinemas: string[] | null;
+  target_theaters: string[] | null;
   created_by: number | null;
   updated_by: number | null;
   created_at: string;

--- a/client/src/types/role.ts
+++ b/client/src/types/role.ts
@@ -14,7 +14,7 @@ export type PermissionName =
   | 'users:list' | 'users:create' | 'users:update' | 'users:delete' | 'users:read'
   | 'scraper:trigger' | 'scraper:trigger_single'
   | 'scraper:schedules:list' | 'scraper:schedules:create' | 'scraper:schedules:update' | 'scraper:schedules:delete'
-  | 'cinemas:create' | 'cinemas:update' | 'cinemas:delete' | 'cinemas:read'
+  | 'theaters:create' | 'theaters:update' | 'theaters:delete' | 'theaters:read'
   | 'settings:read' | 'settings:update' | 'settings:reset' | 'settings:export' | 'settings:import'
   | 'reports:list' | 'reports:view'
   | 'system:info' | 'system:health' | 'system:migrations'

--- a/client/src/utils/adminPermissions.ts
+++ b/client/src/utils/adminPermissions.ts
@@ -11,11 +11,11 @@ import type { PermissionName } from '../types/role';
  * for all admin resources.
  */
 export const ADMIN_PERMISSIONS: PermissionName[] = [
-  // Cinema permissions
-  'cinemas:create',
-  'cinemas:update',
-  'cinemas:delete',
-  'cinemas:read',
+  // Theater permissions
+  'theaters:create',
+  'theaters:update',
+  'theaters:delete',
+  'theaters:read',
   
   // User permissions
   'users:list',
@@ -47,7 +47,7 @@ export const ADMIN_PERMISSIONS: PermissionName[] = [
   'system:health',
   'system:migrations',
   
-  // Scraper permissions (visible in cinemas tab)
+  // Scraper permissions (visible in theaters tab)
   'scraper:trigger',
   'scraper:trigger_single',
   

--- a/client/src/utils/calendar.test.ts
+++ b/client/src/utils/calendar.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { buildGoogleCalendarUrl, buildIcsContent } from './calendar';
-import type { Showtime, Movie, Cinema } from '../types';
+import type { Showtime, Movie, Theater } from '../types';
 
 const baseShowtime: Showtime = {
   id: 'st-1',
   movie_id: 42,
-  cinema_id: 'C0001',
+  theater_id: 'C0001',
   date: '2026-05-20',
   time: '20:30',
   datetime_iso: '2026-05-20T20:30:00',
@@ -24,7 +24,7 @@ const baseMovie: Movie = {
   duration_minutes: 90,
 };
 
-const baseCinema: Cinema = {
+const baseTheater: Theater = {
   id: 'C0001',
   name: 'Cinéma Test',
   address: '10 rue du Cinéma',
@@ -33,47 +33,47 @@ const baseCinema: Cinema = {
 
 describe('buildGoogleCalendarUrl', () => {
   it('returns a valid Google Calendar URL', () => {
-    const url = buildGoogleCalendarUrl(baseShowtime, baseMovie, baseCinema);
+    const url = buildGoogleCalendarUrl(baseShowtime, baseMovie, baseTheater);
     expect(url).toContain('https://calendar.google.com/calendar/render');
     expect(url).toContain('action=TEMPLATE');
   });
 
   it('encodes the film title in the URL', () => {
-    const url = buildGoogleCalendarUrl(baseShowtime, baseMovie, baseCinema);
+    const url = buildGoogleCalendarUrl(baseShowtime, baseMovie, baseTheater);
     const decoded = decodeURIComponent(url.replace(/\+/g, ' '));
     expect(decoded).toContain('Mon Film Test');
   });
 
   it('uses correct start date from datetime_iso', () => {
-    const url = buildGoogleCalendarUrl(baseShowtime, baseMovie, baseCinema);
+    const url = buildGoogleCalendarUrl(baseShowtime, baseMovie, baseTheater);
     // 2026-05-20T20:30:00 → 20260520T203000
     expect(url).toContain('20260520T203000');
   });
 
   it('calculates end time using duration_minutes', () => {
-    const url = buildGoogleCalendarUrl(baseShowtime, baseMovie, baseCinema);
+    const url = buildGoogleCalendarUrl(baseShowtime, baseMovie, baseTheater);
     // 20:30 + 90min = 22:00 → 20260520T220000
     expect(url).toContain('20260520T220000');
   });
 
   it('defaults end time to +2h when duration_minutes is null', () => {
     const movie = { ...baseMovie, duration_minutes: undefined };
-    const url = buildGoogleCalendarUrl(baseShowtime, movie, baseCinema);
+    const url = buildGoogleCalendarUrl(baseShowtime, movie, baseTheater);
     // 20:30 + 120min = 22:30 → 20260520T223000
     expect(url).toContain('20260520T223000');
   });
 
-  it('includes cinema name and address as location', () => {
-    const url = buildGoogleCalendarUrl(baseShowtime, baseMovie, baseCinema);
+  it('includes theater name and address as location', () => {
+    const url = buildGoogleCalendarUrl(baseShowtime, baseMovie, baseTheater);
     // URLSearchParams uses + for spaces; decode the URL to check values
     const decoded = decodeURIComponent(url.replace(/\+/g, ' '));
     expect(decoded).toContain('Cinéma Test');
     expect(decoded).toContain('10 rue du Cinéma');
   });
 
-  it('uses cinema name only when address is missing', () => {
-    const cinema = { ...baseCinema, address: undefined };
-    const url = buildGoogleCalendarUrl(baseShowtime, baseMovie, cinema);
+  it('uses theater name only when address is missing', () => {
+    const theater = { ...baseTheater, address: undefined };
+    const url = buildGoogleCalendarUrl(baseShowtime, baseMovie, theater);
     const decoded = decodeURIComponent(url.replace(/\+/g, ' '));
     expect(decoded).toContain('Cinéma Test');
     expect(decoded).not.toContain('10 rue du Cinéma');
@@ -82,54 +82,54 @@ describe('buildGoogleCalendarUrl', () => {
 
 describe('buildIcsContent', () => {
   it('returns a string starting with BEGIN:VCALENDAR', () => {
-    const ics = buildIcsContent(baseShowtime, baseMovie, baseCinema);
+    const ics = buildIcsContent(baseShowtime, baseMovie, baseTheater);
     expect(ics).toMatch(/^BEGIN:VCALENDAR/);
   });
 
   it('contains BEGIN:VEVENT and END:VEVENT', () => {
-    const ics = buildIcsContent(baseShowtime, baseMovie, baseCinema);
+    const ics = buildIcsContent(baseShowtime, baseMovie, baseTheater);
     expect(ics).toContain('BEGIN:VEVENT');
     expect(ics).toContain('END:VEVENT');
   });
 
   it('contains correct DTSTART', () => {
-    const ics = buildIcsContent(baseShowtime, baseMovie, baseCinema);
+    const ics = buildIcsContent(baseShowtime, baseMovie, baseTheater);
     expect(ics).toContain('DTSTART:20260520T203000');
   });
 
   it('contains correct DTEND with duration', () => {
-    const ics = buildIcsContent(baseShowtime, baseMovie, baseCinema);
+    const ics = buildIcsContent(baseShowtime, baseMovie, baseTheater);
     // 20:30 + 90min = 22:00
     expect(ics).toContain('DTEND:20260520T220000');
   });
 
   it('defaults DTEND to +2h when duration_minutes is null', () => {
     const movie = { ...baseMovie, duration_minutes: undefined };
-    const ics = buildIcsContent(baseShowtime, movie, baseCinema);
+    const ics = buildIcsContent(baseShowtime, movie, baseTheater);
     // 20:30 + 120min = 22:30
     expect(ics).toContain('DTEND:20260520T223000');
   });
 
   it('contains film title as SUMMARY', () => {
-    const ics = buildIcsContent(baseShowtime, baseMovie, baseCinema);
+    const ics = buildIcsContent(baseShowtime, baseMovie, baseTheater);
     expect(ics).toContain('SUMMARY:Mon Film Test');
   });
 
-  it('contains cinema name and address as LOCATION (RFC 5545 escaped)', () => {
-    const ics = buildIcsContent(baseShowtime, baseMovie, baseCinema);
+  it('contains theater name and address as LOCATION (RFC 5545 escaped)', () => {
+    const ics = buildIcsContent(baseShowtime, baseMovie, baseTheater);
     // RFC 5545 requires commas to be escaped as \,
     expect(ics).toContain('LOCATION:Cinéma Test\\, 10 rue du Cinéma');
   });
 
-  it('uses cinema name only as LOCATION when address is missing', () => {
-    const cinema = { ...baseCinema, address: undefined };
-    const ics = buildIcsContent(baseShowtime, baseMovie, cinema);
+  it('uses theater name only as LOCATION when address is missing', () => {
+    const theater = { ...baseTheater, address: undefined };
+    const ics = buildIcsContent(baseShowtime, baseMovie, theater);
     expect(ics).toContain('LOCATION:Cinéma Test');
     expect(ics).not.toContain('LOCATION:Cinéma Test,');
   });
 
   it('ends with END:VCALENDAR', () => {
-    const ics = buildIcsContent(baseShowtime, baseMovie, baseCinema);
+    const ics = buildIcsContent(baseShowtime, baseMovie, baseTheater);
     expect(ics.trim()).toMatch(/END:VCALENDAR$/);
   });
 });

--- a/client/src/utils/calendar.ts
+++ b/client/src/utils/calendar.ts
@@ -1,4 +1,4 @@
-import type { Showtime, Movie, Cinema } from '../types';
+import type { Showtime, Movie, Theater } from '../types';
 
 /**
  * Convert an ISO 8601 datetime string (local, no timezone designator) to
@@ -27,11 +27,11 @@ function addMinutesToIso(isoString: string, minutes: number): string {
   return `${year}${month}${day}T${hours}${mins}${secs}`;
 }
 
-function buildLocation(cinema: Cinema): string {
-  if (cinema.address) {
-    return `${cinema.name}, ${cinema.address}`;
+function buildLocation(theater: Theater): string {
+  if (theater.address) {
+    return `${theater.name}, ${theater.address}`;
   }
-  return cinema.name;
+  return theater.name;
 }
 
 function buildDetails(showtime: Showtime): string {
@@ -82,11 +82,11 @@ function foldIcsLine(line: string): string {
  * Build a Google Calendar "add event" URL.
  * Opens in a new tab with the event pre-filled.
  */
-export function buildGoogleCalendarUrl(showtime: Showtime, movie: Movie, cinema: Cinema): string {
+export function buildGoogleCalendarUrl(showtime: Showtime, movie: Movie, theater: Theater): string {
   const durationMinutes = movie.duration_minutes ?? 120;
   const dtStart = toCompactDateTime(showtime.datetime_iso);
   const dtEnd = addMinutesToIso(showtime.datetime_iso, durationMinutes);
-  const location = buildLocation(cinema);
+  const location = buildLocation(theater);
   const details = buildDetails(showtime);
 
   const params = new URLSearchParams({
@@ -103,13 +103,13 @@ export function buildGoogleCalendarUrl(showtime: Showtime, movie: Movie, cinema:
 /**
  * Build the text content of an RFC 5545 .ics file for a single event.
  */
-export function buildIcsContent(showtime: Showtime, movie: Movie, cinema: Cinema): string {
+export function buildIcsContent(showtime: Showtime, movie: Movie, theater: Theater): string {
   const durationMinutes = movie.duration_minutes ?? 120;
   const dtStart = toCompactDateTime(showtime.datetime_iso);
   const dtEnd = addMinutesToIso(showtime.datetime_iso, durationMinutes);
-  const location = buildLocation(cinema);
+  const location = buildLocation(theater);
   const details = buildDetails(showtime);
-  const uid = `${showtime.datetime_iso}-${showtime.cinema_id}@allo-scrapper`;
+  const uid = `${showtime.datetime_iso}-${showtime.theater_id}@allo-scrapper`;
 
   const lines = [
     'BEGIN:VCALENDAR',
@@ -132,8 +132,8 @@ export function buildIcsContent(showtime: Showtime, movie: Movie, cinema: Cinema
 /**
  * Trigger a browser download of a .ics file for the given showtime.
  */
-export function downloadIcsFile(showtime: Showtime, movie: Movie, cinema: Cinema): void {
-  const content = buildIcsContent(showtime, movie, cinema);
+export function downloadIcsFile(showtime: Showtime, movie: Movie, theater: Theater): void {
+  const content = buildIcsContent(showtime, movie, theater);
   const blob = new Blob([content], { type: 'text/calendar;charset=utf-8' });
   const url = URL.createObjectURL(blob);
   const link = document.createElement('a');

--- a/client/src/utils/highlight.test.tsx
+++ b/client/src/utils/highlight.test.tsx
@@ -80,12 +80,12 @@ describe('highlightText', () => {
     });
 
     it('should highlight match at the end of text', () => {
-      const result = highlightText('Cinema', 'ema');
+      const result = highlightText('Theater', 'ter');
       const { container } = render(<>{result}</>);
       
       const mark = container.querySelector('mark');
-      expect(mark?.textContent).toBe('ema');
-      expect(container.textContent).toBe('Cinema');
+      expect(mark?.textContent).toBe('ter');
+      expect(container.textContent).toBe('Theater');
     });
   });
 

--- a/migrations/001_neutralize_references.sql
+++ b/migrations/001_neutralize_references.sql
@@ -6,10 +6,10 @@
 -- to use neutral terminology throughout the database schema.
 --
 -- IMPORTANT: Backup your database before running this migration!
---   docker compose exec -T db pg_dump -U postgres its > backup_before_neutralize.sql
+--   docker compose exec -T ics-db pg_dump -U postgres ics > backup_before_neutralize.sql
 --
 -- Apply this migration:
---   docker compose exec -T db psql -U postgres -d its -f migrations/001_neutralize_references.sql
+--   docker compose exec -T ics-db psql -U postgres -d ics -f migrations/001_neutralize_references.sql
 
 BEGIN;
 

--- a/migrations/003_add_users_table.sql
+++ b/migrations/003_add_users_table.sql
@@ -4,10 +4,10 @@
 -- Description: Creates users table for JWT authentication (admin seed moved to migration 007)
 --
 -- IMPORTANT: Backup your database before running this migration!
---   docker compose exec -T db pg_dump -U postgres its > backup_before_users_table.sql
+--   docker compose exec -T ics-db pg_dump -U postgres ics > backup_before_users_table.sql
 --
 -- Apply this migration:
---   docker compose exec -T db psql -U postgres -d its -f migrations/003_add_users_table.sql
+--   docker compose exec -T ics-db psql -U postgres -d ics -f migrations/003_add_users_table.sql
 
 BEGIN;
 

--- a/migrations/022_fix_showtime_deduplication.sql
+++ b/migrations/022_fix_showtime_deduplication.sql
@@ -16,10 +16,10 @@
 --      as an additional safety net
 --
 -- IMPORTANT: Backup your database before running!
---   docker compose exec -T db pg_dump -U postgres its > backup_before_022.sql
+--   docker compose exec -T ics-db pg_dump -U postgres ics > backup_before_022.sql
 --
 -- Apply:
---   docker compose exec -T db psql -U postgres -d its -f migrations/022_fix_showtime_deduplication.sql
+--   docker compose exec -T ics-db psql -U postgres -d ics -f migrations/022_fix_showtime_deduplication.sql
 
 BEGIN;
 


### PR DESCRIPTION
## Summary
- Rename all client-side  references to  and  to 
- Permission names:  → 
- Types: →, →, →
- Components renamed: CinemasPage→TheatersPage, CinemaPage→TheaterPage, CinemaShowtimes→TheaterShowtimes, CinemasQuickLinks→TheatersQuickLinks, CinemaDateSelector→TheaterDateSelector, AddCinemaModal→AddTheaterModal, EditCinemaModal→EditTheaterModal, DeleteCinemaDialog→DeleteTheaterDialog
- AdminPage tab ID:  → 
- All variables, tests, comments updated
- French user-facing text preserved

## Breaking Change
Permission names changed from  to  (aligned with database/server naming)

## Verification
- TypeScript: ✅ client + server
- Docker build: ✅
- Client tests: ✅ 43 files / 441 tests
- Server tests: ✅ 54 files / 808 tests
- Coverage: 97.28%

Closes #1050