### PR TITLE
fix(fallow): quick wins — dead code, unused types, mocks orphelins

### DIFF
--- a/server/src/config/rate-limits.ts
+++ b/server/src/config/rate-limits.ts
@@ -1,5 +1,12 @@
 import type { DB } from '../db/client.js';
 
+// NOTE: This is the FLAT runtime config used by the limiter middleware.
+// It is structurally different from `db/rate-limit-queries.ts`'s `RateLimitConfig`
+// (which wraps the same fields under a `config` key plus DB metadata: `source`,
+// `updatedAt`, `updatedBy`, `environment`). The duplication is intentional:
+// this one is consumed by the rate-limit middleware as a flat shape, the
+// other is the DB-backed shape returned to admin routes. Keep both.
+// fallow-ignore-next-line duplicate-export
 export interface RateLimitConfig {
   windowMs: number;
   generalMax: number;

--- a/server/src/db/movie-queries.ts
+++ b/server/src/db/movie-queries.ts
@@ -5,7 +5,7 @@ import { parseJSONMemoized } from '../utils/json-parse-cache.js';
 
 // --- Database Row Interfaces ---
 
-export interface MovieRow {
+interface MovieRow {
   id: number;
   title: string;
   original_title: string | null;

--- a/server/src/db/rate-limit-queries.ts
+++ b/server/src/db/rate-limit-queries.ts
@@ -17,6 +17,14 @@ export interface RateLimitConfigRow {
   environment: string;
 }
 
+// NOTE: This is the DB-backed `RateLimitConfig` shape returned to admin
+// routes. It is structurally different from `config/rate-limits.ts`'s
+// `RateLimitConfig` (which is a flat shape used by the rate-limit
+// middleware). This one wraps the same fields under a `config` key and
+// adds DB metadata (`source`, `updatedAt`, `updatedBy`, `environment`).
+// The duplication is intentional — consumers explicitly import from one
+// module or the other. Keep both.
+// fallow-ignore-next-line duplicate-export
 export interface RateLimitConfig {
   config: {
     windowMs: number;

--- a/server/src/db/showtime-queries.ts
+++ b/server/src/db/showtime-queries.ts
@@ -5,7 +5,7 @@ import { parseJSONMemoized } from '../utils/json-parse-cache.js';
 
 // --- Database Row Interfaces ---
 
-export interface ShowtimeRow {
+interface ShowtimeRow {
   id: string;
   movie_id: number;
   theater_id: string;

--- a/server/src/routes/settings.test.ts
+++ b/server/src/routes/settings.test.ts
@@ -21,15 +21,6 @@ vi.mock('../middleware/auth.js', () => ({
 vi.mock('../middleware/permission.js', () => ({
   requirePermission: (..._perms: string[]) => (req: any, res: any, next: any) => next(),
 }));
-vi.mock('../middleware/admin.js', () => ({
-  requireAdmin: async (req: any, res: any, next: any) => {
-    if (req.user?.id === 1) {
-      next();
-    } else {
-      res.status(403).json({ success: false, error: 'Admin required' });
-    }
-  },
-}));
 
 import * as settingsQueries from '../db/settings-queries.js';
 import * as imageValidator from '../utils/image-validator.js';

--- a/server/src/routes/system.test.ts
+++ b/server/src/routes/system.test.ts
@@ -29,15 +29,6 @@ vi.mock('../middleware/rate-limit.js', () => ({
 vi.mock('../middleware/permission.js', () => ({
   requirePermission: (..._perms: string[]) => (req: any, res: any, next: any) => next(),
 }));
-vi.mock('../middleware/admin.js', () => ({
-  requireAdmin: async (req: any, res: any, next: any) => {
-    if (req.user?.id === 1) {
-      next();
-    } else {
-      res.status(403).json({ success: false, error: 'Admin required' });
-    }
-  },
-}));
 
 // Import mocked modules
 import * as systemQueries from '../db/system-queries.js';
@@ -128,17 +119,12 @@ describe('Routes - System', () => {
     });
 
     it('should return 403 for non-admin users', async () => {
-      vi.mock('../middleware/admin.js', () => ({
-        requireAdmin: async (req: any, res: any, next: any) => {
-          res.status(403).json({ success: false, error: 'Admin required' });
-        },
-      }));
-
       const response = await request(app)
         .get('/api/system/info')
         .set('Authorization', 'Bearer non-admin-token');
 
-      // Note: Since we mocked requireAdmin, this should fail at auth middleware
+      // Note: admin logic now lives in auth.ts::isAdminUser + permission bypass.
+      // Non-admin token must be rejected with 403.
       expect([401, 403]).toContain(response.status);
     });
 

--- a/server/src/routes/theaters.validation.test.ts
+++ b/server/src/routes/theaters.validation.test.ts
@@ -15,11 +15,7 @@ vi.mock('../db/theater-queries.js', () => ({
   deleteTheater: vi.fn(),
 }));
 
-vi.mock('../services/scraper/index.js', () => ({
-  addTheaterAndScrape: vi.fn(),
-}));
-
-vi.mock('../services/scraper/utils.js', () => ({
+vi.mock('../utils/url.js', () => ({
   isValidAllocineUrl: vi.fn().mockImplementation((url) => url.startsWith('https://www.allocine.fr/')),
 }));
 

--- a/server/src/routes/users.test.ts
+++ b/server/src/routes/users.test.ts
@@ -46,16 +46,6 @@ vi.mock('../middleware/permission.js', () => ({
     }
   },
 }));
-vi.mock('../middleware/admin.js', () => ({
-  requireAdmin: async (req: any, res: any, next: any) => {
-    // Admin check: only user with id=1 is admin
-    if (req.user?.id === 1) {
-      next();
-    } else {
-      res.status(403).json({ success: false, error: 'Admin required' });
-    }
-  },
-}));
 vi.mock('../middleware/rate-limit.js', () => ({
   protectedLimiter: (req: any, res: any, next: any) => next(),
 }));


### PR DESCRIPTION
Closes #1162

## Résumé

Quick wins FALLOW : suppression de dead code, déprivatisation de types, suppression de mocks orphelins pointant vers des modules supprimés.

## Commits atomiques

- 1089d90 refactor(server): privatize MovieRow type
- 6dfb3ee refactor(server): privatize ShowtimeRow type
- 2d493c5 chore(server): document RateLimitConfig as intentional duplicate
- b8e324b test(server): remove dead vi.mock for deleted admin middleware
- 46bee1e test(server): remove dead vi.mock for deleted scraper service + admin middleware

## Résultats FALLOW

Avant (issue #1162) : 9 findings
- 2 unused-types (MovieRow, ShowtimeRow)
- 6 unresolved-imports (mocks orphelins admin.js + services/scraper/*)
- 1 duplicate-export (RateLimitConfig)

Après : 1 finding restant
- duplicate-export RateLimitConfig — intentionnel, documenté dans 2d493c5 avec `fallow-ignore-next-line`. Les 2 shapes sont distincts (flat pour le middleware, nested pour les routes admin) et servent des consommateurs différents. À traiter dans un sprint dédié si on veut créer un `.fallowrc.json` global avec `ignoreExports`.

## Vérifications

- [x] `cd server && npx tsc -b` : propre
- [x] `cd server && npx vitest run src/routes/{settings,system,users,theaters.validation}.test.ts` : 104/104 verts
- [x] pre-push hook : tsc + test:run + test:coverage passent
- [x] `fallow analyze` server : 1 finding (RateLimitConfig documenté)

## Hors scope

- 1.1 (RedisProgressPublisher/RedisJobConsumer) : FALLOW signale ces exports comme unused, mais `scraper/tests/unit/redis-client.test.ts` les utilise. Faux positif. Pas touché.
- Scrap `runScraper` / refactors complexité : traités dans issues #1163 et #1164.

Refs: docs/refactoring-plan.md sections 2 et 3.