### PR TITLE
⚡ Bolt: Replace N+1 Promise.all query with batched ANY($1) in getAllRoles

### DIFF
--- a/server/src/db/role-queries.test.ts
+++ b/server/src/db/role-queries.test.ts
@@ -41,8 +41,13 @@ describe('Role & Permission Queries', () => {
 
       vi.mocked(mockDb.query)
         .mockResolvedValueOnce({ rows: mockRoles, rowCount: 2 } as any)
-        .mockResolvedValueOnce({ rows: mockPermissionsForAdmin, rowCount: 0 } as any)
-        .mockResolvedValueOnce({ rows: mockPermissionsForOperator, rowCount: 1 } as any);
+        .mockResolvedValueOnce({
+          rows: [
+            ...mockPermissionsForAdmin.map((p) => ({ role_id: 1, ...p })),
+            ...mockPermissionsForOperator.map((p) => ({ role_id: 2, ...p })),
+          ],
+          rowCount: mockPermissionsForAdmin.length + mockPermissionsForOperator.length,
+        } as any);
 
       const result = await getAllRoles(mockDb);
 

--- a/server/src/db/role-queries.ts
+++ b/server/src/db/role-queries.ts
@@ -29,13 +29,30 @@ export async function getAllRoles(db: DB): Promise<RoleWithPermissions[]> {
     return [];
   }
 
-  // ⚡ PERFORMANCE: Run independent DB queries concurrently to prevent N+1 bottleneck
-  const rolesWithPermissions = await Promise.all(
-    rolesResult.rows.map(async (role) => {
-      const permissions = await fetchPermissionsForRole(db, role.id);
-      return { ...role, permissions };
-    })
+  // ⚡ PERFORMANCE: Batch fetch all permissions for all roles to prevent N+1 query bottleneck
+  const roleIds = rolesResult.rows.map((role) => role.id);
+  const permissionsResult = await db.query<{ role_id: number } & Permission>(
+    `SELECT rp.role_id, p.id, p.name, p.description, p.category, p.created_at
+     FROM permissions p
+     JOIN role_permissions rp ON rp.permission_id = p.id
+     WHERE rp.role_id = ANY($1::int[])
+     ORDER BY p.category, p.name`,
+    [roleIds]
   );
+
+  const permissionsByRoleId: Record<number, Permission[]> = Object.create(null);
+  for (const row of permissionsResult.rows) {
+    if (!permissionsByRoleId[row.role_id]) {
+      permissionsByRoleId[row.role_id] = [];
+    }
+    const { role_id, ...permission } = row;
+    permissionsByRoleId[row.role_id].push(permission);
+  }
+
+  const rolesWithPermissions = rolesResult.rows.map((role) => ({
+    ...role,
+    permissions: permissionsByRoleId[role.id] || [],
+  }));
 
   return rolesWithPermissions;
 }


### PR DESCRIPTION
💡 **What:** Replaced the `Promise.all` + `.map()` approach in `getAllRoles` with a single batched database query using `ANY($1::int[])` to fetch permissions, and then grouped them in memory.
🎯 **Why:** The previous approach executed one initial query to fetch all roles, followed by N sequential queries (one for each role) to fetch permissions. This N+1 query pattern creates significant performance degradation and unnecessary database roundtrips as the number of roles increases.
📊 **Impact:** Reduces database queries from O(N) to exactly 2 queries regardless of how many roles exist, significantly reducing latency and database load.
🔬 **Measurement:** The unit tests have been updated and validated. Benchmarking would show O(1) database roundtrips instead of O(N) where N is the number of roles.

---
*PR created automatically by Jules for task [14156087861332932266](https://jules.google.com/task/14156087861332932266) started by @PhBassin*