### PR TITLE
⚡ Bolt: Fix N+1 query in getAllRoles using batched query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -29,3 +29,7 @@
 ## 2024-05-24 - [Optimize groupShowtimesByCinema iteration]
 **Learning:** Destructuring with rest operator (`...`) is surprisingly slow compared to `Object.assign` combined with `delete` in V8 when cloning large arrays of objects, and using plain Objects instead of `Map` can be >2x faster in tight loops grouping thousands of objects.
 **Action:** In performance-critical loops processing arrays, prefer `Record<string, any>` maps, standard `for` loops, and `Object.assign` + `delete` over modern ES6 destructuring and `Map` collections.
+
+## 2026-06-06 - [Batched Queries with ANY($1::int[]) to fix N+1 in Node/Postgres]
+**Learning:** Found a severe N+1 database bottleneck in `getAllRoles` (`server/src/db/role-queries.ts`). It used `Promise.all` with an array `.map()` to fetch permissions for each role sequentially. This caused an excessive number of roundtrips to the DB.
+**Action:** Replaced the mapped `Promise.all` queries with a single batched query using the Postgres array parameter syntax: `WHERE foreign_id = ANY($1::int[])`. This required modifying the returned fields to include the foreign key (`role_id`), then grouping the related permissions by role in memory using a fast plain object map (`Object.create(null)`). Also, corresponding unit tests must be updated to expect a single, combined result set when mocking the batched DB call instead of sequentially chained mock responses.

--- a/server/src/db/role-queries.test.ts
+++ b/server/src/db/role-queries.test.ts
@@ -34,21 +34,20 @@ describe('Role & Permission Queries', () => {
         { id: 1, name: 'admin', description: 'Administrateur', is_system: true, created_at: '2024-01-01T00:00:00Z' },
         { id: 2, name: 'operator', description: 'Opérateur', is_system: true, created_at: '2024-01-01T00:00:00Z' },
       ];
-      const mockPermissionsForAdmin: Permission[] = [];
-      const mockPermissionsForOperator: Permission[] = [
-        { id: 1, name: 'scraper:trigger', description: 'Lancer un scrape global', category: 'scraper', created_at: '2024-01-01T00:00:00Z' },
+      // Since it's batched now, we return all permissions in a single result that includes role_id
+      const mockBatchedPermissions = [
+        { id: 1, name: 'scraper:trigger', description: 'Lancer un scrape global', category: 'scraper', created_at: '2024-01-01T00:00:00Z', role_id: 2 },
       ];
 
       vi.mocked(mockDb.query)
         .mockResolvedValueOnce({ rows: mockRoles, rowCount: 2 } as any)
-        .mockResolvedValueOnce({ rows: mockPermissionsForAdmin, rowCount: 0 } as any)
-        .mockResolvedValueOnce({ rows: mockPermissionsForOperator, rowCount: 1 } as any);
+        .mockResolvedValueOnce({ rows: mockBatchedPermissions, rowCount: 1 } as any);
 
       const result = await getAllRoles(mockDb);
 
       expect(result).toHaveLength(2);
       expect(result[0]).toMatchObject({ id: 1, name: 'admin', permissions: [] });
-      expect(result[1]).toMatchObject({ id: 2, name: 'operator', permissions: mockPermissionsForOperator });
+      expect(result[1]).toMatchObject({ id: 2, name: 'operator', permissions: [{ id: 1, name: 'scraper:trigger', description: 'Lancer un scrape global', category: 'scraper', created_at: '2024-01-01T00:00:00Z' }] });
     });
 
     it('should return empty array when no roles exist', async () => {

--- a/server/src/db/role-queries.ts
+++ b/server/src/db/role-queries.ts
@@ -29,13 +29,38 @@ export async function getAllRoles(db: DB): Promise<RoleWithPermissions[]> {
     return [];
   }
 
-  // ⚡ PERFORMANCE: Run independent DB queries concurrently to prevent N+1 bottleneck
-  const rolesWithPermissions = await Promise.all(
-    rolesResult.rows.map(async (role) => {
-      const permissions = await fetchPermissionsForRole(db, role.id);
-      return { ...role, permissions };
-    })
+  const roleIds = rolesResult.rows.map(role => role.id);
+
+  // ⚡ PERFORMANCE: Use a single batched query with ANY to eliminate N+1 overhead
+  const permissionsResult = await db.query<Permission & { role_id: number }>(
+    `SELECT p.id, p.name, p.description, p.category, p.created_at, rp.role_id
+     FROM permissions p
+     JOIN role_permissions rp ON rp.permission_id = p.id
+     WHERE rp.role_id = ANY($1::int[])
+     ORDER BY p.category, p.name`,
+    [roleIds]
   );
+
+  // Group permissions by role efficiently
+  const permissionsByRole: Record<number, Permission[]> = Object.create(null);
+  for (let i = 0; i < roleIds.length; i++) {
+    permissionsByRole[roleIds[i]] = [];
+  }
+
+  for (let i = 0; i < permissionsResult.rows.length; i++) {
+    const row = permissionsResult.rows[i];
+    const { role_id, ...permission } = row;
+    permissionsByRole[role_id].push(permission as Permission);
+  }
+
+  const rolesWithPermissions: RoleWithPermissions[] = [];
+  for (let i = 0; i < rolesResult.rows.length; i++) {
+    const role = rolesResult.rows[i];
+    rolesWithPermissions.push({
+      ...role,
+      permissions: permissionsByRole[role.id],
+    });
+  }
 
   return rolesWithPermissions;
 }


### PR DESCRIPTION
💡 **What:**
Replaced the N+1 database queries in `getAllRoles` (`server/src/db/role-queries.ts`) with a single batched query using Postgres's `ANY($1::int[])`. Grouped the resulting permissions by role in memory using a fast `Object.create(null)` dictionary.

🎯 **Why:**
The previous implementation used `Promise.all` alongside `.map()` to iterate over each role and dispatch an independent query to fetch its permissions. This architectural pattern resulted in an N+1 query problem, increasing latency and tying up database connections significantly as the number of roles grows.

📊 **Impact:**
- Reduces database roundtrips for the `getAllRoles` operation from `O(N+1)` to `O(2)`.
- Replaces backend asynchronous execution overhead for hundreds of promises with highly optimized synchronous memory grouping.

🔬 **Measurement:**
Tested and verified via updated unit tests in `server/src/db/role-queries.test.ts`. Test pass execution confirms logic is preserved while mocking the new database sequence footprint.

---
*PR created automatically by Jules for task [3858532919589959903](https://jules.google.com/task/3858532919589959903) started by @PhBassin*