### PR TITLE
⚡ Bolt: Fix N+1 query in getAllRoles via batch fetching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -29,3 +29,7 @@
 ## 2024-05-24 - [Optimize groupShowtimesByCinema iteration]
 **Learning:** Destructuring with rest operator (`...`) is surprisingly slow compared to `Object.assign` combined with `delete` in V8 when cloning large arrays of objects, and using plain Objects instead of `Map` can be >2x faster in tight loops grouping thousands of objects.
 **Action:** In performance-critical loops processing arrays, prefer `Record<string, any>` maps, standard `for` loops, and `Object.assign` + `delete` over modern ES6 destructuring and `Map` collections.
+
+## 2024-05-25 - [Optimize getAllRoles Batched Permission Query]
+**Learning:** Found that `getAllRoles` was executing an N+1 query problem by combining `Promise.all` with `.map` to fetch permissions for each role. While concurrent, this causes unnecessary database roundtrips and connection overhead.
+**Action:** When fetching child records for parent rows (like permissions for roles), always use a single batched query with a PostgreSQL array parameter (e.g., `WHERE foreign_id = ANY($1::int[])`), and then join the related results in memory using a simple grouping map.

--- a/server/src/db/role-queries.test.ts
+++ b/server/src/db/role-queries.test.ts
@@ -34,20 +34,20 @@ describe('Role & Permission Queries', () => {
         { id: 1, name: 'admin', description: 'Administrateur', is_system: true, created_at: '2024-01-01T00:00:00Z' },
         { id: 2, name: 'operator', description: 'Opérateur', is_system: true, created_at: '2024-01-01T00:00:00Z' },
       ];
-      const mockPermissionsForAdmin: Permission[] = [];
-      const mockPermissionsForOperator: Permission[] = [
-        { id: 1, name: 'scraper:trigger', description: 'Lancer un scrape global', category: 'scraper', created_at: '2024-01-01T00:00:00Z' },
+
+      const mockPermissionsResult = [
+        { role_id: 2, id: 1, name: 'scraper:trigger', description: 'Lancer un scrape global', category: 'scraper', created_at: '2024-01-01T00:00:00Z' },
       ];
 
       vi.mocked(mockDb.query)
         .mockResolvedValueOnce({ rows: mockRoles, rowCount: 2 } as any)
-        .mockResolvedValueOnce({ rows: mockPermissionsForAdmin, rowCount: 0 } as any)
-        .mockResolvedValueOnce({ rows: mockPermissionsForOperator, rowCount: 1 } as any);
+        .mockResolvedValueOnce({ rows: mockPermissionsResult, rowCount: 1 } as any);
 
       const result = await getAllRoles(mockDb);
 
       expect(result).toHaveLength(2);
       expect(result[0]).toMatchObject({ id: 1, name: 'admin', permissions: [] });
+      const mockPermissionsForOperator = [{ id: 1, name: 'scraper:trigger', description: 'Lancer un scrape global', category: 'scraper', created_at: '2024-01-01T00:00:00Z' }];
       expect(result[1]).toMatchObject({ id: 2, name: 'operator', permissions: mockPermissionsForOperator });
     });
 

--- a/server/src/db/role-queries.ts
+++ b/server/src/db/role-queries.ts
@@ -29,13 +29,31 @@ export async function getAllRoles(db: DB): Promise<RoleWithPermissions[]> {
     return [];
   }
 
-  // ⚡ PERFORMANCE: Run independent DB queries concurrently to prevent N+1 bottleneck
-  const rolesWithPermissions = await Promise.all(
-    rolesResult.rows.map(async (role) => {
-      const permissions = await fetchPermissionsForRole(db, role.id);
-      return { ...role, permissions };
-    })
+  const roleIds = rolesResult.rows.map(r => r.id);
+
+  // ⚡ PERFORMANCE: Batch fetch permissions to eliminate N+1 bottleneck and DB roundtrips
+  const permissionsResult = await db.query<Permission & { role_id: number }>(
+    `SELECT rp.role_id, p.id, p.name, p.description, p.category, p.created_at
+     FROM permissions p
+     JOIN role_permissions rp ON rp.permission_id = p.id
+     WHERE rp.role_id = ANY($1::int[])
+     ORDER BY rp.role_id, p.category, p.name`,
+    [roleIds]
   );
+
+  const permissionsByRoleId: Record<number, Permission[]> = Object.create(null);
+  for (const row of permissionsResult.rows) {
+    if (!permissionsByRoleId[row.role_id]) {
+      permissionsByRoleId[row.role_id] = [];
+    }
+    const { role_id, ...permission } = row;
+    permissionsByRoleId[role_id].push(permission);
+  }
+
+  const rolesWithPermissions = rolesResult.rows.map((role) => ({
+    ...role,
+    permissions: permissionsByRoleId[role.id] || [],
+  }));
 
   return rolesWithPermissions;
 }


### PR DESCRIPTION
💡 **What:** Refactored `getAllRoles` in `server/src/db/role-queries.ts` to use a single batched database query instead of executing N+1 independent queries to fetch permissions for each role.

🎯 **Why:** Previously, the `getAllRoles` function fetched all roles and then used `Promise.all` coupled with an array `.map` to fetch permissions per role using `fetchPermissionsForRole`. Even though the queries ran concurrently, this resulted in N database roundtrips for N roles, wasting connection pool resources and adding noticeable latency. 

📊 **Impact:** Reduces database queries from N+1 to exactly 2. By leveraging PostgreSQL array parameters (`ANY($1::int[])`), we eliminate N DB roundtrips and connection setup overhead, improving the endpoint throughput significantly.

🔬 **Measurement:** Server-side unit tests correctly pass (`npm test -w server -- --run`) and the type checker (`npm run build -w server`) verifies the new in-memory join correctly respects the TypeScript interfaces. A journal entry was also added to `.jules/bolt.md` documenting this optimization pattern.

---
*PR created automatically by Jules for task [4114017814566631394](https://jules.google.com/task/4114017814566631394) started by @PhBassin*