### PR TITLE
chore(deps): align package-lock with develop package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "allo-scrapper",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "allo-scrapper",
-      "version": "4.7.1",
+      "version": "4.7.2",
       "license": "MIT",
       "workspaces": [
         "client",
@@ -16,15 +16,11 @@
       "devDependencies": {
         "@playwright/test": "^1.60.0",
         "fallow": "^2.89.0",
-        "flatted": "^3.4.2",
         "husky": "^9.1.7"
       },
       "engines": {
         "node": ">=24.0.0 <25.0.0",
         "npm": ">=10.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.3"
       }
     },
     "client": {
@@ -5868,6 +5864,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
Regenerate `package-lock.json` to match `package.json` (commits `8ad446d` had dropped `flatted` and `fsevents` from root devDeps, but the lockfile was not regenerated).

- `flatted` remains in lockfile as transitive dep of `flat-cache` (fallow) and `@vitest/coverage-v8`
- `fsevents` no longer in `optionalDependencies`
- Lockfile version aligned to 4.7.2

Pre-push hook: tsc + 847 server tests + 173 scraper tests all green.