### PR TITLE
⚡ Bolt: Batch insert rate limit audit logs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -29,3 +29,7 @@
 ## 2024-05-24 - [Optimize groupShowtimesByCinema iteration]
 **Learning:** Destructuring with rest operator (`...`) is surprisingly slow compared to `Object.assign` combined with `delete` in V8 when cloning large arrays of objects, and using plain Objects instead of `Map` can be >2x faster in tight loops grouping thousands of objects.
 **Action:** In performance-critical loops processing arrays, prefer `Record<string, any>` maps, standard `for` loops, and `Object.assign` + `delete` over modern ES6 destructuring and `Map` collections.
+
+## 2024-05-25 - [Batch Insertion for Audit Logs]
+**Learning:** Performing `INSERT` queries within a `for...of` loop creates an N+1 query bottleneck. Batching the `INSERT` operation significantly reduces the number of database roundtrips, which is crucial for reducing backend latency.
+**Action:** When inserting multiple rows into a database, construct a single batch `INSERT` query with multiple value sets instead of looping over individual queries.

--- a/server/src/db/rate-limit-queries.test.ts
+++ b/server/src/db/rate-limit-queries.test.ts
@@ -238,9 +238,18 @@ describe('rate-limit-queries', () => {
         'Test'
       );
 
-      // Should create 3 audit log entries
+      // Should create 1 batch audit log insert containing 3 entries
       const auditInserts = queries.filter((q: any) => q.sql.includes('rate_limit_audit_log'));
-      expect(auditInserts).toHaveLength(3);
+      expect(auditInserts).toHaveLength(1);
+
+      const insertQuery = auditInserts[0];
+      // Expect the query to have 3 value sets for batching: ($1...$8), ($9...$16), ($17...$24)
+      expect(insertQuery.sql).toContain('($17');
+      expect(insertQuery.params).toHaveLength(24);
+
+      expect(insertQuery.params).toContain('general_max');
+      expect(insertQuery.params).toContain('auth_max');
+      expect(insertQuery.params).toContain('scraper_max');
     });
   });
 

--- a/server/src/db/rate-limit-queries.ts
+++ b/server/src/db/rate-limit-queries.ts
@@ -171,13 +171,23 @@ export async function updateRateLimits(
     
     const updateResult = await db.query<RateLimitConfigRow>(updateQuery, values);
     
-    // Insert audit log entries
-    for (const entry of auditEntries) {
+    // Insert audit log entries (⚡ PERFORMANCE: Batch insert to prevent N+1 query bottleneck)
+    if (auditEntries.length > 0) {
+      const valueSets: string[] = [];
+      const flatValues: any[] = [];
+      let paramIndex = 1;
+
+      for (const entry of auditEntries) {
+        valueSets.push(`($${paramIndex}, $${paramIndex+1}, $${paramIndex+2}, $${paramIndex+3}, $${paramIndex+4}, $${paramIndex+5}, $${paramIndex+6}, $${paramIndex+7})`);
+        flatValues.push(userId, username, roleName, entry.field, entry.oldValue, entry.newValue, userIp, userAgent);
+        paramIndex += 8;
+      }
+
       await db.query(
         `INSERT INTO rate_limit_audit_log 
          (changed_by, changed_by_username, changed_by_role, field_name, old_value, new_value, user_ip, user_agent)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-        [userId, username, roleName, entry.field, entry.oldValue, entry.newValue, userIp, userAgent]
+         VALUES ${valueSets.join(', ')}`,
+        flatValues
       );
     }
     


### PR DESCRIPTION
### 💡 What
Replaced the `for...of` loop in `server/src/db/rate-limit-queries.ts` that performed multiple sequential `INSERT INTO rate_limit_audit_log` queries with a single batch `INSERT` query containing multiple parameterized value sets.

### 🎯 Why
When multiple rate limit fields are updated at once, the previous implementation created an N+1 database query bottleneck, executing individual inserts for each changed field. This increased database roundtrips and API latency unnecessarily. 

### 📊 Impact
Reduces database insertions from `N` to `1` (where N is the number of changed fields). Eliminates unnecessary database network roundtrips during rate limit updates. 

### 🔬 Measurement
Tests were updated to verify that `db.query` is only called once for inserting audit logs, even when multiple fields (e.g. `general_max`, `auth_max`, `scraper_max`) are changed simultaneously, validating the elimination of the N+1 issue.

---
*PR created automatically by Jules for task [7983115569914046443](https://jules.google.com/task/7983115569914046443) started by @PhBassin*