### PR TITLE
fix(server): skip redundant SELECT in DELETE /api/roles/:id (#1200)

### DIFF
--- a/server/src/db/role-queries.test.ts
+++ b/server/src/db/role-queries.test.ts
@@ -8,6 +8,7 @@ import {
   createRole,
   updateRole,
   deleteRole,
+  deleteRoleById,
   getAllPermissions,
   getRolePermissions,
   assignPermissionsToRole,
@@ -253,6 +254,41 @@ describe('Role & Permission Queries', () => {
 
       // Only lookup query should have been called, not a DELETE
       expect(mockDb.query).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // deleteRoleById
+  // -------------------------------------------------------------------------
+  describe('deleteRoleById', () => {
+    it('should delete a role by id and return true when the row exists', async () => {
+      vi.mocked(mockDb.query).mockResolvedValue({ rows: [], rowCount: 1 } as any);
+
+      const result = await deleteRoleById(mockDb, 3);
+
+      expect(result).toBe(true);
+      expect(mockDb.query).toHaveBeenCalledWith(
+        expect.stringContaining('DELETE FROM roles'),
+        [3]
+      );
+    });
+
+    it('should return false when no role matches the id (rowCount=0)', async () => {
+      vi.mocked(mockDb.query).mockResolvedValue({ rows: [], rowCount: 0 } as any);
+
+      const result = await deleteRoleById(mockDb, 999);
+
+      expect(result).toBe(false);
+    });
+
+    it('should issue exactly one DELETE query and never a SELECT on roles', async () => {
+      vi.mocked(mockDb.query).mockResolvedValue({ rows: [], rowCount: 1 } as any);
+
+      await deleteRoleById(mockDb, 3);
+
+      expect(mockDb.query).toHaveBeenCalledTimes(1);
+      const [sql] = vi.mocked(mockDb.query).mock.calls[0];
+      expect(sql).toMatch(/^\s*DELETE\s+FROM\s+roles\s+WHERE\s+id\s+=\s+\$1\s*;?\s*$/i);
     });
   });
 

--- a/server/src/db/role-queries.test.ts
+++ b/server/src/db/role-queries.test.ts
@@ -7,7 +7,6 @@ import {
   getRoleByName,
   createRole,
   updateRole,
-  deleteRole,
   deleteRoleById,
   getAllPermissions,
   getRolePermissions,
@@ -202,58 +201,6 @@ describe('Role & Permission Queries', () => {
       const result = await updateRole(mockDb, 999, { name: 'ghost' });
 
       expect(result).toBeUndefined();
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // deleteRole
-  // -------------------------------------------------------------------------
-  describe('deleteRole', () => {
-    it('should delete a non-system role and return true', async () => {
-      const mockRole: Role = {
-        id: 3, name: 'moderator', description: null, is_system: false, created_at: '2024-01-01T00:00:00Z',
-      };
-
-      vi.mocked(mockDb.query)
-        .mockResolvedValueOnce({ rows: [mockRole], rowCount: 1 } as any)  // lookup
-        .mockResolvedValueOnce({ rows: [], rowCount: 1 } as any);           // delete
-
-      const result = await deleteRole(mockDb, 3);
-
-      expect(result).toBe(true);
-    });
-
-    it('should return false if role is a system role (is_system=true)', async () => {
-      const systemRole: Role = {
-        id: 1, name: 'admin', description: 'Administrateur', is_system: true, created_at: '2024-01-01T00:00:00Z',
-      };
-
-      vi.mocked(mockDb.query).mockResolvedValue({ rows: [systemRole], rowCount: 1 } as any);
-
-      const result = await deleteRole(mockDb, 1);
-
-      expect(result).toBe(false);
-    });
-
-    it('should return false for non-existent role', async () => {
-      vi.mocked(mockDb.query).mockResolvedValue({ rows: [], rowCount: 0 } as any);
-
-      const result = await deleteRole(mockDb, 999);
-
-      expect(result).toBe(false);
-    });
-
-    it('should not issue DELETE query for system roles', async () => {
-      const systemRole: Role = {
-        id: 1, name: 'admin', description: null, is_system: true, created_at: '2024-01-01T00:00:00Z',
-      };
-
-      vi.mocked(mockDb.query).mockResolvedValue({ rows: [systemRole], rowCount: 1 } as any);
-
-      await deleteRole(mockDb, 1);
-
-      // Only lookup query should have been called, not a DELETE
-      expect(mockDb.query).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/server/src/db/role-queries.ts
+++ b/server/src/db/role-queries.ts
@@ -164,6 +164,24 @@ export async function deleteRole(db: DB, roleId: number): Promise<boolean> {
 }
 
 /**
+ * Delete a role by ID without any pre-checks.
+ *
+ * Callers MUST have already verified existence and `is_system` (typically via
+ * `getRoleById` + a system-role guard in the route). The function issues a
+ * single `DELETE` and returns whether the row was actually removed — `false`
+ * indicates a TOCTOU race where the row was deleted between the caller's
+ * check and this call.
+ */
+export async function deleteRoleById(db: DB, roleId: number): Promise<boolean> {
+  const result = await db.query(
+    'DELETE FROM roles WHERE id = $1',
+    [roleId]
+  );
+
+  return (result.rowCount ?? 0) > 0;
+}
+
+/**
  * Get all available permissions
  */
 export async function getAllPermissions(db: DB): Promise<Permission[]> {

--- a/server/src/db/role-queries.ts
+++ b/server/src/db/role-queries.ts
@@ -140,30 +140,6 @@ export async function updateRole(
 }
 
 /**
- * Delete a role by ID
- * Returns false if the role is a system role (is_system=true) or not found
- * Returns true if successfully deleted
- */
-export async function deleteRole(db: DB, roleId: number): Promise<boolean> {
-  const lookupResult = await db.query<Role>(
-    'SELECT id, name, description, is_system, created_at FROM roles WHERE id = $1',
-    [roleId]
-  );
-
-  if (lookupResult.rows.length === 0) {
-    return false;
-  }
-
-  const role = lookupResult.rows[0];
-  if (role.is_system) {
-    return false;
-  }
-
-  await db.query('DELETE FROM roles WHERE id = $1', [roleId]);
-  return true;
-}
-
-/**
  * Delete a role by ID without any pre-checks.
  *
  * Callers MUST have already verified existence and `is_system` (typically via

--- a/server/src/routes/roles.test.ts
+++ b/server/src/routes/roles.test.ts
@@ -20,6 +20,7 @@ vi.mock('../db/role-queries.js', () => ({
   createRole: vi.fn(),
   updateRole: vi.fn(),
   deleteRole: vi.fn(),
+  deleteRoleById: vi.fn(),
   setRolePermissions: vi.fn(),
   getAllPermissions: vi.fn(),
 }));
@@ -287,11 +288,11 @@ describe('Routes - Roles', () => {
   // DELETE /api/roles/:id
   describe('DELETE /api/roles/:id', () => {
     it('should delete a non-system role and return 204', async () => {
-      const { getRoleById, deleteRole } = await import('../db/role-queries.js');
+      const { getRoleById, deleteRoleById } = await import('../db/role-queries.js');
       const { getRoleInUseCount } = await import('../repositories/role-repository.js');
       (getRoleById as any).mockResolvedValue(mockCustomRole); // is_system: false
       (getRoleInUseCount as any).mockResolvedValue(0); // no users
-      (deleteRole as any).mockResolvedValue(true);
+      (deleteRoleById as any).mockResolvedValue(true);
 
       const { default: router } = await import('./roles.js');
       const handler = getRouteHandler(router, 'delete', '/:id');
@@ -359,12 +360,12 @@ describe('Routes - Roles', () => {
       expect(next).toHaveBeenCalledWith(expect.any(NotFoundError));
     });
 
-    it('should return 404 when deleteRole reports the role no longer exists', async () => {
-      const { getRoleById, deleteRole } = await import('../db/role-queries.js');
+    it('should return 404 when deleteRoleById reports the role no longer exists', async () => {
+      const { getRoleById, deleteRoleById } = await import('../db/role-queries.js');
       const { getRoleInUseCount } = await import('../repositories/role-repository.js');
       (getRoleById as any).mockResolvedValue(mockCustomRole);
       (getRoleInUseCount as any).mockResolvedValue(0);
-      (deleteRole as any).mockResolvedValue(false); // race: deleted between checks
+      (deleteRoleById as any).mockResolvedValue(false); // race: deleted between checks
 
       const { default: router } = await import('./roles.js');
       const handler = getRouteHandler(router, 'delete', '/:id');
@@ -379,12 +380,12 @@ describe('Routes - Roles', () => {
       expect(next.mock.calls[0][0].message).toBe('Role not found');
     });
 
-    it('should route the delete through deleteRole and getRoleInUseCount', async () => {
-      const { getRoleById, deleteRole } = await import('../db/role-queries.js');
+    it('should route the delete through deleteRoleById and getRoleInUseCount', async () => {
+      const { getRoleById, deleteRoleById } = await import('../db/role-queries.js');
       const { getRoleInUseCount } = await import('../repositories/role-repository.js');
       (getRoleById as any).mockResolvedValue(mockCustomRole);
       (getRoleInUseCount as any).mockResolvedValue(0);
-      (deleteRole as any).mockResolvedValue(true);
+      (deleteRoleById as any).mockResolvedValue(true);
 
       const { default: router } = await import('./roles.js');
       const handler = getRouteHandler(router, 'delete', '/:id');
@@ -395,7 +396,28 @@ describe('Routes - Roles', () => {
       await handler(req, res, vi.fn());
 
       expect(getRoleInUseCount).toHaveBeenCalledWith(mockDb, 3);
-      expect(deleteRole).toHaveBeenCalledWith(mockDb, 3);
+      expect(deleteRoleById).toHaveBeenCalledWith(mockDb, 3);
+    });
+
+    it('should fetch the role exactly once (issue #1200: no redundant inner SELECT)', async () => {
+      const { getRoleById, deleteRole, deleteRoleById } = await import('../db/role-queries.js');
+      const { getRoleInUseCount } = await import('../repositories/role-repository.js');
+      (getRoleById as any).mockResolvedValue(mockCustomRole);
+      (getRoleInUseCount as any).mockResolvedValue(0);
+      (deleteRoleById as any).mockResolvedValue(true);
+
+      const { default: router } = await import('./roles.js');
+      const handler = getRouteHandler(router, 'delete', '/:id');
+
+      const req = { params: { id: '3' }, app: buildMockApp(mockDb) } as any;
+      const res = buildMockRes();
+
+      await handler(req, res, vi.fn());
+
+      expect(getRoleById).toHaveBeenCalledTimes(1);
+      expect(deleteRoleById).toHaveBeenCalledTimes(1);
+      // The pre-fix deleteRole did its own SELECT inside the route — it must not be called.
+      expect(deleteRole).not.toHaveBeenCalled();
     });
   });
 
@@ -486,6 +508,7 @@ describe('Routes - Roles / Permission guards', () => {
       createRole: vi.fn(),
       updateRole: vi.fn(),
       deleteRole: vi.fn(),
+      deleteRoleById: vi.fn(),
       setRolePermissions: vi.fn(),
       getAllPermissions: vi.fn(),
     }));

--- a/server/src/routes/roles.test.ts
+++ b/server/src/routes/roles.test.ts
@@ -19,7 +19,6 @@ vi.mock('../db/role-queries.js', () => ({
   getRoleById: vi.fn(),
   createRole: vi.fn(),
   updateRole: vi.fn(),
-  deleteRole: vi.fn(),
   deleteRoleById: vi.fn(),
   setRolePermissions: vi.fn(),
   getAllPermissions: vi.fn(),
@@ -400,7 +399,7 @@ describe('Routes - Roles', () => {
     });
 
     it('should fetch the role exactly once (issue #1200: no redundant inner SELECT)', async () => {
-      const { getRoleById, deleteRole, deleteRoleById } = await import('../db/role-queries.js');
+      const { getRoleById, deleteRoleById } = await import('../db/role-queries.js');
       const { getRoleInUseCount } = await import('../repositories/role-repository.js');
       (getRoleById as any).mockResolvedValue(mockCustomRole);
       (getRoleInUseCount as any).mockResolvedValue(0);
@@ -416,8 +415,6 @@ describe('Routes - Roles', () => {
 
       expect(getRoleById).toHaveBeenCalledTimes(1);
       expect(deleteRoleById).toHaveBeenCalledTimes(1);
-      // The pre-fix deleteRole did its own SELECT inside the route — it must not be called.
-      expect(deleteRole).not.toHaveBeenCalled();
     });
   });
 
@@ -507,7 +504,6 @@ describe('Routes - Roles / Permission guards', () => {
       getRoleById: vi.fn(),
       createRole: vi.fn(),
       updateRole: vi.fn(),
-      deleteRole: vi.fn(),
       deleteRoleById: vi.fn(),
       setRolePermissions: vi.fn(),
       getAllPermissions: vi.fn(),

--- a/server/src/routes/roles.ts
+++ b/server/src/routes/roles.ts
@@ -6,7 +6,7 @@ import {
   getRoleById,
   createRole,
   updateRole,
-  deleteRole,
+  deleteRoleById,
   getAllPermissions,
   getAllPermissionCategoryLabels,
   setRolePermissions,
@@ -224,7 +224,7 @@ router.delete(
         return next(new AppError(`Role is assigned to ${userCount} user(s)`, 409));
       }
 
-      const deleted = await deleteRole(db, roleId);
+      const deleted = await deleteRoleById(db, roleId);
       if (!deleted) {
         return next(new NotFoundError('Role not found'));
       }


### PR DESCRIPTION
## Summary

The DELETE /api/roles/:id handler issued **two** SELECTs against `roles` on the happy path:

1. `getRoleById` — fetches the role + its permissions for the existence and `is_system` guards.
2. `deleteRole` — re-ran the same `SELECT id, name, description, is_system, created_at FROM roles WHERE id = $1` internally before issuing the `DELETE`.

The route had already done all the work needed to decide whether the delete was safe (`getRoleById` returned the role with its `is_system` flag, `getRoleInUseCount` confirmed no users were assigned), making the inner SELECT dead weight.

## Fix

Add `deleteRoleById(db, roleId): Promise<boolean>` — a thin DELETE-only repository function that issues a single `DELETE FROM roles WHERE id = $1` and returns whether the row was removed via `rowCount > 0`. Switch the route handler to use it.

Net effect: **1 SELECT on `roles` in the happy path (was 2)**, no behavior change. Mirrors the slice-1 pattern (commit 3caf921) of narrow single-purpose repository helpers (`roleExists`, `getRoleNameById`).

## Commits

Three atomic commits, each leaving the tree green:

1. **`feat(server/db): add deleteRoleById repository function`** — new function + its 3 unit tests, additive; old `deleteRole` untouched.
2. **`perf(server/routes): use deleteRoleById to skip redundant SELECT`** — route handler + route tests updated; pins the AC with a new "fetch the role exactly once" test.
3. **`chore(server/db): remove now-unused deleteRole function`** — dead-code cleanup after the route switched callers.

## Acceptance criteria

- [x] DELETE /api/roles/:id happy path runs exactly 1 SELECT on `roles` (was 2) — pinned by the new "fetch the role exactly once" route test and the `deleteRoleById` "issues exactly one DELETE query and never a SELECT" repository test.
- [x] Behavior preserved: 204 on success, 404 on missing role, 403 on system role, 409 on users still assigned — existing route tests still pass against the new wiring.
- [x] `routes/roles.test.ts` mocks the new function shape.
- [x] Coverage gate passes (98.78% lines / 92.82% branches, gates 80/65).

## Verification

- `cd server && npx tsc --noEmit` — clean
- `cd scraper && npx tsc --noEmit` — clean
- `cd server && npm run test:run` — 871 tests pass
- `cd server && npm run test:coverage` — gate passes
- `cd scraper && npm run test:run` — 223 tests pass

## Out of scope

Same `deleteRole`-style redundancy in `refresh-token-service.ts` (slice 5, #1197) — separate fix, separate PR.

Closes #1200