### PR TITLE
feat(1198): [PRD #1192 / 6] AppError + error middleware + routes-throw cleanup

### DIFF
--- a/server/src/middleware/error-handler.test.ts
+++ b/server/src/middleware/error-handler.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 import { errorHandler } from './error-handler.js';
-import { AppError, ValidationError } from '../utils/errors.js';
+import { AppError, ValidationError, TheaterNotFoundError } from '../utils/errors.js';
 
 describe('Error Handler Middleware', () => {
   let app: express.Application;
@@ -83,6 +83,20 @@ describe('Error Handler Middleware', () => {
       expect(response.body).toEqual({
         success: false,
         error: 'Internal server error',
+      });
+    });
+
+    it('should return 404 and preserve message for TheaterNotFoundError', async () => {
+      app.get('/error-theater', (_req, _res, next) => {
+        next(new TheaterNotFoundError('C0153'));
+      });
+      app.use(errorHandler);
+
+      const response = await request(app).get('/error-theater');
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual({
+        success: false,
+        error: 'Theater not found: C0153',
       });
     });
 

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -7,7 +7,6 @@ import { requirePermission } from '../middleware/permission.js';
 import { AuthService } from '../services/auth-service.js';
 import { RefreshTokenService } from '../services/refresh-token-service.js';
 import type { PermissionName } from '../types/role.js';
-import { ValidationError, AuthError, NotFoundError } from '../utils/errors.js';
 import { logger } from '../utils/logger.js';
 import crypto from 'crypto';
 
@@ -131,13 +130,7 @@ router.post('/login', authLimiter, async (req: Request, res: Response, next: Nex
         };
 
         res.json(response);
-    } catch (error: any) {
-        if (error.message === 'Username and password are required') {
-            return next(new ValidationError(error.message));
-        }
-        if (error.message === 'Invalid credentials') {
-            return next(new AuthError(error.message));
-        }
+    } catch (error) {
         next(error);
     }
 });
@@ -160,13 +153,7 @@ router.post('/register', registerLimiter, requireAuth, requirePermission('users:
         };
 
         res.status(201).json(response);
-    } catch (error: any) {
-        if (error.message === 'Username and password are required' || error.message.includes('Password must')) {
-            return next(new ValidationError(error.message));
-        }
-        if (error.message === 'Username already exists') {
-            return next(new ValidationError(error.message)); // Conflict mapped to validation for now
-        }
+    } catch (error) {
         next(error);
     }
 });
@@ -197,17 +184,7 @@ router.post('/change-password', authLimiter, requireAuth, async (req: AuthReques
         };
 
         res.json(response);
-    } catch (error: any) {
-        if (error.message === 'Current password and new password are required' || 
-            error.message.includes('Password must')) {
-            return next(new ValidationError(error.message));
-        }
-        if (error.message === 'User not found') {
-            return next(new NotFoundError(error.message));
-        }
-        if (error.message === 'Current password is incorrect') {
-            return next(new AuthError(error.message));
-        }
+    } catch (error) {
         next(error);
     }
 });

--- a/server/src/routes/scraper.test.ts
+++ b/server/src/routes/scraper.test.ts
@@ -2,6 +2,7 @@ import { errorHandler } from '../middleware/error-handler.js';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import request from 'supertest';
 import express from 'express';
+import { TheaterNotFoundError } from '../utils/errors.js';
 
 const mockTriggerScrape = vi.fn();
 const mockGetStatus = vi.fn();
@@ -144,7 +145,7 @@ describe('Routes - Scraper', () => {
     });
 
     it('should handle service errors gracefully (e.g., Theater not found)', async () => {
-      mockTriggerScrape.mockRejectedValue(new Error('Theater not found: X'));
+      mockTriggerScrape.mockRejectedValue(new TheaterNotFoundError('X'));
       const app = await setupApp();
       
       const response = await request(app).post('/api/scraper/trigger').send({ theaterId: 'X' });

--- a/server/src/routes/scraper.ts
+++ b/server/src/routes/scraper.ts
@@ -76,10 +76,7 @@ router.post('/trigger', scraperLimiter, requireAuth, async (req: AuthRequest, re
       },
     };
     res.json(response);
-  } catch (error: any) {
-    if (error.message.startsWith('Theater not found')) {
-      return next(new NotFoundError(error.message));
-    }
+  } catch (error) {
     next(error);
   }
 });

--- a/server/src/routes/theaters.test.ts
+++ b/server/src/routes/theaters.test.ts
@@ -2,6 +2,7 @@ import { errorHandler } from '../middleware/error-handler.js';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import request from 'supertest';
 import express from 'express';
+import { ValidationError, NotFoundError } from '../utils/errors.js';
 
 const mockGetAllTheaters = vi.fn();
 const mockGetTheaterShowtimes = vi.fn();
@@ -89,7 +90,7 @@ describe('Routes - Theaters', () => {
     });
 
     it('should handle URL validation errors from service', async () => {
-      mockAddTheaterViaUrl.mockRejectedValue(new Error('Invalid Allocine URL.'));
+      mockAddTheaterViaUrl.mockRejectedValue(new ValidationError('Invalid Allocine URL.'));
       const app = await setupApp();
       
       const response = await request(app).post('/api/theaters').send({ url: 'https://badurl.com' });

--- a/server/src/routes/theaters.ts
+++ b/server/src/routes/theaters.ts
@@ -6,7 +6,7 @@ import type { ApiResponse } from '../types/api.js';
 import { publicLimiter, protectedLimiter } from '../middleware/rate-limit.js';
 import { requireAuth } from '../middleware/auth.js';
 import { requirePermission } from '../middleware/permission.js';
-import { ValidationError, NotFoundError } from '../utils/errors.js';
+import { ValidationError } from '../utils/errors.js';
 
 const router = express.Router();
 
@@ -44,9 +44,8 @@ router.post('/', protectedLimiter, requireAuth, requirePermission('theaters:crea
           data: theater,
         };
         return res.status(201).json(response);
-      } catch (error: any) {
-        if (error instanceof ValidationError) return next(error);
-        return next(new ValidationError(error.message));
+      } catch (error) {
+        return next(error);
       }
     }
 
@@ -61,11 +60,7 @@ router.post('/', protectedLimiter, requireAuth, requirePermission('theaters:crea
         data: theater,
       };
       return res.status(201).json(response);
-    } catch (error: any) {
-      if (error instanceof ValidationError) return next(error);
-      if (error.message.includes('already exists')) {
-        return next(new ValidationError(error.message));
-      }
+    } catch (error) {
       return next(error);
     }
   } catch (error) {
@@ -87,12 +82,8 @@ router.put('/:id', protectedLimiter, requireAuth, requirePermission('theaters:up
         data: theater,
       };
       return res.json(response);
-    } catch (error: any) {
-      if (error instanceof ValidationError) return next(error);
-      if (error.message.includes('not found')) {
-        return next(new NotFoundError(error.message));
-      }
-      return next(new ValidationError(error.message));
+    } catch (error) {
+      return next(error);
     }
   } catch (error) {
     return next(error);
@@ -109,8 +100,8 @@ router.delete('/:id', protectedLimiter, requireAuth, requirePermission('theaters
     try {
       await theaterService.deleteTheater(theaterId);
       return res.status(204).send();
-    } catch (error: any) {
-      return next(new NotFoundError(error.message));
+    } catch (error) {
+      return next(error);
     }
   } catch (error) {
     return next(error);

--- a/server/src/services/auth-service.ts
+++ b/server/src/services/auth-service.ts
@@ -8,6 +8,7 @@ import { logger } from '../utils/logger.js';
 import { parseJwtExpiration } from '../utils/jwt-config.js';
 import type { PermissionName } from '../types/role.js';
 import { getCurrentSecret } from '../utils/jwt-secrets.js';
+import { ValidationError, AuthError, NotFoundError } from '../utils/errors.js';
 
 // Pre-computed hash for 'dummy' (cost 10) to prevent timing attacks
 const DUMMY_HASH = 'scrypt:16384:8:1:00000000000000000000000000000000:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000';
@@ -17,7 +18,7 @@ export class AuthService {
 
   async login(username?: string, password?: string) {
     if (!username || !password) {
-      throw new Error('Username and password are required');
+      throw new ValidationError('Username and password are required');
     }
 
     const user = await getUserByUsername(this.db, username);
@@ -25,7 +26,7 @@ export class AuthService {
     const isMatch = await comparePassword(password, hashToCompare);
 
     if (!user || !isMatch) {
-      throw new Error('Invalid credentials');
+      throw new AuthError('Invalid credentials');
     }
 
     const permissions = await getPermissionNamesByRoleId(this.db, user.role_id) as PermissionName[];
@@ -62,17 +63,17 @@ export class AuthService {
 
   async register(username?: string, password?: string) {
     if (!username || !password) {
-      throw new Error('Username and password are required');
+      throw new ValidationError('Username and password are required');
     }
 
     const passwordError = validatePasswordStrength(password);
     if (passwordError) {
-      throw new Error(passwordError); // Let controller decide status code
+      throw new ValidationError(passwordError);
     }
 
     const existingUser = await getUserByUsername(this.db, username);
     if (existingUser) {
-      throw new Error('Username already exists');
+      throw new ValidationError('Username already exists');
     }
 
     const passwordHash = await hashPassword(password);
@@ -89,22 +90,22 @@ export class AuthService {
 
   async changePassword(currentUsername: string, currentPassword?: string, newPassword?: string) {
     if (!currentPassword || !newPassword) {
-      throw new Error('Current password and new password are required');
+      throw new ValidationError('Current password and new password are required');
     }
 
     const passwordError = validatePasswordStrength(newPassword);
     if (passwordError) {
-      throw new Error(passwordError); // Let controller decide status code
+      throw new ValidationError(passwordError);
     }
 
     const user = await getUserByUsername(this.db, currentUsername);
     if (!user) {
-      throw new Error('User not found');
+      throw new NotFoundError('User not found');
     }
 
     const isMatch = await comparePassword(currentPassword, user.password_hash);
     if (!isMatch) {
-      throw new Error('Current password is incorrect');
+      throw new AuthError('Current password is incorrect');
     }
 
     const newPasswordHash = await hashPassword(newPassword);

--- a/server/src/services/scraper-service.ts
+++ b/server/src/services/scraper-service.ts
@@ -4,6 +4,7 @@ import { createScrapeReport, getLatestScrapeReport } from '../db/report-queries.
 import { getTheaters } from '../db/theater-queries.js';
 import type { DB } from '../db/client.js';
 import { logger } from '../utils/logger.js';
+import { TheaterNotFoundError } from '../utils/errors.js';
 import type { ScrapeAttempt } from '../db/scrape-attempt-queries.js';
 
 export class ScraperService {
@@ -22,7 +23,7 @@ export class ScraperService {
       const theaterExists = theaters.some(c => c.id === theaterId);
 
       if (!theaterExists) {
-        throw new Error(`Theater not found: ${theaterId}`);
+        throw new TheaterNotFoundError(theaterId);
       }
     }
 

--- a/server/src/services/theater-service.ts
+++ b/server/src/services/theater-service.ts
@@ -4,6 +4,7 @@ import { getTheaters, addTheater, updateTheaterConfig, deleteTheater } from '../
 import { extractTheaterIdFromUrl, cleanTheaterUrl } from '../utils/url.js';
 import { getRedisClient } from './redis-client.js';
 import { logger } from '../utils/logger.js';
+import { ValidationError, NotFoundError } from '../utils/errors.js';
 import {
   validateTheaterId,
   validateTheaterName,
@@ -33,7 +34,7 @@ export class TheaterService {
 
     const theaterId = extractTheaterIdFromUrl(url);
     if (!theaterId) {
-      throw new Error('Could not extract theater ID from URL. URL format should be like https://www.allocine.fr/seance/salle_gen_csalle=C0013.html');
+      throw new ValidationError('Could not extract theater ID from URL. URL format should be like https://www.allocine.fr/seance/salle_gen_csalle=C0013.html');
     }
 
     const cleanedUrl = cleanTheaterUrl(url);
@@ -58,7 +59,7 @@ export class TheaterService {
       return await addTheater(this.db, { id, name, url });
     } catch (error: any) {
       if (error.message && error.message.includes('duplicate key')) {
-        throw new Error('Theater with this ID already exists');
+        throw new ValidationError('Theater with this ID already exists');
       }
       throw error;
     }
@@ -89,7 +90,7 @@ export class TheaterService {
 
     const theater = await updateTheaterConfig(this.db, theaterId, updates);
     if (!theater) {
-      throw new Error(`Theater ${theaterId} not found`);
+      throw new NotFoundError(`Theater ${theaterId} not found`);
     }
 
     return theater;
@@ -98,7 +99,7 @@ export class TheaterService {
   async deleteTheater(theaterId: string) {
     const deleted = await deleteTheater(this.db, theaterId);
     if (!deleted) {
-      throw new Error(`Theater ${theaterId} not found`);
+      throw new NotFoundError(`Theater ${theaterId} not found`);
     }
     return deleted;
   }

--- a/server/src/utils/errors.ts
+++ b/server/src/utils/errors.ts
@@ -28,3 +28,9 @@ export class AuthError extends AppError {
     super(message, statusCode);
   }
 }
+
+export class TheaterNotFoundError extends AppError {
+  constructor(theaterId: string) {
+    super(`Theater not found: ${theaterId}`, 404);
+  }
+}


### PR DESCRIPTION
## Summary

Part of #1192 (slice 6) — AppError + error middleware + routes-throw cleanup.

Replaces the string-sniff pattern in `routes/scraper.ts:80` (`error.message.startsWith("Theater not found")`) with a typed `TheaterNotFoundError extends AppError`. Extends this pattern to `auth-service` and `theater-service`, collapsing every route `try/catch` that manually translated error messages into `AppError` subclasses.

## Acceptance criteria

- [x] `utils/errors.ts` exports `TheaterNotFoundError extends AppError`
- [x] `middleware/error-handler.ts` exists and is mounted as the last `app.use` in `app.ts`
- [x] The middleware maps every `AppError` subclass to its HTTP status (instanceof chain)
- [x] Unknown errors are logged with `logger.error` and return a static sanitized 500 (no `error.message` in the response)
- [x] `routes/scraper.ts:80` string-sniff replaced with pass-through `next(error)` (scraper-service already throws `TheaterNotFoundError`)
- [x] Every route's `try { ... } catch (error) { next(new XError(...)) }` collapsed to a `throw`:
  - `routes/auth.ts` — login, register, change-password
  - `routes/scraper.ts` — trigger route
  - `routes/theaters.ts` — addTheaterViaUrl, addTheaterManual, updateTheater, deleteTheater
- [x] `app.ts:155` `SELECT 1` health probe remains inline
- [x] `middleware/error-handler.test.ts` updated with `TheaterNotFoundError` → 404 mapping test
- [x] Route tests updated to assert the new throw/middleware error path (`scraper.test.ts`, `theaters.test.ts`)
- [x] `cd server && npx tsc --noEmit` clean
- [x] `npm run test:run --workspace=allo-scrapper-server` passes (833 tests)
- [x] `cd server && npm run test:coverage` passes the coverage gate

## Changes

### New error class
- **`server/src/utils/errors.ts`** — Added `TheaterNotFoundError extends AppError` (constructor takes `theaterId: string`, status 404)

### Services updated to throw typed errors
- **`server/src/services/scraper-service.ts`** — `throw new Error("Theater not found: ...")` → `throw new TheaterNotFoundError(theaterId)`
- **`server/src/services/auth-service.ts`** — All `throw new Error(...)` replaced with `ValidationError`, `AuthError`, or `NotFoundError`
- **`server/src/services/theater-service.ts`** — `throw new Error(...)` replaced with `ValidationError` or `NotFoundError`

### Route catch blocks collapsed (no more string-sniffing)
- **`server/src/routes/scraper.ts`** — String-sniff removed; passes through to error middleware
- **`server/src/routes/auth.ts`** — Login, register, change-password catch blocks collapsed to `next(error)`
- **`server/src/routes/theaters.ts`** — All 4 mutation catch blocks collapsed

### Tests updated
- **`server/src/middleware/error-handler.test.ts`** — Added test for `TheaterNotFoundError` → 404
- **`server/src/routes/scraper.test.ts`** — Mock uses `new TheaterNotFoundError("X")`
- **`server/src/routes/theaters.test.ts`** — Mock uses `new ValidationError(...)`

### Already in place (no changes needed)
- `middleware/error-handler.ts` — Already maps `instanceof AppError` → status code, sanitizes 5xx in production, handles JWT errors
- `app.ts:256` — Error middleware already mounted as last `app.use`
- `app.ts:155` — `SELECT 1` health probe remains inline

## Verification
- `tsc --noEmit` — clean
- 833 server tests pass (55 files)
- 223 scraper tests pass (19 files)
- Coverage gate passes

## Linked issues
- Sub-issue: closes #1198
- Parent: #1192