### PR TITLE
docs: introduce CONTEXT.md as project domain glossary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Theater showtimes aggregator. npm-workspaces monorepo: **Express API (`server`) 
 - Each workspace has its OWN `utils/logger.js`. `packages/logger` is not a real workspace — ignore it.
 - Dependency installs use `npm install --legacy-peer-deps` (peer-dep conflicts exist; plain `npm install` may fail). CI deletes `package-lock.json` before installing.
 - **Never add a dependency without explicit user consent.** Prefer existing libraries already in the relevant workspace.
+- **`CONTEXT.md` at the repo root is the project's domain glossary.** Before introducing or naming a domain concept (entity, FSM, wire-format type), read it first and extend it in the same change. New code MUST use the canonical terms it defines; new or overloaded concepts MUST be added there with cross-references to the source files.
 
 ## Commands (run inside the workspace dir or via `--workspace`)
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -55,3 +55,75 @@ An external website that publishes showtime data and from which one or more Thea
 - Not a **Parser**. A Parser is a helper function inside a Strategy that handles a specific data shape (an HTML page, a JSON blob). Parsers are implementation detail of Strategies, not domain entities.
 
 **Practical note:** "Add support for a new Source" = add a new Strategy whose `sourceName` matches a new Source string. The Source identity is what Theater rows reference; the Strategy is what the scraper wires up.
+
+## Scraping
+
+The terms in this section name the recurring concepts of one end-to-end scrape run. A run is initiated by a ScrapeJob on the Redis queue, executed by the scraper microservice which emits ProgressEvents during the run, and tracked in the database via a ScrapeReport (the run-level record) holding many ScrapeAttempts (one per `(theater, date)` pair). One concept — Resume — lets a stopped/incomplete run be re-issued scoped to only its unfinished attempts. RateLimitConfig governs the API-side request throttling that protects AlloCiné responses from being overwhelmed.
+
+### ScrapeAttempt
+
+One per-`(theater, date)` outcome inside a ScrapeReport. A ScrapeAttempt is the unit of "did we get data for this theater on this date for this run?". Lives at `server/src/db/scrape-attempt-queries.ts:4` and is also persisted under that name in the scraper's local DB copy.
+
+A ScrapeAttempt has a **status** drawn from a small finite state machine. Two creation paths exist; once created, the row is terminal (a Resume creates a NEW ScrapeAttempt on a fresh `report_id`, it does not re-open an old one):
+
+- **Created as `pending`** at the moment a date is about to be scraped. Transitions:
+  - `pending → success` — the date's scrape returned data; counts `movies_scraped` and `showtimes_scraped` are stamped.
+  - `pending → failed` — a non-rate-limit error (parse, 5xx, network, timeout); `error_type`, `error_message`, `http_status_code` are stamped.
+  - `pending → rate_limited` — a `RateLimitError` (HTTP 429 from the source); the cascade described below fires.
+- **Created as `not_attempted` directly**, without going through `pending`. The triggers are inside `handleRateLimit` (`scraper/src/scraper/index.ts:462`):
+  - For the current theater, the remaining dates *after* the rate-limited one.
+  - For every theater processed *after* the rate-limited one (the "cascade"), every planned date.
+
+Terminal states: `success`, `failed`, `rate_limited`, `not_attempted`. There is no `pending → not_attempted` and no transitions out of any terminal state.
+
+**What a ScrapeAttempt is *not*:**
+- Not the **run-level** record of a scrape. One ScrapeReport holds many ScrapeAttempts; see `getScrapeAttemptsByReport` at `server/src/db/scrape-attempt-queries.ts:112`.
+- Not the **rate-limit configuration**. A `rate_limited` attempt is one *instance* of being throttled; see `RateLimitConfig` below for the configuration.
+- Not the **dataset of what was scraped**. A `success` attempt does not hold the movies and showtimes themselves — those are written straight to the main tables; the attempt holds only counts and timestamps.
+
+### ScrapeSummary
+
+The structured result of one scrape run, attached to the final `'completed'` (or `'failed'`) ProgressEvent. Carries run-level counters (theaters / movies / showtimes / dates / duration / per-error list) and a final `status`. **One definition, two byte-identical copies:** the canonical declaration lives in `scraper/src/types/scraper.ts:113` and is re-declared in `server/src/services/progress-tracker.ts:19`. Both exist today because no shared protocol package exists yet — the same pattern repeats for `ProgressEvent`, `ScrapeJob`, and `ScheduleChangeEvent`. When the protocol package lands, these converge.
+
+The scrape-side and server-side shapes are identical *today* (both include `total_dates` and `status`), so for new code pick either copy; the arrival of a protocol package will move both into it.
+
+### Resume
+
+Re-issuing a stopped or incomplete scrape scoped to only the (theater, date) pairs that did not reach `success`. The UI exposes it as the "Reprendre le scraping" button (`client/src/pages/ReportsPage/ReportRateLimitedNotice.tsx:38`) wired through the `resume` function (`client/src/pages/ReportsPage.tsx:90`); the API path is `POST /api/scraper/resume/:reportId` (`server/src/routes/scraper.ts:85`); the scraper-runtime flag is `options.resumeMode: true` and the payload list is `options.pendingAttempts: Array<{ theater_id; date }>` (`scraper/src/scraper/index.ts:146-147`).
+
+A Resume always produces a **new** ScrapeReport with `parent_report_id` set to the original. The server reads `getPendingScrapeAttempts(parentReportId)` (any attempt in `failed | rate_limited | not_attempted`), translates them into the `pendingAttempts` payload, and publishes a new ScrapeJob in resume mode. `filterDatesForScrape` then narrows each theater's plan to only its pending dates.
+
+**Resume is not free retry.** It does not re-scrape dates that already reached `success` in the parent report. It is also not idempotent on the receiving theater: a date that was `not_attempted` in the parent becomes a brand new `pending` → `success/failed/...` sequence under the new report id.
+
+### ScrapeJob
+
+A unit of work submitted by the server over the Redis `scrape:jobs` list for the scraper microservice to execute. A ScrapeJob is a **discriminated union**: `{ type: 'scrape' }` for a standard run and `{ type: 'add_theater' }` for fetching metadata for a new AlloCiné URL and scraping everything it publishes. Every job carries a `reportId` and an optional OpenTelemetry `traceContext`.
+
+Two byte-identical copies live at `server/src/services/redis-client.ts:50` and `scraper/src/redis/client.ts:50`. **Canonical home is the forthcoming protocol package** (issue #<TBD>); when that lands, both sites re-export from it. Until then, edit both — `grep -r 'export type ScrapeJob' server/src scraper/src` is the audit.
+
+**Drift to be aware of (not fixed by this entry):** the server-side `ScrapeJobScrape.options` shape (`server/src/services/redis-client.ts:30-37`) includes `resumeMode` and `pendingAttempts` for the Resume case; the structurally-identical scraper-side declaration (`scraper/src/redis/client.ts:30-36`) does not. The scraper consumes those fields via its own `ScrapeOptions` type (`scraper/src/scraper/index.ts:140`), which is why this works in practice today. The protocol-package work should converge all three.
+
+### ProgressEvent
+
+A discrete event published by the scraper onto the Redis `scrape:progress` pub/sub channel during a run, fanned out by the server to connected SSE clients. The union covers run start (`started`), per-theater and per-date lifecycle (`theater_started`, `date_started`, `date_completed`, `date_failed`, `date_stale`), per-movie lifecycle (`movie_started`, `movie_completed`, `movie_failed`), run completion (`completed` with the ScrapeSummary), and fatal failure (`failed`).
+
+Declared at `scraper/src/types/scraper.ts:98` and re-declared at `server/src/services/progress-tracker.ts:4`. Same two-sites, one concept pattern as `ScrapeJob` and `ScrapeSummary`. Canonical home is the forthcoming protocol package.
+
+### ScheduleChangeEvent
+
+A fire-and-forget pub/sub notification on the Redis `scraper:schedule:changed` channel telling the scraper to reload its local cron registrations after the admin has created, updated, or deleted a `schedules` row. The event carries `action: 'created' | 'updated' | 'deleted'`, `scheduleId`, and the optional denormalized `schedule` snapshot. The **server is the source of truth** for the schedules table; the scraper subscribes and re-evaluates its in-process cron jobs in response.
+
+Declared identically at `scraper/src/redis/client.ts:9` and `server/src/services/redis-client.ts:15`. Same forthcoming protocol-package note as the other wire types.
+
+**ScheduleChangeEvent is not Schedule.** A `Schedule` is the persisted row in the `schedules` table (server-admin CRUD via `routes/scraper-schedules.ts`); a `ScheduleChangeEvent` is the live pub/sub notification that one of those rows changed. The event's optional `schedule` snapshot is a payload convenience, NOT a redefinition of the row — readers should fetch the row from the DB if they need canonical state.
+
+### RateLimitConfig
+
+The configured thresholds that govern the server's per-endpoint HTTP rate-limit middleware. Lives at `server/src/config/rate-limits.ts:10` as the **flat runtime shape** consumed by the limiter: per-endpoint `*_Max` caps and `*_WindowMs` windows for general, auth, register, protected, scraper, public, and health routes. Resolution order (cached 30s): DB row in `rate_limit_configs` → env vars (e.g. `RATE_LIMIT_GENERAL_MAX`) → built-in defaults.
+
+The **admin-facing shape** at `server/src/db/rate-limit-queries.ts:28` wraps the flat config under a `config` key and tacks on audit-only metadata: `source` (`'database' | 'env' | 'default'` — the layer that produced the values), `updatedAt`, `updatedBy` (the admin who last edited), and `environment`. The `source` discriminator is **audit metadata** about provenance of the row — it is NOT a domain property of the limit set itself. Consumers that just need to enforce limits import the flat shape from `config/`; consumers that need to render the admin form import the wrapped shape from `db/`. The duplication should converge when the limit-config service is split out.
+
+**What RateLimitConfig is *not*:**
+- Not a per-request decision. The limiter decides per-request allow/deny; the config sets the thresholds.
+- Not the source-side rate limiter that protects AlloCiné (`RateLimitError`). Those are separate concerns: `RateLimitConfig` protects this service's HTTP surface; `RateLimitError` reports when the upstream source has throttled us.
+- Not the same across services. Only the server has an HTTP surface to rate-limit; the scraper has no equivalent shape.


### PR DESCRIPTION
Closes #1210

## Acceptance criteria (from #1210)

- [x] `CONTEXT.md` exists at the repo root
- [x] `ScrapeAttempt` (FSM: states, transitions, who triggers each) — `CONTEXT.md:63`
  - States: `pending`, `success`, `failed`, `rate_limited`, `not_attempted`
  - Transitions: `pending → success/failed/rate_limited`; `not_attempted` reached directly from `handleRateLimit` (`scraper/src/scraper/index.ts:462`)
- [x] `ScrapeSummary` (one canonical definition; server-side shape noted as the post-convergence target) — `CONTEXT.md:84`
- [x] `Resume` (maps the three names — UI "Reprendre le scraping", `resumeMode: true`, `pendingAttempts`) — `CONTEXT.md:90`
- [x] `ScrapeJob` (discriminated union `{ type: 'scrape' | 'add_theater' }`, anchored to the forthcoming protocol package) — `CONTEXT.md:98`
- [x] `ProgressEvent` (anchored to the forthcoming protocol package) — `CONTEXT.md:106`
- [x] `ScheduleChangeEvent` — `CONTEXT.md:112`
- [x] `RateLimitConfig` (one definition; `source` discriminator documented as audit-only) — `CONTEXT.md:120`
- [x] Cross-references to source files inline (e.g. `server/src/db/scrape-attempt-queries.ts:4`, `server/src/services/progress-tracker.ts:19`, `scraper/src/types/scraper.ts:113`, `server/src/services/redis-client.ts:50`, `scraper/src/redis/client.ts:50`, `client/src/pages/ReportsPage/ReportRateLimitedNotice.tsx:38`, `server/src/routes/scraper.ts:85`, `scraper/src/scraper/index.ts:146-147`, `server/src/config/rate-limits.ts:10`, `server/src/db/rate-limit-queries.ts:28`)
- [x] `AGENTS.md` mentions `CONTEXT.md` in Critical conventions — `AGENTS.md:12`

## What
Introduce `CONTEXT.md` at the repo root as the project's domain glossary, per the architectural-review finding that domain terms were spread across JSDoc, scattered across services, and ambiguous between server and scraper.

## Entries
- **Core entities:** `Theater`, `Showtime`, `WeeklyProgram`, `Source`
- **Scraping:** `ScrapeAttempt` (with the pending → {success, failed, rate_limited} FSM plus the handleRateLimit cascade into `not_attempted`), `ScrapeSummary`, `Resume` (collapses three names — UI button / `resumeMode` flag / `pendingAttempts` payload — into one concept), `ScrapeJob`, `ProgressEvent`, `ScheduleChangeEvent`, `RateLimitConfig`

Each entry uses inline file:line citations to the canonical code, and calls out the "What X is not" cases that future contributors most often trip on (Showtime vs. Screening/Session; Source vs. Strategy/Parser; ScheduleChangeEvent vs. Schedule; `source` discriminator as audit metadata only).

## Why
The architecture-review process consumes `CONTEXT.md` to frame candidates and avoid re-deriving terms from JSDoc. The ScrapeAttempt FSM and the Resume concept were the most acute prior gaps; both are now in one place.

## Coordination
- No auth-task terms (`UserService`, `mintAccessToken`) exist yet, so none are added here. They land together with whatever PR introduces them.
- The `ScrapeSummary` / `ScrapeJob` / `ProgressEvent` / `ScheduleChangeEvent` type collisions are documented and deferred to the forthcoming protocol package, per the issue's note ("CONTEXT.md just documents the canonical one").

## AGENTS.md
Adds the "`CONTEXT.md` is the project's domain glossary — read first, extend in the same change" bullet to Critical conventions.

## Verification
Documentation only — no code change, no schema migration. Acceptance criteria from #1210 checked off above.