### PR TITLE
docs(1210): expand CONTEXT.md with process & runtime glossary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Theater showtimes aggregator. npm-workspaces monorepo: **Express API (`server`) 
 - Each workspace has its OWN `utils/logger.js`. `packages/logger` is not a real workspace — ignore it.
 - Dependency installs use `npm install --legacy-peer-deps` (peer-dep conflicts exist; plain `npm install` may fail). CI deletes `package-lock.json` before installing.
 - **Never add a dependency without explicit user consent.** Prefer existing libraries already in the relevant workspace.
+- **`CONTEXT.md` is the project's domain glossary** (Theater, Showtime, ScrapeAttempt FSM, ScrapeJob, ProgressEvent, RateLimitConfig, …). When introducing a new domain term or refining an existing one, update it there before opening a PR — see `docs/agents/domain.md`. Architecture docs (`docs/architecture-*.md`) describe *how* the system is wired; `CONTEXT.md` describes *what the terms mean*.
 
 ## Commands (run inside the workspace dir or via `--workspace`)
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -55,3 +55,231 @@ An external website that publishes showtime data and from which one or more Thea
 - Not a **Parser**. A Parser is a helper function inside a Strategy that handles a specific data shape (an HTML page, a JSON blob). Parsers are implementation detail of Strategies, not domain entities.
 
 **Practical note:** "Add support for a new Source" = add a new Strategy whose `sourceName` matches a new Source string. The Source identity is what Theater rows reference; the Strategy is what the scraper wires up.
+
+---
+
+## Process & runtime terms
+
+These terms describe how a scrape actually runs end-to-end — the lifecycle of a single attempt, the wire contract between server and scraper, the stream of progress events, and the rate-limit configuration that protects the API. They complement the entity glossary above.
+
+### ScrapeAttempt
+
+One attempt to scrape one (theater, date) pair within one ScrapeReport. It is the **unit of resumability**: a report can be partially failed, and the Resume flow re-queues the not-yet-successful attempts.
+
+Canonical type & transitions:
+
+```ts
+// server/src/db/scrape-attempt-queries.ts:4-16
+status: 'pending' | 'success' | 'failed' | 'rate_limited' | 'not_attempted'
+```
+
+State machine:
+
+| From            | To              | Triggered by                                                                                  |
+| --------------- | --------------- | --------------------------------------------------------------------------------------------- |
+| `(none)`        | `pending`       | `createScrapeAttempt` at the start of `processOneDate` (`scraper/src/scraper/index.ts:35-48`) |
+| `pending`       | `success`       | Normal completion of the date (`updateScrapeAttempt({ status: 'success' })`)                  |
+| `pending`       | `failed`        | Non-429 error (network, parse, 5xx, …)                                                        |
+| `pending`       | `rate_limited`  | 429 from source — `handleRateLimit` (`scraper/src/scraper/index.ts:462`)                      |
+| `pending`       | `not_attempted` | Date filtered out (not published yet, or filtered by `filterDatesForScrape`)                  |
+
+**Terminal states:** `success`, `failed`, `rate_limited`, `not_attempted`. There is no retry inside one report — recovery is via the Resume flow, which creates a new report and re-queues only the `failed` / `rate_limited` / `not_attempted` rows of the parent.
+
+The set of "pending" attempts from the perspective of the Resume route is defined as the terminal-but-not-success states: `getPendingScrapeAttempts` (`server/src/db/scrape-attempt-queries.ts:97-109`) filters on `status IN ('failed', 'rate_limited', 'not_attempted')`.
+
+**Anchors:**
+- Type: `server/src/db/scrape-attempt-queries.ts:4-16`
+- FSM transitions: `scraper/src/scraper/index.ts` (`handleRateLimit` at 462, `processOneDate` at 360, `filterDatesForScrape` at 632)
+- Resume consumer: `server/src/services/scraper-service.ts:53-77` (`triggerResume`)
+
+### ScrapeSummary
+
+The end-of-run totals published on the `completed` ProgressEvent. One canonical definition; consumer code may extend it for UI display only.
+
+Canonical shape (the producer side):
+
+```ts
+// scraper/src/types/scraper.ts:113-130
+interface ScrapeSummary {
+  total_theaters: number;
+  successful_theaters: number;
+  failed_theaters: number;
+  total_movies: number;
+  total_showtimes: number;
+  total_dates: number;
+  duration_ms: number;
+  errors: Array<{
+    theater_name: string;
+    theater_id: string;
+    date?: string;
+    error: string;
+    error_type?: 'http_429' | 'http_5xx' | 'http_4xx' | 'network' | 'parse' | 'timeout';
+    http_status_code?: number;
+  }>;
+  status?: 'success' | 'partial_success' | 'failed' | 'rate_limited';
+}
+```
+
+**Known collision:** `server/src/services/progress-tracker.ts:19-36` declares a structurally identical `ScrapeSummary`. It exists because the SSE subscriber needs the type locally and the scraper protocol package is not yet extracted (tracked separately — see `packages/scraper-protocol` work). When the protocol package lands, this duplicate disappears and the canonical type lives there. Until then: **the canonical is `scraper/src/types/scraper.ts`** (the producer); the progress-tracker copy is a tolerated drift, listed in `.fallowrc.json` `ignoreExports`.
+
+The `status` field is the canonical extension point — `success` means all attempts succeeded, `partial_success` means some failed but at least one succeeded, `failed` means none succeeded, `rate_limited` means a 429 short-circuited the run.
+
+**Anchors:**
+- Producer: `scraper/src/types/scraper.ts:113-130`
+- Consumer (tolerated drift): `server/src/services/progress-tracker.ts:19-36`
+- Orchestrator mutations: `scraper/src/scraper/index.ts` (`summarizeTheater` at 670, `finalizeScrape` at 785)
+
+### Resume (`resumeMode`, `pendingAttempts`)
+
+One concept, three names that appear in different layers of the stack. They must move together — if any one is renamed without the others, the wire breaks silently.
+
+| Name              | Layer                                | What it is                                                                                                                 |
+| ----------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| **Resume**        | UI / API                             | The button on a rate-limited report (`client/src/pages/ReportsPage/ReportRateLimitedNotice.tsx`) and the `POST /api/scraper/resume/:reportId` route (`server/src/routes/scraper.ts:84-129`). |
+| `resumeMode`      | Wire (ScrapeJob.options)             | The boolean flag the server sets on the re-issued job (`server/src/services/scraper-service.ts:71`).                      |
+| `pendingAttempts` | Wire (ScrapeJob.options payload)     | The list of `{ theater_id, date }` pairs to retry (`server/src/services/scraper-service.ts:72`).                            |
+
+**Semantics:** when the scraper receives a `scrape` job with `resumeMode: true`, it intersects the originally-requested dates with `pendingAttempts` for each theater before scraping (`scraper/src/scraper/index.ts:632-661` — `filterDatesForScrape`). Attempts that already succeeded in the parent report are excluded from the list and therefore not re-scraped.
+
+**Drift hazard:** the server's `ScrapeJobScrape.options` (`server/src/services/redis-client.ts:30-37`) declares `resumeMode` and `pendingAttempts`; the scraper's `ScrapeJobScrape.options` (`scraper/src/redis/client.ts:30-35`) does not. The scraper reads the fields anyway (`scraper/src/scraper/index.ts:146-148`, `:632-660`) — the compiler doesn't catch it. This is the canonical example of why the `packages/scraper-protocol` extraction is the project's highest-leverage refactor.
+
+**Anchors:**
+- Route: `server/src/routes/scraper.ts:84-129`
+- Service: `server/src/services/scraper-service.ts:53-77`
+- Wire (server): `server/src/services/redis-client.ts:30-37`
+- Wire (scraper, drifted): `scraper/src/redis/client.ts:30-35`
+- Consumer: `scraper/src/scraper/index.ts` (`ScrapeOptions` at 140-148, `filterDatesForScrape` at 632-661)
+
+### ScrapeJob
+
+The discriminated-union payload published by the server onto the Redis `scrape:jobs` list and consumed by the scraper microservice. Two variants today:
+
+```ts
+// server/src/services/redis-client.ts:27-50
+type ScrapeJob = ScrapeJobScrape | ScrapeJobAddTheater;
+
+interface ScrapeJobScrape extends BaseScrapeJob {
+  type: 'scrape';
+  triggerType: 'manual' | 'cron';
+  options?: {
+    mode?: 'weekly' | 'from_today' | 'from_today_limited';
+    days?: number;
+    theaterId?: string;
+    movieId?: number;
+    resumeMode?: boolean;          // see Resume above
+    pendingAttempts?: Array<{ theater_id: string; date: string }>;
+  };
+}
+
+interface ScrapeJobAddTheater extends BaseScrapeJob {
+  type: 'add_theater';
+  triggerType: 'manual';
+  url: string;
+}
+```
+
+The `type` field is the discriminant. Every consumer narrows on it before reading fields (`scraper/src/redis/client.ts:101-116`).
+
+**Where this lives — pending refactor.** Today the type is duplicated on both sides of the wire (`server/src/services/redis-client.ts:9-50` and `scraper/src/redis/client.ts:21-50`) and has already drifted — see the `resumeMode` / `pendingAttempts` row in the Resume section above. The canonical home is the planned `packages/scraper-protocol` workspace. Until that lands, treat `server/src/services/redis-client.ts:27-50` as the canonical definition (the producer) and the scraper's local copy as a tolerated drift listed in `.fallowrc.json`.
+
+**What a ScrapeJob is *not*:**
+- Not a **ScrapeReport**. A ScrapeReport is the persistent row that groups one run's ScrapeAttempts; a ScrapeJob is the transient wire payload that triggers a run. The `reportId` on the job becomes the `id` of the ScrapeReport that the scraper creates on startup.
+- Not a **ScrapeSchedule**. A ScrapeSchedule is a cron row that *triggers* the publishing of ScrapeJobs on a schedule. The schedule lives in the DB (`server/src/db/schedule-queries.ts`); the job is the consequence.
+
+**Anchors:**
+- Producer: `server/src/services/redis-client.ts:9-50`
+- Consumer: `scraper/src/redis/client.ts:21-50`, `:77-137`
+- Job routing: `scraper/src/index.ts` (the four `RUN_MODE` call sites)
+
+### ProgressEvent
+
+The discriminated-union stream of status updates the scraper publishes to Redis `scrape:progress`, the server subscribes to, and forwards to the SPA via SSE.
+
+```ts
+// scraper/src/types/scraper.ts:98-111
+type ProgressEvent =
+  | { type: 'started'; total_theaters: number; total_dates: number }
+  | { type: 'theater_started'; theater_name: string; theater_id: string; index: number }
+  | { type: 'date_started'; date: string; theater_name: string }
+  | { type: 'date_stale'; date: string; theater_name: string; actual_date: string }
+  | { type: 'date_failed'; date: string; theater_name: string; error: string }
+  | { type: 'movie_started'; movie_title: string; movie_id: number }
+  | { type: 'movie_completed'; movie_title: string; showtimes_count: number }
+  | { type: 'movie_failed'; movie_title: string; error: string }
+  | { type: 'date_completed'; date: string; movies_count: number }
+  | { type: 'theater_completed'; theater_name: string; total_movies: number }
+  | { type: 'theater_failed'; theater_name: string; error: string }
+  | { type: 'completed'; summary: ScrapeSummary }
+  | { type: 'failed'; error: string };
+```
+
+The producer is the scraper orchestrator (`scraper/src/scraper/index.ts` — every `progress?.emit(...)` call site). The consumer is `server/src/services/redis-client.ts:95-107`, which fans events out to the `ProgressTracker` SSE singleton (`server/src/services/progress-tracker.ts:39-135`). The SPA connects to `/api/scraper/progress` and receives these events as `data: {json}\n\n` SSE frames.
+
+**Drift hazard:** like `ScrapeJob` and `ScrapeSummary`, `ProgressEvent` is duplicated on producer and consumer sides (`scraper/src/types/scraper.ts:98-111` vs `server/src/services/progress-tracker.ts:4-17`). Same mitigation — when `packages/scraper-protocol` lands, the canonical lives there. The duplicated copies have not yet drifted in field shape, but the file count is two and the drift hazard is the same.
+
+**Anchors:**
+- Producer: `scraper/src/types/scraper.ts:98-111`, emitted from `scraper/src/scraper/index.ts`
+- Consumer: `server/src/services/redis-client.ts:95-107`, fanned out via `server/src/services/progress-tracker.ts`
+- Wire: Redis channel `scrape:progress`
+
+### ScheduleChangeEvent
+
+The discriminated-union payload the server publishes onto Redis `scraper:schedule:changed` when an admin creates, updates, or deletes a ScrapeSchedule, so the scraper microservice can refresh its in-memory schedule list.
+
+```ts
+// server/src/services/redis-client.ts:15-25
+interface ScheduleChangeEvent {
+  action: 'created' | 'updated' | 'deleted';
+  scheduleId: number;
+  schedule?: {
+    id: number;
+    name: string;
+    cron_expression: string;
+    enabled: boolean;
+    target_theaters?: string[] | null;
+  };
+}
+```
+
+The `action` field is the discriminant; the `schedule` payload is included on `created` and `updated` so the scraper can update its in-memory copy without an extra DB roundtrip. On `deleted`, only `scheduleId` is needed.
+
+**Anchors:**
+- Producer: `server/src/services/redis-client.ts:15-25`, published via `publishScheduleChange` at `:115`
+- Consumer: `scraper/src/redis/client.ts:143-169` (`RedisScheduleSubscriber`)
+
+### RateLimitConfig
+
+The set of buckets the API applies to incoming requests — general, auth, register, protected, scraper, public, health. Each bucket is `(windowMs, max)`; the rest of the fields are per-bucket overrides.
+
+```ts
+// server/src/config/rate-limits.ts:10-21
+interface RateLimitConfig {
+  windowMs: number;
+  generalMax: number;
+  authMax: number;
+  registerMax: number;
+  registerWindowMs: number;
+  protectedMax: number;
+  scraperMax: number;
+  publicMax: number;
+  healthMax: number;
+  healthWindowMs: number;
+}
+```
+
+The **flat shape above is the canonical** — this is what the middleware consumes on every request (`server/src/middleware/rate-limit.ts:7-10` `MutableConfig`, applied via `createRefreshableLimiter` at `:87-107`).
+
+**Audit wrapper (not the canonical):** `server/src/db/rate-limit-queries.ts:28-45` declares a `RateLimitConfig` with the same fields wrapped under a `config` key, plus `source`, `updatedAt`, `updatedBy`, `environment` metadata. This is the shape the admin route returns for display and the audit log captures for history — *not* the shape the middleware reads.
+
+**`source` discriminator is audit-only.** It records *where the active values came from* (`'database' | 'env' | 'default'`) and exists so the admin UI can show "currently using DB values" vs "no DB row, falling back to env". It must **not** leak onto the per-request hot path — the middleware reads only the flat fields. Putting `source` on the domain object is a known leak; the convergence to a single `RateLimitSource` module is tracked separately.
+
+**Drift hazard:** two interfaces with the same name and different shapes. A `grep` for `RateLimitConfig` returns hits in both files; the "duplication is intentional" comments (`server/src/config/rate-limits.ts:3-9`, `server/src/db/rate-limit-queries.ts:20-27`) document the split. Listed in `.fallowrc.json` `ignoreExports` until the single-source refactor lands.
+
+**Resolution order at boot / refresh:** the 60s `rate-limit-refresher` polls the DB (`getRateLimitConfig` at `server/src/config/rate-limits.ts:48-115`); on DB miss it falls back to `process.env.RATE_LIMIT_*` (parsed twice today — once at module load in the middleware, once here). The DB value wins.
+
+**Anchors:**
+- Canonical flat type: `server/src/config/rate-limits.ts:10-21`
+- Audit wrapper: `server/src/db/rate-limit-queries.ts:28-45`
+- Middleware consumer: `server/src/middleware/rate-limit.ts:7-10`, `:87-107`
+- Boot / refresh: `server/src/services/rate-limit-refresher.ts:6-31`
+- Admin CRUD: `server/src/routes/admin/rate-limits.ts`


### PR DESCRIPTION
## Summary

Resolves #1210. Expands `CONTEXT.md` from a 4-entity glossary to a full project glossary that includes the process & runtime terms required by the architectural review.

## What changed

**`CONTEXT.md`** — added a new "Process & runtime terms" section with 7 entries, each with a canonical code-block type, state machine / shape where applicable, and inline `file:line` source anchors:

| Term | Coverage |
| --- | --- |
| `ScrapeAttempt` | FSM table (from → to + trigger site) |
| `ScrapeSummary` | One canonical (`scraper/src/types/scraper.ts:113`) + documented collision with `progress-tracker.ts:19` |
| `Resume` / `resumeMode` / `pendingAttempts` | Three-row table mapping the three names to one concept + drift hazard |
| `ScrapeJob` | Discriminated union, anchored to the planned `packages/scraper-protocol` workspace |
| `ProgressEvent` | Producer/consumer drift noted, same protocol-package anchor |
| `ScheduleChangeEvent` | Discriminant + payload semantics |
| `RateLimitConfig` | Flat canonical vs audit wrapper, `source` discriminator flagged audit-only |

**`AGENTS.md`** — added one bullet to **Critical conventions** pointing to `CONTEXT.md` as the project glossary, with the rule that new domain terms land there before opening a PR. The existing "Domain docs" subsection is preserved.

## Surfaces three open code issues for follow-up

The glossary explicitly flags drift the documentation alone can't fix:
1. `ScrapeSummary` duplicated in `server/src/services/progress-tracker.ts:19-36` (separate code issue needed — per #1210 implementation note).
2. `ScrapeJob` wire-type drift (`server` has `resumeMode`/`pendingAttempts`, `scraper` doesn't) — root cause of #1212.
3. `RateLimitConfig` fork — root cause of #1213.

## Verification

- All `file:line` anchors cross-verified with `grep -n`.
- Pre-push hook (server + scraper `tsc --noEmit`, server tests, scraper tests, 223 tests) passed.
- No code changes, no tests, no migration.

## Checklist

- [x] Branched from `develop` (`docs/1210-context-glossary`)
- [x] Conventional commit (`docs(1210): …`)
- [x] Issue linked (#1210)
- [x] No `feat:`/`fix:` prefix → no version bump triggered (correct for docs-only change)