### PR TITLE
Remédiation fallow — CRAP 442 theater-service.ts + collecteur épic #1140

### DIFF
--- a/server/src/routes/theaters.ts
+++ b/server/src/routes/theaters.ts
@@ -45,6 +45,7 @@ router.post('/', protectedLimiter, requireAuth, requirePermission('theaters:crea
         };
         return res.status(201).json(response);
       } catch (error: any) {
+        if (error instanceof ValidationError) return next(error);
         return next(new ValidationError(error.message));
       }
     }
@@ -61,13 +62,8 @@ router.post('/', protectedLimiter, requireAuth, requirePermission('theaters:crea
       };
       return res.status(201).json(response);
     } catch (error: any) {
-      if (
-        error.message.includes('Invalid') || 
-        error.message.includes('too long') || 
-        error.message.includes('Missing') ||
-        error.message.includes('Name must be a string between') ||
-        error.message.includes('already exists')
-      ) {
+      if (error instanceof ValidationError) return next(error);
+      if (error.message.includes('already exists')) {
         return next(new ValidationError(error.message));
       }
       return next(error);
@@ -92,6 +88,7 @@ router.put('/:id', protectedLimiter, requireAuth, requirePermission('theaters:up
       };
       return res.json(response);
     } catch (error: any) {
+      if (error instanceof ValidationError) return next(error);
       if (error.message.includes('not found')) {
         return next(new NotFoundError(error.message));
       }

--- a/server/src/services/theater-service.ts
+++ b/server/src/services/theater-service.ts
@@ -1,9 +1,20 @@
 import { getShowtimesByTheaterAndWeek } from '../db/showtime-queries.js';
 import { createScrapeReport } from '../db/report-queries.js';
 import { getTheaters, addTheater, updateTheaterConfig, deleteTheater } from '../db/theater-queries.js';
-import { isValidAllocineUrl, extractTheaterIdFromUrl, cleanTheaterUrl } from '../utils/url.js';
+import { extractTheaterIdFromUrl, cleanTheaterUrl } from '../utils/url.js';
 import { getRedisClient } from './redis-client.js';
 import { logger } from '../utils/logger.js';
+import {
+  validateTheaterId,
+  validateTheaterName,
+  validateTheaterUrl,
+  validateOptionalUrl,
+  validateAddress,
+  validatePostalCode,
+  validateCity,
+  validateScreenCount,
+  validateAtLeastOneField,
+} from './theater-validator.js';
 import type { DB } from '../db/client.js';
 
 export class TheaterService {
@@ -18,13 +29,7 @@ export class TheaterService {
   }
 
   async addTheaterViaUrl(url: string) {
-    if (url.length > 2048) {
-      throw new Error('URL is too long (max 2048 characters)');
-    }
-
-    if (!isValidAllocineUrl(url)) {
-      throw new Error('Invalid Allocine URL. Must be https://www.allocine.fr/...');
-    }
+    validateTheaterUrl(url);
 
     const theaterId = extractTheaterIdFromUrl(url);
     if (!theaterId) {
@@ -45,25 +50,9 @@ export class TheaterService {
   }
 
   async addTheaterManual(id: string, name: string, url: string) {
-    if (typeof id !== 'string' || !/^[A-Za-z0-9]+$/.test(id)) {
-      throw new Error('Invalid ID format. Must be alphanumeric string.');
-    }
-
-    if (id.length > 20) {
-      throw new Error('ID is too long (max 20 characters)');
-    }
-
-    if (typeof name !== 'string' || name.length > 100) {
-      throw new Error('Name must be a string between 1 and 100 characters');
-    }
-
-    if (typeof url !== 'string' || url.length > 2048) {
-      throw new Error('URL is too long (max 2048 characters)');
-    }
-
-    if (!isValidAllocineUrl(url)) {
-      throw new Error('Invalid Allocine URL. Must be https://www.allocine.fr/...');
-    }
+    validateTheaterId(id);
+    validateTheaterName(name);
+    validateTheaterUrl(url);
 
     try {
       return await addTheater(this.db, { id, name, url });
@@ -81,50 +70,14 @@ export class TheaterService {
   ) {
     const { name, url, address, postal_code, city, screen_count } = data;
 
-    if (!name && !url && !address && postal_code === undefined && !city && screen_count === undefined) {
-      throw new Error('At least one field must be provided: name, url, address, postal_code, city, screen_count');
-    }
+    validateAtLeastOneField(data, ['name', 'url', 'address', 'postal_code', 'city', 'screen_count']);
 
-    if (name && (typeof name !== 'string' || name.length > 100)) {
-      throw new Error('Name must be a string between 1 and 100 characters');
-    }
-
-    if (url && (typeof url !== 'string' || url.length > 2048)) {
-      throw new Error('URL is too long (max 2048 characters)');
-    }
-
-    if (url && !isValidAllocineUrl(url)) {
-      throw new Error('Invalid Allocine URL. Must be https://www.allocine.fr/...');
-    }
-
-    if (address !== undefined && (typeof address !== 'string' || address.length > 200)) {
-      throw new Error('Address must be at most 200 characters');
-    }
-
-    if (postal_code !== undefined) {
-      if (typeof postal_code !== 'string' || postal_code.length > 10) {
-        throw new Error('Postal code must be at most 10 characters');
-      }
-      if (postal_code && !/^[a-zA-Z0-9]+$/.test(postal_code)) {
-        throw new Error('Postal code must be alphanumeric');
-      }
-    }
-
-    if (city !== undefined && (typeof city !== 'string' || city.length > 100)) {
-      throw new Error('City must be at most 100 characters');
-    }
-
-    if (screen_count !== undefined && screen_count !== null) {
-      if (typeof screen_count !== 'number') {
-        throw new Error('Screen count must be a number');
-      }
-      if (!Number.isInteger(screen_count)) {
-        throw new Error('Screen count must be an integer');
-      }
-      if (screen_count < 1 || screen_count > 50) {
-        throw new Error('Screen count must be between 1 and 50');
-      }
-    }
+    if (name) validateTheaterName(name);
+    validateOptionalUrl(url);
+    validateAddress(address);
+    validatePostalCode(postal_code);
+    validateCity(city);
+    validateScreenCount(screen_count);
 
     const updates: any = {};
     if (name) updates.name = name;

--- a/server/src/services/theater-validator.test.ts
+++ b/server/src/services/theater-validator.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  validateTheaterId,
+  validateTheaterName,
+  validateTheaterUrl,
+  validateOptionalUrl,
+  validateAddress,
+  validatePostalCode,
+  validateCity,
+  validateScreenCount,
+  validateAtLeastOneField,
+} from './theater-validator.js';
+import { isValidAllocineUrl } from '../utils/url.js';
+
+vi.mock('../utils/url.js', () => ({
+  isValidAllocineUrl: vi.fn(() => true),
+}));
+
+describe('theater-validator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isValidAllocineUrl).mockReturnValue(true);
+  });
+
+  describe('validateTheaterId', () => {
+    it('should accept valid alphanumeric ID', () => {
+      expect(() => validateTheaterId('C0013')).not.toThrow();
+      expect(() => validateTheaterId('W7517')).not.toThrow();
+    });
+
+    it('should reject special characters', () => {
+      expect(() => validateTheaterId('id!')).toThrow('Invalid ID format');
+      expect(() => validateTheaterId('id space')).toThrow('Invalid ID format');
+    });
+
+    it('should reject ID longer than 20 chars', () => {
+      expect(() => validateTheaterId('a'.repeat(21))).toThrow('too long');
+    });
+
+    it('should reject non-string', () => {
+      expect(() => validateTheaterId(42 as any)).toThrow('Invalid ID format');
+    });
+  });
+
+  describe('validateTheaterName', () => {
+    it('should accept valid name', () => {
+      expect(() => validateTheaterName('Grand Rex')).not.toThrow();
+    });
+
+    it('should reject empty string', () => {
+      expect(() => validateTheaterName('')).toThrow('between 1 and 100');
+    });
+
+    it('should reject name longer than 100 chars', () => {
+      expect(() => validateTheaterName('a'.repeat(101))).toThrow('between 1 and 100');
+    });
+
+    it('should reject non-string', () => {
+      expect(() => validateTheaterName(123 as any)).toThrow('between 1 and 100');
+    });
+  });
+
+  describe('validateTheaterUrl', () => {
+    it('should accept valid URL', () => {
+      expect(() => validateTheaterUrl('https://www.allocine.fr/test')).not.toThrow();
+    });
+
+    it('should reject URL longer than 2048 chars', () => {
+      expect(() => validateTheaterUrl('a'.repeat(2049))).toThrow('too long');
+    });
+
+    it('should reject invalid Allocine URL', () => {
+      vi.mocked(isValidAllocineUrl).mockReturnValue(false);
+      expect(() => validateTheaterUrl('https://bad.com')).toThrow('Invalid Allocine URL');
+    });
+
+    it('should reject non-string', () => {
+      expect(() => validateTheaterUrl(123 as any)).toThrow('too long');
+    });
+  });
+
+  describe('validateOptionalUrl', () => {
+    it('should accept undefined', () => {
+      expect(() => validateOptionalUrl(undefined)).not.toThrow();
+    });
+
+    it('should validate when provided', () => {
+      expect(() => validateOptionalUrl('https://www.allocine.fr/test')).not.toThrow();
+    });
+
+    it('should reject invalid when provided', () => {
+      vi.mocked(isValidAllocineUrl).mockReturnValue(false);
+      expect(() => validateOptionalUrl('https://bad.com')).toThrow('Invalid Allocine URL');
+    });
+  });
+
+  describe('validateAddress', () => {
+    it('should accept valid address', () => {
+      expect(() => validateAddress('1 rue de Paris')).not.toThrow();
+    });
+
+    it('should accept undefined', () => {
+      expect(() => validateAddress(undefined)).not.toThrow();
+    });
+
+    it('should reject address longer than 200 chars', () => {
+      expect(() => validateAddress('a'.repeat(201))).toThrow('at most 200');
+    });
+  });
+
+  describe('validatePostalCode', () => {
+    it('should accept valid postal code', () => {
+      expect(() => validatePostalCode('75001')).not.toThrow();
+      expect(() => validatePostalCode('SW1A1AA')).not.toThrow();
+    });
+
+    it('should accept undefined', () => {
+      expect(() => validatePostalCode(undefined)).not.toThrow();
+    });
+
+    it('should reject postal code longer than 10 chars', () => {
+      expect(() => validatePostalCode('a'.repeat(11))).toThrow('at most 10');
+    });
+
+    it('should reject postal code with special chars', () => {
+      expect(() => validatePostalCode('75001!')).toThrow('alphanumeric');
+    });
+
+    it('should accept empty string (reset)', () => {
+      expect(() => validatePostalCode('')).not.toThrow();
+    });
+  });
+
+  describe('validateCity', () => {
+    it('should accept valid city', () => {
+      expect(() => validateCity('Paris')).not.toThrow();
+    });
+
+    it('should accept undefined', () => {
+      expect(() => validateCity(undefined)).not.toThrow();
+    });
+
+    it('should reject city longer than 100 chars', () => {
+      expect(() => validateCity('a'.repeat(101))).toThrow('at most 100');
+    });
+  });
+
+  describe('validateScreenCount', () => {
+    it('should accept valid screen count', () => {
+      expect(() => validateScreenCount(5)).not.toThrow();
+      expect(() => validateScreenCount(1)).not.toThrow();
+      expect(() => validateScreenCount(50)).not.toThrow();
+    });
+
+    it('should accept undefined and null', () => {
+      expect(() => validateScreenCount(undefined)).not.toThrow();
+      expect(() => validateScreenCount(null)).not.toThrow();
+    });
+
+    it('should reject non-integer', () => {
+      expect(() => validateScreenCount(3.5)).toThrow('must be an integer');
+    });
+
+    it('should reject non-number', () => {
+      expect(() => validateScreenCount('5' as any)).toThrow('must be a number');
+    });
+
+    it('should reject out of range', () => {
+      expect(() => validateScreenCount(0)).toThrow('between 1 and 50');
+      expect(() => validateScreenCount(51)).toThrow('between 1 and 50');
+      expect(() => validateScreenCount(-1)).toThrow('between 1 and 50');
+    });
+  });
+
+  describe('validateAtLeastOneField', () => {
+    it('should pass when at least one field is present', () => {
+      expect(() =>
+        validateAtLeastOneField({ name: 'x' }, ['name', 'url', 'screen_count']),
+      ).not.toThrow();
+    });
+
+    it('should pass when a non-string field is zero', () => {
+      expect(() =>
+        validateAtLeastOneField({ screen_count: 0 }, ['name', 'url', 'screen_count']),
+      ).not.toThrow();
+    });
+
+    it('should reject when all fields are missing or empty', () => {
+      expect(() =>
+        validateAtLeastOneField({}, ['name', 'url', 'screen_count']),
+      ).toThrow('At least one field must be provided');
+      expect(() =>
+        validateAtLeastOneField({ name: '', url: undefined }, ['name', 'url']),
+      ).toThrow('At least one field must be provided');
+    });
+  });
+});

--- a/server/src/services/theater-validator.ts
+++ b/server/src/services/theater-validator.ts
@@ -1,0 +1,79 @@
+import { ValidationError } from '../utils/errors.js';
+import { isValidAllocineUrl } from '../utils/url.js';
+
+export function validateTheaterId(id: string): void {
+  if (typeof id !== 'string' || !/^[A-Za-z0-9]+$/.test(id)) {
+    throw new ValidationError('Invalid ID format. Must be alphanumeric string.');
+  }
+  if (id.length > 20) {
+    throw new ValidationError('ID is too long (max 20 characters)');
+  }
+}
+
+export function validateTheaterName(name: string): void {
+  if (typeof name !== 'string' || !name || name.length > 100) {
+    throw new ValidationError('Name must be a string between 1 and 100 characters');
+  }
+}
+
+export function validateTheaterUrl(url: string): void {
+  if (typeof url !== 'string' || url.length > 2048) {
+    throw new ValidationError('URL is too long (max 2048 characters)');
+  }
+  if (!isValidAllocineUrl(url)) {
+    throw new ValidationError('Invalid Allocine URL. Must be https://www.allocine.fr/...');
+  }
+}
+
+export function validateOptionalUrl(url: string | undefined): void {
+  if (url !== undefined) {
+    validateTheaterUrl(url);
+  }
+}
+
+export function validateAddress(address: string | undefined): void {
+  if (address !== undefined && (typeof address !== 'string' || address.length > 200)) {
+    throw new ValidationError('Address must be at most 200 characters');
+  }
+}
+
+export function validatePostalCode(postalCode: string | undefined): void {
+  if (postalCode !== undefined) {
+    if (typeof postalCode !== 'string' || postalCode.length > 10) {
+      throw new ValidationError('Postal code must be at most 10 characters');
+    }
+    if (postalCode && !/^[a-zA-Z0-9]+$/.test(postalCode)) {
+      throw new ValidationError('Postal code must be alphanumeric');
+    }
+  }
+}
+
+export function validateCity(city: string | undefined): void {
+  if (city !== undefined && (typeof city !== 'string' || city.length > 100)) {
+    throw new ValidationError('City must be at most 100 characters');
+  }
+}
+
+export function validateScreenCount(screenCount: number | undefined | null): void {
+  if (screenCount !== undefined && screenCount !== null) {
+    if (typeof screenCount !== 'number') {
+      throw new ValidationError('Screen count must be a number');
+    }
+    if (!Number.isInteger(screenCount)) {
+      throw new ValidationError('Screen count must be an integer');
+    }
+    if (screenCount < 1 || screenCount > 50) {
+      throw new ValidationError('Screen count must be between 1 and 50');
+    }
+  }
+}
+
+export function validateAtLeastOneField(
+  data: Record<string, unknown>,
+  fields: string[],
+): void {
+  const hasField = fields.some((f) => data[f] !== undefined && data[f] !== null && data[f] !== '');
+  if (!hasField) {
+    throw new ValidationError(`At least one field must be provided: ${fields.join(', ')}`);
+  }
+}


### PR DESCRIPTION
## Épic

Issue parente : **#1140 — Remédiation complète des alertes fallow (hors dead code)**

Objectif : faire passer le score de santé du projet de **68.3 (Grade C) à >80 (Grade B)**.

---

## Cette PR

Branche collectrice `refactor/1140-fallow-remediation` — elle agrège toutes les sous-issues de lépic.

### Déjà mergé : [#1] `theater-service.ts` — CRAP 442 → <50 (fix #1141)

| Métrique | Avant | Après |
|---|---|---|
| CRAP | 442 | <50 |
| Complexité cyclomatique | ~64 | ~20 |
| Lignes | 152 | 105 |

**Changements :**
- `server/src/services/theater-validator.ts` — 9 fonctions de validation pures (`validateTheaterId`, `validateTheaterName`, `validateTheaterUrl`, …), throw `ValidationError`
- `server/src/services/theater-validator.test.ts` — 34 tests unitaires
- `server/src/services/theater-service.ts` — validation déléguée au validateur (-31% lignes)
- `server/src/routes/theaters.ts` — évite le double-wrapping `ValidationError` (instanceof check)

### Reste à faire (après merge de cette PR)

- [ ] **[#2] SettingsPage.tsx** — CRAP 299 → #1142
- [ ] **[#3] api/client.ts** — CRAP 184, fan-in 27 → #1143
- [ ] **[#4] showtime-queries.ts** — duplication 4x → #1144
- [ ] **[#5] AllocineScraperStrategy.ts** — CRAP 172 → #1145
- [ ] **[#6] EditTheaterModal.tsx** — CRAP 172 → #1146
- [ ] **[#7] Tests dedup** — 16.3% duplication → #1147
- [ ] **[#8] Sécurité** — vérifier 26 candidats → #1148

---

## Vérification

```
Server:  55 test files, 844 tests — all pass
Scraper: 17 test files, 173 tests — all pass
tsc:     clean (0 errors)
Coverage: 98.87% stmts / 92.09% branches
```

Closes #1141