### PR TITLE
feat(server): refresh route uses getUserWithRoleById (#1195)

### DIFF
--- a/server/src/db/user-queries.test.ts
+++ b/server/src/db/user-queries.test.ts
@@ -4,6 +4,7 @@ import type { UserPublic } from '../types/user.js';
 import {
   getAllUsers,
   getUserById,
+  getUserWithRoleById,
   updateUserRole,
   deleteUser,
   getAdminCount,
@@ -161,6 +162,78 @@ describe('User Management Queries', () => {
 
       expect(result?.id).toBe(42);
       expect(mockDb.query).toHaveBeenCalledWith(expect.any(String), [42]);
+    });
+  });
+
+  describe('getUserWithRoleById', () => {
+    it('should return user joined with role including is_system_role for a system admin', async () => {
+      vi.mocked(mockDb.query).mockResolvedValue({
+        rows: [{
+          id: 1,
+          username: 'admin',
+          role_id: 1,
+          role_name: 'admin',
+          is_system_role: true,
+        }],
+        rowCount: 1,
+      } as any);
+
+      const result = await getUserWithRoleById(mockDb, 1);
+
+      expect(result).toEqual({
+        id: 1,
+        username: 'admin',
+        role_id: 1,
+        role_name: 'admin',
+        is_system_role: true,
+      });
+    });
+
+    it('should return is_system_role=false for a non-system role', async () => {
+      vi.mocked(mockDb.query).mockResolvedValue({
+        rows: [{
+          id: 7,
+          username: 'operator',
+          role_id: 2,
+          role_name: 'operator',
+          is_system_role: false,
+        }],
+        rowCount: 1,
+      } as any);
+
+      const result = await getUserWithRoleById(mockDb, 7);
+
+      expect(result?.is_system_role).toBe(false);
+    });
+
+    it('should issue a single JOIN query parameterized on user id', async () => {
+      vi.mocked(mockDb.query).mockResolvedValue({ rows: [], rowCount: 0 } as any);
+
+      await getUserWithRoleById(mockDb, 42);
+
+      const [sql, params] = vi.mocked(mockDb.query).mock.calls[0];
+      expect(sql).toContain('JOIN roles');
+      expect(sql).toContain('is_system AS is_system_role');
+      expect(sql).toContain('WHERE u.id = $1');
+      expect(params).toEqual([42]);
+    });
+
+    it('should not select password_hash or created_at', async () => {
+      vi.mocked(mockDb.query).mockResolvedValue({ rows: [], rowCount: 0 } as any);
+
+      await getUserWithRoleById(mockDb, 1);
+
+      const [sql] = vi.mocked(mockDb.query).mock.calls[0];
+      expect(sql).not.toContain('password_hash');
+      expect(sql).not.toContain('created_at');
+    });
+
+    it('should return undefined when no user matches the id', async () => {
+      vi.mocked(mockDb.query).mockResolvedValue({ rows: [], rowCount: 0 } as any);
+
+      const result = await getUserWithRoleById(mockDb, 999);
+
+      expect(result).toBeUndefined();
     });
   });
 

--- a/server/src/db/user-queries.ts
+++ b/server/src/db/user-queries.ts
@@ -15,6 +15,19 @@ export interface UserRow {
 }
 
 /**
+ * User joined with its role — used by the refresh-token route and any other
+ * caller that needs to mint a JWT or otherwise inspect the user's role
+ * without exposing the password hash.
+ */
+export interface UserWithRoleRow {
+  id: number;
+  username: string;
+  role_id: number;
+  role_name: string;
+  is_system_role: boolean;
+}
+
+/**
  * Get all users without passwords (for admin panel)
  * Uses JOIN on roles table to get role_name
  * @param db - Database client
@@ -52,6 +65,36 @@ export async function getUserById(
 ): Promise<UserPublic | undefined> {
   const result = await db.query<UserPublic>(
     `SELECT u.id, u.username, u.role_id, r.name as role_name, u.created_at
+     FROM users u
+     JOIN roles r ON r.id = u.role_id
+     WHERE u.id = $1`,
+    [userId]
+  );
+
+  return result.rows[0];
+}
+
+/**
+ * Get user by ID joined with their role, including the role's
+ * `is_system` flag aliased as `is_system_role`. Intended for the refresh
+ * route and any other caller that needs to mint a JWT without re-deriving
+ * the role's system-status from a separate lookup.
+ *
+ * Does NOT return `created_at` — callers that need the public profile shape
+ * (id, username, role_id, role_name, created_at) should use {@link getUserById}
+ * instead.
+ *
+ * @param db - Database client
+ * @param userId - User ID
+ * @returns User + role row, or undefined if no user with that id exists
+ */
+export async function getUserWithRoleById(
+  db: DB,
+  userId: number
+): Promise<UserWithRoleRow | undefined> {
+  const result = await db.query<UserWithRoleRow>(
+    `SELECT u.id, u.username, r.id AS role_id, r.name AS role_name,
+            r.is_system AS is_system_role
      FROM users u
      JOIN roles r ON r.id = u.role_id
      WHERE u.id = $1`,

--- a/server/src/routes/auth.test.ts
+++ b/server/src/routes/auth.test.ts
@@ -388,14 +388,12 @@ describe('Auth Routes', () => {
             mockValidate.mockResolvedValue(1);
             mockRotate.mockResolvedValue('new-refresh-token-raw');
 
-            vi.mocked(db.query).mockResolvedValue({
-                rows: [{
-                    id: 1,
-                    username: 'testuser',
-                    role_id: 2,
-                    role_name: 'user',
-                    is_system_role: false,
-                }],
+            vi.mocked(queries.getUserWithRoleById).mockResolvedValue({
+                id: 1,
+                username: 'testuser',
+                role_id: 2,
+                role_name: 'user',
+                is_system_role: false,
             });
 
             const response = await request(app)
@@ -406,6 +404,7 @@ describe('Auth Routes', () => {
             expect(response.body.success).toBe(true);
             expect(response.body.data.token).toBeDefined();
             expect(response.body.data.user.username).toBe('testuser');
+            expect(response.body.data.user.is_system_role).toBe(false);
             // Should set access_token cookie as httpOnly
             const setCookieHeaders = response.headers['set-cookie'];
             const cookies = Array.isArray(setCookieHeaders) ? setCookieHeaders : [setCookieHeaders];
@@ -413,9 +412,54 @@ describe('Auth Routes', () => {
             expect(accessTokenCookie).toBeDefined();
             expect(accessTokenCookie).toContain('HttpOnly');
             expect(accessTokenCookie).toContain('SameSite=Lax');
+            expect(queries.getUserWithRoleById).toHaveBeenCalledWith(db, 1);
             expect(mockRotate).toHaveBeenCalledWith(1, 'valid-old-token');
             expect(mockGenerate).not.toHaveBeenCalled();
             expect(mockRevoke).not.toHaveBeenCalled();
+        });
+
+        it('should propagate is_system_role=true for a system-admin refresh', async () => {
+            const refreshTokenMocks = await import('../services/refresh-token-service.js');
+            const mockValidate = (refreshTokenMocks as any).__mockValidate;
+            const mockRotate = (refreshTokenMocks as any).__mockRotate;
+
+            mockValidate.mockResolvedValue(1);
+            mockRotate.mockResolvedValue('new-refresh-token-raw');
+            vi.mocked(queries.getUserWithRoleById).mockResolvedValue({
+                id: 1,
+                username: 'admin',
+                role_id: 1,
+                role_name: 'admin',
+                is_system_role: true,
+            });
+
+            const response = await request(app)
+                .post('/api/auth/refresh')
+                .set('Cookie', 'refresh_token=valid-old-token');
+
+            expect(response.status).toBe(200);
+            expect(response.body.data.user.is_system_role).toBe(true);
+            expect(response.body.data.user.role_name).toBe('admin');
+        });
+
+        it('should return 401 when getUserWithRoleById yields no user', async () => {
+            const refreshTokenMocks = await import('../services/refresh-token-service.js');
+            const mockValidate = (refreshTokenMocks as any).__mockValidate;
+            const mockRotate = (refreshTokenMocks as any).__mockRotate;
+
+            mockValidate.mockResolvedValue(1);
+            mockRotate.mockResolvedValue('new-refresh-token-raw');
+            vi.mocked(queries.getUserWithRoleById).mockResolvedValue(undefined);
+
+            const response = await request(app)
+                .post('/api/auth/refresh')
+                .set('Cookie', 'refresh_token=valid-old-token');
+
+            expect(response.status).toBe(401);
+            expect(response.body.success).toBe(false);
+            expect(response.body.error).toBe('User not found.');
+            // No new refresh/access tokens should be issued and the old refresh token should NOT be rotated
+            expect(mockRotate).not.toHaveBeenCalled();
         });
 
         it('should return 401 if no refresh token cookie', async () => {

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -9,6 +9,7 @@ import { RefreshTokenService } from '../services/refresh-token-service.js';
 import type { PermissionName } from '../types/role.js';
 import { ValidationError, AuthError, NotFoundError } from '../utils/errors.js';
 import { logger } from '../utils/logger.js';
+import { getUserWithRoleById } from '../db/user-queries.js';
 import crypto from 'crypto';
 
 const router = express.Router();
@@ -241,17 +242,9 @@ router.post('/refresh', authLimiter, async (req: Request, res: Response, next: N
         }
 
         // Get user info for new access token
-        const userResult = await db.query<{
-            id: number; username: string; role_id: number; role_name: string; is_system_role: boolean;
-        }>(
-            `SELECT u.id, u.username, r.id as role_id, r.name as role_name, r.is_system_role
-             FROM users u
-             JOIN roles r ON u.role_id = r.id
-             WHERE u.id = $1`,
-            [userId]
-        );
+        const user = await getUserWithRoleById(db, userId);
 
-        if (userResult.rows.length === 0) {
+        if (!user) {
             clearRefreshTokenCookie(res);
             clearAccessTokenCookie(res);
             res.status(401).json({
@@ -260,8 +253,6 @@ router.post('/refresh', authLimiter, async (req: Request, res: Response, next: N
             });
             return;
         }
-
-        const user = userResult.rows[0];
 
         // Atomically rotate: generate new token AND revoke old one in one transaction
         const newRefreshToken = await refreshTokenService.rotate(userId, refreshToken);


### PR DESCRIPTION
Closes #1195, closes #1194

## What

Replaces the raw SQL JOIN in the token-refresh handler with the new `getUserWithRoleById` query from `db/user-queries.ts`.

## Changes

- Added `getUserWithRoleById(db, userId)` to `db/user-queries.ts` returning `{ id, username, role_id, role_name, is_system_role }`
- `routes/auth.ts` refresh handler uses `getUserWithRoleById` instead of raw JOIN
- Added test coverage in `db/user-queries.test.ts` and `routes/auth.test.ts`

## Acceptance criteria

- [x] `db/user-queries.ts` exports `getUserWithRoleById(db, userId)` returning the required row shape
- [x] `routes/auth.ts` uses `getUserWithRoleById` instead of the raw JOIN
- [x] `db/user-queries.test.ts` covers `getUserWithRoleById`
- [x] `routes/auth.test.ts` mocks it; behavior assertions survive
- [x] `cd server && npx tsc --noEmit` clean
- [x] `npm run test:run --workspace=allo-scrapper-server` passes
- [x] `cd server && npm run test:coverage` passes the coverage gate