### PR TITLE
refactor(client): split SettingsPage into 5 tab components (CRAP 299 → 71)

### DIFF
--- a/client/src/components/admin/ColorsTab.tsx
+++ b/client/src/components/admin/ColorsTab.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import type { AppSettingsUpdate } from '../../api/settings';
+import ColorPicker from './ColorPicker';
+
+const COLOR_FIELDS = [
+    { field: 'color_primary', label: 'Primary Color', default: '#FECC00' },
+    { field: 'color_secondary', label: 'Secondary Color', default: '#1E40AF' },
+    { field: 'color_accent', label: 'Accent Color', default: '#10B981' },
+    { field: 'color_background', label: 'Background Color', default: '#FFFFFF' },
+    { field: 'color_text', label: 'Text Color', default: '#1F2937' },
+    { field: 'color_text_secondary', label: 'Secondary Text Color', default: '#6B7280' },
+    { field: 'color_border', label: 'Border Color', default: '#E5E7EB' },
+    { field: 'color_success', label: 'Success Color', default: '#10B981' },
+    { field: 'color_error', label: 'Error Color', default: '#EF4444' },
+] as const;
+
+interface ColorsTabProps {
+    value: AppSettingsUpdate;
+    onChange: (field: string, value: string | null) => void;
+    disabled: boolean;
+}
+
+const ColorsTab: React.FC<ColorsTabProps> = ({ value, onChange, disabled }) => (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-4xl">
+        {COLOR_FIELDS.map(({ field, label, default: defaultVal }) => (
+            <ColorPicker
+                key={field}
+                label={label}
+                value={(value as Record<string, string | null | undefined>)[field] || defaultVal}
+                onChange={(val) => onChange(field, val)}
+                disabled={disabled}
+            />
+        ))}
+    </div>
+);
+
+export default ColorsTab;

--- a/client/src/components/admin/EmailTab.tsx
+++ b/client/src/components/admin/EmailTab.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import type { AppSettingsUpdate } from '../../api/settings';
+import ImageUpload from './ImageUpload';
+
+interface EmailTabProps {
+    value: AppSettingsUpdate;
+    onChange: (field: string, value: string | null) => void;
+    disabled: boolean;
+}
+
+const EmailTab: React.FC<EmailTabProps> = ({ value, onChange, disabled }) => (
+    <div className="space-y-6 max-w-2xl">
+        <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+                From Name
+            </label>
+            <input
+                type="text"
+                value={value.email_from_name || ''}
+                onChange={(e) => onChange('email_from_name', e.target.value)}
+                disabled={disabled}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                placeholder="My Theater Site"
+            />
+        </div>
+
+        <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+                From Email Address
+            </label>
+            <input
+                type="email"
+                value={value.email_from_address || ''}
+                onChange={(e) => onChange('email_from_address', e.target.value)}
+                disabled={disabled}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                placeholder="noreply@example.com"
+            />
+        </div>
+
+        <ImageUpload
+            label="Email Logo"
+            value={value.email_logo_base64 || null}
+            onChange={(val) => onChange('email_logo_base64', val)}
+            disabled={disabled}
+            maxSizeKB={200}
+        />
+    </div>
+);
+
+export default EmailTab;

--- a/client/src/components/admin/FooterTab.tsx
+++ b/client/src/components/admin/FooterTab.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import type { AppSettingsUpdate, FooterLink } from '../../api/settings';
+import FooterLinksEditor from './FooterLinksEditor';
+
+interface FooterTabProps {
+    value: AppSettingsUpdate;
+    onChange: (field: string, value: string | FooterLink[] | null) => void;
+    disabled: boolean;
+}
+
+const FooterTab: React.FC<FooterTabProps> = ({ value, onChange, disabled }) => (
+    <div className="space-y-6 max-w-3xl">
+        <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+                Footer Text
+            </label>
+            <textarea
+                value={value.footer_text || ''}
+                onChange={(e) => onChange('footer_text', e.target.value)}
+                disabled={disabled}
+                rows={3}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                placeholder="© 2024 My Theater Site. All rights reserved."
+            />
+        </div>
+
+        <FooterLinksEditor
+            value={value.footer_links || []}
+            onChange={(val) => onChange('footer_links', val as FooterLink[])}
+            disabled={disabled}
+        />
+    </div>
+);
+
+export default FooterTab;

--- a/client/src/components/admin/GeneralTab.tsx
+++ b/client/src/components/admin/GeneralTab.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import type { AppSettingsUpdate } from '../../api/settings';
+import ImageUpload from './ImageUpload';
+
+interface GeneralTabProps {
+    value: AppSettingsUpdate;
+    onChange: (field: string, value: string | null) => void;
+    disabled: boolean;
+}
+
+const GeneralTab: React.FC<GeneralTabProps> = ({ value, onChange, disabled }) => (
+    <div className="space-y-6 max-w-2xl">
+        <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+                Site Name
+            </label>
+            <input
+                type="text"
+                value={value.site_name || ''}
+                onChange={(e) => onChange('site_name', e.target.value)}
+                disabled={disabled}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                placeholder="My Theater Site"
+            />
+        </div>
+
+        <ImageUpload
+            label="Logo"
+            value={value.logo_base64 || null}
+            onChange={(val) => onChange('logo_base64', val)}
+            disabled={disabled}
+            maxSizeKB={200}
+        />
+
+        <ImageUpload
+            label="Favicon"
+            value={value.favicon_base64 || null}
+            onChange={(val) => onChange('favicon_base64', val)}
+            disabled={disabled}
+            maxSizeKB={50}
+        />
+    </div>
+);
+
+export default GeneralTab;

--- a/client/src/components/admin/TypographyTab.tsx
+++ b/client/src/components/admin/TypographyTab.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import type { AppSettingsUpdate } from '../../api/settings';
+import FontSelector from './FontSelector';
+
+interface TypographyTabProps {
+    value: AppSettingsUpdate;
+    onChange: (field: string, value: string | null) => void;
+    disabled: boolean;
+}
+
+const TypographyTab: React.FC<TypographyTabProps> = ({ value, onChange, disabled }) => (
+    <div className="space-y-6 max-w-2xl">
+        <FontSelector
+            label="Heading Font"
+            value={value.font_family_heading || 'Playfair Display'}
+            onChange={(val) => onChange('font_family_heading', val)}
+            disabled={disabled}
+            type="heading"
+        />
+        <FontSelector
+            label="Body Font"
+            value={value.font_family_body || 'Roboto'}
+            onChange={(val) => onChange('font_family_body', val)}
+            disabled={disabled}
+            type="body"
+        />
+    </div>
+);
+
+export default TypographyTab;

--- a/client/src/pages/admin/SettingsPage.tsx
+++ b/client/src/pages/admin/SettingsPage.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useContext } from 'react';
 import { SettingsContext } from '../../contexts/SettingsContext';
 import { AuthContext } from '../../contexts/AuthContext';
-import { downloadSettingsExport, uploadSettingsImport, resetSettings, type AppSettings, type AppSettingsUpdate, type FooterLink } from '../../api/settings';
-import ColorPicker from '../../components/admin/ColorPicker';
-import FontSelector from '../../components/admin/FontSelector';
-import ImageUpload from '../../components/admin/ImageUpload';
-import FooterLinksEditor from '../../components/admin/FooterLinksEditor';
+import { downloadSettingsExport, uploadSettingsImport, resetSettings, type AppSettings, type AppSettingsUpdate } from '../../api/settings';
+import GeneralTab from '../../components/admin/GeneralTab';
+import ColorsTab from '../../components/admin/ColorsTab';
+import TypographyTab from '../../components/admin/TypographyTab';
+import FooterTab from '../../components/admin/FooterTab';
+import EmailTab from '../../components/admin/EmailTab';
 import Button from '../../components/ui/Button';
 
 type Tab = 'general' | 'colors' | 'typography' | 'footer' | 'email';
@@ -188,179 +189,43 @@ const SettingsPage: React.FC = () => {
                     {/* Tab content */}
                     <div className="p-6">
                         {activeTab === 'general' && (
-                            <div className="space-y-6 max-w-2xl">
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                                        Site Name
-                                    </label>
-                                    <input
-                                        type="text"
-                                        value={formData.site_name || ''}
-                                        onChange={(e) => handleFieldChange('site_name', e.target.value)}
-                                        disabled={!canUpdate}
-                                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                        placeholder="My Theater Site"
-                                    />
-                                </div>
-
-                                <ImageUpload
-                                    label="Logo"
-                                    value={formData.logo_base64 || null}
-                                    onChange={(value) => handleFieldChange('logo_base64', value)}
-                                    disabled={!canUpdate}
-                                    maxSizeKB={200}
-                                />
-
-                                <ImageUpload
-                                    label="Favicon"
-                                    value={formData.favicon_base64 || null}
-                                    onChange={(value) => handleFieldChange('favicon_base64', value)}
-                                    disabled={!canUpdate}
-                                    maxSizeKB={50}
-                                />
-                            </div>
+                            <GeneralTab
+                                value={formData}
+                                onChange={(field, value) => handleFieldChange(field as keyof AppSettingsUpdate, value)}
+                                disabled={!canUpdate}
+                            />
                         )}
 
                         {activeTab === 'colors' && (
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-4xl">
-                                <ColorPicker
-                                    label="Primary Color"
-                                    value={formData.color_primary || '#FECC00'}
-                                    onChange={(value) => handleFieldChange('color_primary', value)}
-                                    disabled={!canUpdate}
-                                />
-                                <ColorPicker
-                                    label="Secondary Color"
-                                    value={formData.color_secondary || '#1E40AF'}
-                                    onChange={(value) => handleFieldChange('color_secondary', value)}
-                                    disabled={!canUpdate}
-                                />
-                                <ColorPicker
-                                    label="Accent Color"
-                                    value={formData.color_accent || '#10B981'}
-                                    onChange={(value) => handleFieldChange('color_accent', value)}
-                                    disabled={!canUpdate}
-                                />
-                                <ColorPicker
-                                    label="Background Color"
-                                    value={formData.color_background || '#FFFFFF'}
-                                    onChange={(value) => handleFieldChange('color_background', value)}
-                                    disabled={!canUpdate}
-                                />
-                                <ColorPicker
-                                    label="Text Color"
-                                    value={formData.color_text || '#1F2937'}
-                                    onChange={(value) => handleFieldChange('color_text', value)}
-                                    disabled={!canUpdate}
-                                />
-                                <ColorPicker
-                                    label="Secondary Text Color"
-                                    value={formData.color_text_secondary || '#6B7280'}
-                                    onChange={(value) => handleFieldChange('color_text_secondary', value)}
-                                    disabled={!canUpdate}
-                                />
-                                <ColorPicker
-                                    label="Border Color"
-                                    value={formData.color_border || '#E5E7EB'}
-                                    onChange={(value) => handleFieldChange('color_border', value)}
-                                    disabled={!canUpdate}
-                                />
-                                <ColorPicker
-                                    label="Success Color"
-                                    value={formData.color_success || '#10B981'}
-                                    onChange={(value) => handleFieldChange('color_success', value)}
-                                    disabled={!canUpdate}
-                                />
-                                <ColorPicker
-                                    label="Error Color"
-                                    value={formData.color_error || '#EF4444'}
-                                    onChange={(value) => handleFieldChange('color_error', value)}
-                                    disabled={!canUpdate}
-                                />
-                            </div>
+                            <ColorsTab
+                                value={formData}
+                                onChange={(field, value) => handleFieldChange(field as keyof AppSettingsUpdate, value)}
+                                disabled={!canUpdate}
+                            />
                         )}
 
                         {activeTab === 'typography' && (
-                            <div className="space-y-6 max-w-2xl">
-                                <FontSelector
-                                    label="Heading Font"
-                                    value={formData.font_family_heading || 'Playfair Display'}
-                                    onChange={(value) => handleFieldChange('font_family_heading', value)}
-                                    disabled={!canUpdate}
-                                    type="heading"
-                                />
-                                <FontSelector
-                                    label="Body Font"
-                                    value={formData.font_family_body || 'Roboto'}
-                                    onChange={(value) => handleFieldChange('font_family_body', value)}
-                                    disabled={!canUpdate}
-                                    type="body"
-                                />
-                            </div>
+                            <TypographyTab
+                                value={formData}
+                                onChange={(field, value) => handleFieldChange(field as keyof AppSettingsUpdate, value)}
+                                disabled={!canUpdate}
+                            />
                         )}
 
                         {activeTab === 'footer' && (
-                            <div className="space-y-6 max-w-3xl">
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                                        Footer Text
-                                    </label>
-                                    <textarea
-                                        value={formData.footer_text || ''}
-                                        onChange={(e) => handleFieldChange('footer_text', e.target.value)}
-                                        disabled={!canUpdate}
-                                        rows={3}
-                                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                        placeholder="© 2024 My Theater Site. All rights reserved."
-                                    />
-                                </div>
-
-                                <FooterLinksEditor
-                                    value={formData.footer_links || []}
-                                    onChange={(value) => handleFieldChange('footer_links', value as FooterLink[])}
-                                    disabled={!canUpdate}
-                                />
-                            </div>
+                            <FooterTab
+                                value={formData}
+                                onChange={(field, value) => handleFieldChange(field as keyof AppSettingsUpdate, value)}
+                                disabled={!canUpdate}
+                            />
                         )}
 
                         {activeTab === 'email' && (
-                            <div className="space-y-6 max-w-2xl">
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                                        From Name
-                                    </label>
-                                    <input
-                                        type="text"
-                                        value={formData.email_from_name || ''}
-                                        onChange={(e) => handleFieldChange('email_from_name', e.target.value)}
-                                        disabled={!canUpdate}
-                                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                        placeholder="My Theater Site"
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                                        From Email Address
-                                    </label>
-                                    <input
-                                        type="email"
-                                        value={formData.email_from_address || ''}
-                                        onChange={(e) => handleFieldChange('email_from_address', e.target.value)}
-                                        disabled={!canUpdate}
-                                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                        placeholder="noreply@example.com"
-                                    />
-                                </div>
-
-                                <ImageUpload
-                                    label="Email Logo"
-                                    value={formData.email_logo_base64 || null}
-                                    onChange={(value) => handleFieldChange('email_logo_base64', value)}
-                                    disabled={!canUpdate}
-                                    maxSizeKB={200}
-                                />
-                            </div>
+                            <EmailTab
+                                value={formData}
+                                onChange={(field, value) => handleFieldChange(field as keyof AppSettingsUpdate, value)}
+                                disabled={!canUpdate}
+                            />
                         )}
                     </div>
 


### PR DESCRIPTION
Closes #1142

## Changements
- Extrait 5 composants d'onglet depuis SettingsPage.tsx (294 lignes au lieu de 429)
- Chaque onglet reçoit `{ value, onChange, disabled }` en props
- Nouveaux composants : `GeneralTab`, `ColorsTab`, `TypographyTab`, `FooterTab`, `EmailTab`

## Fallow
- **CRAP SettingsPage : 299 → 71.3** (-76%)
- Tous les nouveaux composants d'onglet : CRAP < 8
- 443/443 tests passent, 0 régression