### PR TITLE
⚡ Bolt: Optimize `getAllRoles` by eliminating N+1 query in `Promise.all`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -29,3 +29,7 @@
 ## 2024-05-24 - [Optimize groupShowtimesByCinema iteration]
 **Learning:** Destructuring with rest operator (`...`) is surprisingly slow compared to `Object.assign` combined with `delete` in V8 when cloning large arrays of objects, and using plain Objects instead of `Map` can be >2x faster in tight loops grouping thousands of objects.
 **Action:** In performance-critical loops processing arrays, prefer `Record<string, any>` maps, standard `for` loops, and `Object.assign` + `delete` over modern ES6 destructuring and `Map` collections.
+## 2026-06-02 - N+1 Query in `Promise.all` with Array.map
+
+**Learning:** When using `Promise.all` combined with an array `.map()` to fetch child records for each parent row, the database still experiences N+1 overhead because of network roundtrips, despite concurrent execution in Node.js.
+**Action:** Always replace concurrent DB map loops with a single batch query using Postgres arrays (e.g. `WHERE foreign_id = ANY($1::int[])`) and group the results manually in memory to reduce latency.

--- a/server/src/db/role-queries.test.ts
+++ b/server/src/db/role-queries.test.ts
@@ -34,21 +34,32 @@ describe('Role & Permission Queries', () => {
         { id: 1, name: 'admin', description: 'Administrateur', is_system: true, created_at: '2024-01-01T00:00:00Z' },
         { id: 2, name: 'operator', description: 'Opérateur', is_system: true, created_at: '2024-01-01T00:00:00Z' },
       ];
-      const mockPermissionsForAdmin: Permission[] = [];
-      const mockPermissionsForOperator: Permission[] = [
-        { id: 1, name: 'scraper:trigger', description: 'Lancer un scrape global', category: 'scraper', created_at: '2024-01-01T00:00:00Z' },
+      // The single batch query returns permissions mapped to their role IDs
+      const mockBatchedPermissions = [
+        {
+          id: 1,
+          name: 'scraper:trigger',
+          description: 'Lancer un scrape global',
+          category: 'scraper',
+          created_at: '2024-01-01T00:00:00Z',
+          role_id: 2 // Assign this permission to operator role
+        },
       ];
 
       vi.mocked(mockDb.query)
         .mockResolvedValueOnce({ rows: mockRoles, rowCount: 2 } as any)
-        .mockResolvedValueOnce({ rows: mockPermissionsForAdmin, rowCount: 0 } as any)
-        .mockResolvedValueOnce({ rows: mockPermissionsForOperator, rowCount: 1 } as any);
+        .mockResolvedValueOnce({ rows: mockBatchedPermissions, rowCount: 1 } as any);
 
       const result = await getAllRoles(mockDb);
 
       expect(result).toHaveLength(2);
       expect(result[0]).toMatchObject({ id: 1, name: 'admin', permissions: [] });
-      expect(result[1]).toMatchObject({ id: 2, name: 'operator', permissions: mockPermissionsForOperator });
+
+      // We expect the original permission format (without role_id)
+      const expectedOperatorPermission = { ...mockBatchedPermissions[0] };
+      delete (expectedOperatorPermission as any).role_id;
+
+      expect(result[1]).toMatchObject({ id: 2, name: 'operator', permissions: [expectedOperatorPermission] });
     });
 
     it('should return empty array when no roles exist', async () => {

--- a/server/src/db/role-queries.ts
+++ b/server/src/db/role-queries.ts
@@ -29,13 +29,45 @@ export async function getAllRoles(db: DB): Promise<RoleWithPermissions[]> {
     return [];
   }
 
-  // ⚡ PERFORMANCE: Run independent DB queries concurrently to prevent N+1 bottleneck
-  const rolesWithPermissions = await Promise.all(
-    rolesResult.rows.map(async (role) => {
-      const permissions = await fetchPermissionsForRole(db, role.id);
-      return { ...role, permissions };
-    })
+  // ⚡ PERFORMANCE: Use a single batch query for all roles instead of an N+1 concurrent loop
+  const roleIds = rolesResult.rows.map((r) => r.id);
+
+  // Need a custom type that includes role_id to map them back correctly
+  type PermissionWithRoleId = Permission & { role_id: number };
+
+  const permissionsResult = await db.query<PermissionWithRoleId>(
+    `SELECT p.id, p.name, p.description, p.category, p.created_at, rp.role_id
+     FROM permissions p
+     JOIN role_permissions rp ON rp.permission_id = p.id
+     WHERE rp.role_id = ANY($1::int[])
+     ORDER BY p.category, p.name`,
+    [roleIds]
   );
+
+  // Group permissions by role_id using a fast dictionary
+  const permissionsByRoleId: Record<number, Permission[]> = Object.create(null);
+
+  // Initialize empty arrays for all roles
+  for (let i = 0; i < roleIds.length; i++) {
+    permissionsByRoleId[roleIds[i]] = [];
+  }
+
+  // Populate permissions
+  for (let i = 0; i < permissionsResult.rows.length; i++) {
+    const row = permissionsResult.rows[i];
+    const { role_id, ...permission } = row;
+    permissionsByRoleId[role_id].push(permission as Permission);
+  }
+
+  // Map back to roles
+  const rolesWithPermissions: RoleWithPermissions[] = new Array(rolesResult.rows.length);
+  for (let i = 0; i < rolesResult.rows.length; i++) {
+    const role = rolesResult.rows[i];
+    rolesWithPermissions[i] = {
+      ...role,
+      permissions: permissionsByRoleId[role.id]
+    };
+  }
 
   return rolesWithPermissions;
 }


### PR DESCRIPTION
💡 **What:** Replaced an N+1 query pattern masked by `Promise.all` in `getAllRoles` (`server/src/db/role-queries.ts`) with a single batch query and in-memory grouping using `Object.create(null)`. Updated tests to match the batched return format.

🎯 **Why:** While `Promise.all` runs concurrently in Node.js, mapping over database records and calling `fetchPermissionsForRole` for each role still triggered an N+1 query anti-pattern due to the network/database roundtrip overhead for each individual row. 

📊 **Impact:** Reduces database queries for `getAllRoles` from O(N) to exactly 2 queries, regardless of how many roles exist in the database, directly improving response times and reducing database load.

🔬 **Measurement:** Running `npm run test:run -w server -- src/db/role-queries.test.ts` passes with correct logic validation. In production, the `/api/roles` endpoint will scale linearly rather than exponentially.

---
*PR created automatically by Jules for task [5545245250456321577](https://jules.google.com/task/5545245250456321577) started by @PhBassin*