### PR TITLE
🛡️ Sentinel: [HIGH] Fix system role immutability bypass

### DIFF
--- a/server/src/routes/roles.test.ts
+++ b/server/src/routes/roles.test.ts
@@ -196,6 +196,26 @@ describe('Routes - Roles', () => {
 
       expect(next).toHaveBeenCalledWith(expect.any(ValidationError));
     });
+
+    it('should return 403 when trying to update permissions of a system role', async () => {
+      const { getRoleById } = await import('../db/role-queries.js');
+      (getRoleById as any).mockResolvedValue(mockAdminRole); // is_system: true
+
+      const { default: router } = await import('./roles.js');
+      const handler = getRouteHandler(router, 'put', '/:id/permissions');
+
+      const req = {
+        params: { id: '1' },
+        body: { permission_ids: [] },
+        app: buildMockApp(mockDb),
+      } as any;
+      const res = buildMockRes();
+      const next = vi.fn();
+
+      await handler(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(AuthError));
+    });
   });
 
   // PUT /api/roles/:id
@@ -224,8 +244,8 @@ describe('Routes - Roles', () => {
     });
 
     it('should return 404 when role does not exist', async () => {
-      const { updateRole } = await import('../db/role-queries.js');
-      (updateRole as any).mockResolvedValue(undefined);
+      const { getRoleById } = await import('../db/role-queries.js');
+      (getRoleById as any).mockResolvedValue(undefined);
 
       const { default: router } = await import('./roles.js');
       const handler = getRouteHandler(router, 'put', '/:id');
@@ -241,6 +261,26 @@ describe('Routes - Roles', () => {
       await handler(req, res, next);
 
       expect(next).toHaveBeenCalledWith(expect.any(NotFoundError));
+    });
+
+    it('should return 403 when trying to update a system role', async () => {
+      const { getRoleById } = await import('../db/role-queries.js');
+      (getRoleById as any).mockResolvedValue(mockAdminRole); // is_system: true
+
+      const { default: router } = await import('./roles.js');
+      const handler = getRouteHandler(router, 'put', '/:id');
+
+      const req = {
+        params: { id: '1' },
+        body: { description: 'Malicious update' },
+        app: buildMockApp(mockDb),
+      } as any;
+      const res = buildMockRes();
+      const next = vi.fn();
+
+      await handler(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(AuthError));
     });
   });
 

--- a/server/src/routes/roles.ts
+++ b/server/src/routes/roles.ts
@@ -168,15 +168,20 @@ router.put(
         return next(new ValidationError('Invalid role ID'));
       }
 
-      const { name, description } = req.body;
-      const updated = await updateRole(db, roleId, { name, description });
-
-      if (!updated) {
+      const role = await getRoleById(db, roleId);
+      if (!role) {
         return next(new NotFoundError('Role not found'));
       }
 
-      const role = await getRoleById(db, roleId);
-      const response: ApiResponse = { success: true, data: role };
+      if (role.is_system) {
+        return next(new AuthError('Cannot update a system role', 403));
+      }
+
+      const { name, description } = req.body;
+      await updateRole(db, roleId, { name, description });
+
+      const updatedRole = await getRoleById(db, roleId);
+      const response: ApiResponse = { success: true, data: updatedRole };
       res.json(response);
     } catch (error) {
       next(error);
@@ -258,6 +263,10 @@ router.put(
       const role = await getRoleById(db, roleId);
       if (!role) {
         return next(new NotFoundError('Role not found'));
+      }
+
+      if (role.is_system) {
+        return next(new AuthError('Cannot update permissions of a system role', 403));
       }
 
       await setRolePermissions(db, roleId, permission_ids);


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The API allowed the modification of core system roles (e.g., the 'admin' role) via `PUT /api/roles/:id` and `PUT /api/roles/:id/permissions`. The `is_system` flag was only being checked on deletion, leaving updates vulnerable.
🎯 **Impact:** An attacker with `roles:update` permissions could rename system roles, alter their descriptions, or, crucially, modify their assigned permissions, potentially leading to privilege escalation or denial of service by stripping admins of necessary rights.
🔧 **Fix:** Added checks in the `PUT /api/roles/:id` and `PUT /api/roles/:id/permissions` route handlers in `server/src/routes/roles.ts` to throw a 403 `AuthError` if the target role has `is_system` set to `true`.
✅ **Verification:** Added dedicated unit tests in `server/src/routes/roles.test.ts` to verify that attempts to update system role properties or permissions correctly result in a 403 `AuthError`. Evaluated and passed by `npm run test:run -w server`.

---
*PR created automatically by Jules for task [5526760787351845684](https://jules.google.com/task/5526760787351845684) started by @PhBassin*