### PR TITLE
fix(server): throw on malformed count from getRoleInUseCount (#1201)

### DIFF
--- a/server/src/repositories/role-repository.test.ts
+++ b/server/src/repositories/role-repository.test.ts
@@ -48,5 +48,27 @@ describe('role-repository', () => {
 
       expect(result).toBe(0);
     });
+
+    it('throws when count is null (malformed row, not a legitimate empty result)', async () => {
+      vi.mocked(mockDb.query).mockResolvedValueOnce({
+        rows: [{ count: null }],
+        rowCount: 1,
+      } as any);
+
+      await expect(getRoleInUseCount(mockDb, 11)).rejects.toThrow(
+        /getRoleInUseCount: unexpected non-numeric count from database/
+      );
+    });
+
+    it('throws when count is non-numeric (malformed row, not a legitimate empty result)', async () => {
+      vi.mocked(mockDb.query).mockResolvedValueOnce({
+        rows: [{ count: 'not-a-number' }],
+        rowCount: 1,
+      } as any);
+
+      await expect(getRoleInUseCount(mockDb, 13)).rejects.toThrow(
+        /getRoleInUseCount: unexpected non-numeric count from database/
+      );
+    });
   });
 });

--- a/server/src/repositories/role-repository.ts
+++ b/server/src/repositories/role-repository.ts
@@ -3,11 +3,21 @@ import { type DB } from '../db/index.js';
 /**
  * Count how many users currently hold the given role.
  * Used by the role-deletion route to enforce "role must not be in use".
+ *
+ * Throws if the row exists but the count is non-numeric or null — that
+ * indicates a malformed response (SQL bug, schema drift, broken migration),
+ * which the route handler must NOT silently treat as "role is unused".
  */
 export async function getRoleInUseCount(db: DB, roleId: number): Promise<number> {
   const result = await db.query<{ count: string }>(
     'SELECT COUNT(*) as count FROM users WHERE role_id = $1',
     [roleId]
   );
-  return parseInt(result.rows[0]?.count ?? '0', 10);
+  const row = result.rows[0];
+  if (!row) return 0;
+  const count = parseInt(row.count, 10);
+  if (Number.isNaN(count)) {
+    throw new Error('getRoleInUseCount: unexpected non-numeric count from database');
+  }
+  return count;
 }


### PR DESCRIPTION
## Summary

Fixes the unsafe default in `getRoleInUseCount` where the `?? '0'` fallback silently collapsed two distinct cases into the same value:
1. **Legitimate empty result** — no rows returned, role genuinely has 0 users.
2. **Malformed row** — `{ count: null }` or non-numeric `count` from a SQL bug, schema drift, or broken migration.

The second case previously surfaced as `0`, letting `DELETE /api/roles/:id` proceed on a role that may be in use.

## Changes

- **Empty rows**: returned 0 via an explicit branch (no fallback).
- **Malformed count**: throws `Error: getRoleInUseCount: unexpected non-numeric count from database`, which the route's `catch (error) { next(error); }` block propagates to a 5xx response.
- Per the `parseStrictInt` → `parseInt(..., 10)` decision in commit `0538c43`, the parser choice is unchanged. This fix is **only** about the silent fallback.

## Acceptance criteria (from #1201)

- [x] Empty rows still return 0 (explicit branch, not a fallback)
- [x] `null`/non-numeric `count` surfaces as a thrown error (→ 5xx), not 0
- [x] `repositories/role-repository.test.ts` covers the malformed-count case
- [x] Behavior for the 204 / 409 / 404 paths unchanged (all 29 route tests pass)

## Out of scope

- Generic `parseStrictInt` NaN policy (separate sentinel/security concern).
- Reopening the `parseInt` vs `parseStrictInt` question — settled by `0538c43`.

## Verification

- **873/873** server tests pass (`npm run test:run --workspace=allo-scrapper-server`).
- **223/223** scraper tests pass.
- Server coverage gate met: 98.86% stmt / 92.89% branch; `role-repository.ts` at 100% lines.
- `tsc --noEmit` clean on both `server` and `scraper`.
- All 29 role-route tests pass — 204/409/404 paths unchanged.

## Atomic commits (TDD red → green)

1. `test(server): cover malformed count case in getRoleInUseCount` — RED: 2 new tests, failing against original impl.
2. `fix(server): throw on malformed count from getRoleInUseCount` — GREEN: tests pass.

Resolves #1201