### PR TITLE
fix(logging): use template literals so Winston JSON captures error messages

### DIFF
--- a/server/src/db/migrations.ts
+++ b/server/src/db/migrations.ts
@@ -144,12 +144,24 @@ export async function applyMigration(db: DB, filename: string): Promise<void> {
 
   // Special handling for admin seed migration
   if (filename === '007_seed_default_admin.sql') {
-    await handleAdminSeed(db);
+    try {
+      await handleAdminSeed(db);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      logger.error(`Admin seed handler failed (migration 007): ${msg}`);
+      throw error;
+    }
   }
 
   // Special handling for permission-based roles migration
   if (filename === '008_permission_based_roles.sql') {
-    await handleAdminRoleIdSeed(db);
+    try {
+      await handleAdminRoleIdSeed(db);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      logger.error(`Admin role seed handler failed (migration 008): ${msg}`);
+      throw error;
+    }
   }
 
   logger.info(`Migration ${filename} completed successfully`);

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -29,7 +29,7 @@ export async function initializeDatabase() {
     } catch (error) {
       // Log only the error message to prevent sensitive data exposure
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      logger.error('❌ Database migration failed:', errorMessage);
+        logger.error(`❌ Database migration failed: ${errorMessage}`);
       throw error;
     }
   } else {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -82,7 +82,7 @@ async function startServer() {
   } catch (error) {
     // Log only the error message to prevent sensitive data exposure
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    logger.error('❌ Failed to start server:', errorMessage);
+    logger.error(`❌ Failed to start server: ${errorMessage}`);
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary

Winston's `json()` format only captures the first argument to `logger.error()` in the `message` field. Extra arguments are silently dropped from JSON output, making migration crash details invisible in production logs.

## Changes

- **`server/src/db/schema.ts`**: Changed `logger.error('msg:', err)` to template literal
- **`server/src/index.ts`**: Same fix for server startup error log
- **`server/src/db/migrations.ts`**: Wrapped `handleAdminSeed` and `handleAdminRoleIdSeed` in try-catch with detailed error logging

## Before (invisible error)
```json
{"message":"❌ Database migration failed:","level":"error"}
```

## After (visible error)
```json
{"message":"❌ Database migration failed: Migration failed: films.source_url does not exist","level":"error"}
```

Closes #1131