### PR TITLE
chore(fallow): dead code cleanup — unused re-exports, broken import, false-positive suppressions (#1186)

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -10,14 +10,9 @@ export {
 
 export {
   getTheaters,
-  createTheater,
-  updateTheater,
-  deleteTheater,
   getTheaterSchedule,
   addTheater,
 } from './theaters';
-
-export type { TheaterCreate, TheaterUpdate } from './theaters';
 
 export {
   triggerScrape,
@@ -41,5 +36,3 @@ export {
   getReportDetails,
   resumeScrape,
 } from './reports';
-
-export type { ScrapeAttempt, ReportDetails } from './reports';

--- a/client/src/api/settings.ts
+++ b/client/src/api/settings.ts
@@ -60,6 +60,7 @@ export interface AppSettingsUpdate {
   email_logo_base64?: string | null;
 }
 
+// fallow-ignore-next-line unused-type
 export interface AppSettingsExport {
   version: string;
   exported_at: string;

--- a/scraper/src/scraper/strategies/AllocineScraperStrategy.ts
+++ b/scraper/src/scraper/strategies/AllocineScraperStrategy.ts
@@ -130,18 +130,22 @@ async function processMovieShowtimes(
 export class AllocineScraperStrategy implements IScraperStrategy {
   readonly sourceName = 'allocine';
 
+  // fallow-ignore-next-line unused-class-member
   canHandleUrl(url: string): boolean {
     return isValidAllocineUrl(url);
   }
 
+  // fallow-ignore-next-line unused-class-member
   extractTheaterId(url: string): string | null {
     return extractTheaterIdFromUrl(url);
   }
 
+  // fallow-ignore-next-line unused-class-member
   cleanTheaterUrl(url: string): string {
     return cleanTheaterUrl(url);
   }
 
+  // fallow-ignore-next-line unused-class-member
   async loadTheaterMetadata(
     db: DB,
     theater: TheaterConfig

--- a/scraper/tests/unit/redis-client.test.ts
+++ b/scraper/tests/unit/redis-client.test.ts
@@ -26,7 +26,7 @@ vi.mock('ioredis', () => ({
   default: MockRedis,
 }));
 
-import { RedisProgressPublisher, RedisJobConsumer } from '../../../src/redis/client.js';
+import { RedisProgressPublisher, RedisJobConsumer } from '../../src/redis/client.js';
 
 describe('RedisProgressPublisher', () => {
   let publisher: RedisProgressPublisher;

--- a/server/src/services/redis-client.ts
+++ b/server/src/services/redis-client.ts
@@ -111,6 +111,7 @@ export class RedisClient {
   // --------------------------------------------------------------------------
 
   /** Publish a schedule change event to notify the scraper of CRUD operations. */
+  // fallow-ignore-next-line unused-class-member
   async publishScheduleChange(event: ScheduleChangeEvent): Promise<void> {
     await this.publisher.publish('scraper:schedule:changed', JSON.stringify(event));
   }


### PR DESCRIPTION
## Summary

Resolves #1186

Closes the 17 dead-code findings reported by `fallow analyze`, including 1 real bug (silently broken test) and 6 false-positive suppressions.

`fallow analyze` goes from **17 issues → 0 issues**.

## Changes (3 atomic commits)

### 1. `fix(scraper)` — broken import path (real bug)
**File:** `scraper/tests/unit/redis-client.test.ts:29`

The import specifier `../../../src/redis/client.js` has one `../` too many. The test was silently failing to resolve the module, so the 5 tests in `tests/unit/redis-client.test.ts` were not actually exercising `RedisProgressPublisher` and `RedisJobConsumer`. Fixing the path (→ `../../src/redis/client.js`) makes them run for real (5/5 pass).

This bug also caused fallow to falsely flag both classes as unused exports in `scraper/src/redis/client.ts`.

### 2. `chore(client)` — remove 7 unused re-exports
**File:** `client/src/api/client.ts`

The barrel re-exported 7 names that no consumer ever imports through it. Verified by grep: every consumer of `createTheater`/`updateTheater`/`deleteTheater`/`TheaterCreate`/`TheaterUpdate`/`ScrapeAttempt`/`ReportDetails` imports directly from the source module (`api/theaters` or `api/reports`).

The underlying functions and types remain exported from their source modules — this is purely a barrel surface reduction.

### 3. `chore(fallow)` — suppress 6 false positives
Added targeted `// fallow-ignore-next-line` comments:

| File | Line | Member | Why it's a false positive |
|---|---|---|---|
| `scraper/src/scraper/strategies/AllocineScraperStrategy.ts` | 133 | `canHandleUrl` | Implements `IScraperStrategy` interface |
| `scraper/src/scraper/strategies/AllocineScraperStrategy.ts` | 137 | `extractTheaterId` | Implements `IScraperStrategy` interface |
| `scraper/src/scraper/strategies/AllocineScraperStrategy.ts` | 141 | `cleanTheaterUrl` | Implements `IScraperStrategy` interface |
| `scraper/src/scraper/strategies/AllocineScraperStrategy.ts` | 145 | `loadTheaterMetadata` | Implements `IScraperStrategy` interface |
| `server/src/services/redis-client.ts` | 114 | `publishScheduleChange` | Called via `getRedisClient().publishScheduleChange(...)` in `routes/scraper.ts:238,290,329`; tested in `routes/scraper.test.ts:58` |
| `client/src/api/settings.ts` | 63 | `AppSettingsExport` | Used locally by `exportSettings`/`importSettings` in the same file (lines 121, 122, 132, 170) |

## Verification

| Check | Result |
|---|---|
| `fallow analyze` (group_by: directory) | **0 issues** (was 17) |
| `tsc --noEmit` (server) | ✓ |
| `tsc --noEmit` (scraper) | ✓ |
| `tsc -b` (client) | ✓ |
| Server tests (vitest) | **832/832 ✓** |
| Scraper tests (vitest) | **200/200 ✓** |
| → `tests/unit/redis-client.test.ts` | **5/5 ✓** (previously silently broken) |

## Files changed

```
 client/src/api/client.ts                                  | 7 -------
 client/src/api/settings.ts                                | 1 +
 scraper/src/scraper/strategies/AllocineScraperStrategy.ts | 4 ++++
 scraper/tests/unit/redis-client.test.ts                   | 2 +-
 server/src/services/redis-client.ts                       | 1 +
 5 files changed, 7 insertions(+), 8 deletions(-)
```

## Out of scope (future work)

The `fallow check_health` report identified ~40 functions with cyclomatic complexity > 10, concentrated in `client/src/pages/**` and `client/src/components/admin/**` (e.g. `MoviePage` CC=29, `ReportsPage` CC=27, `ScrapeProgress` CC=26). These require structural refactors and are tracked separately in #1181 and #1182. The current PR is intentionally limited to dead-code elimination.

## Pre-push checklist (per AGENTS.md)

- [x] `tsc --noEmit` server + scraper, `tsc -b` client
- [x] Server `test:run` + `test:coverage`
- [x] Scraper `test:run`
- [x] Branched from `develop`
- [x] Conventional Commits
- [x] Atomic commits (one logical change per commit)