### PR TITLE
fix(scraper): reject non-allocine URLs in fetchTheaterPage (closes #1214)

### DIFF
--- a/docs/architecture-scraper.md
+++ b/docs/architecture-scraper.md
@@ -36,7 +36,7 @@ scraper/src/
 │   └── client.ts               # Redis transport (publisher / consumer / subscriber)
 ├── scraper/                    # Core scraping logic
 │   ├── index.ts                # Scraper orchestration
-│   ├── http-client.ts          # Puppeteer/Cheerio HTTP client
+│   ├── http-client.ts          # Two transports (Puppeteer + fetch) with shared SSRF guard
 │   ├── theater-parser.ts       # HTML theater page parser
 │   ├── movie-parser.ts         # Movie showtime parser
 │   ├── theater-json-parser.ts  # JSON-LD structured data parser
@@ -100,10 +100,15 @@ Concrete implementation for AlloCiné.fr:
 │         │       ▼                                        │
 │         │   AllocineScraperStrategy                      │
 │         │       │                                        │
-│         │       ├─► http-client.ts (Puppeteer/Cheerio)   │
+│         │       ├─► http-client.ts (two transports)      │
 │         │       │       │                                │
-│         │       │       ▼                                │
-│         │       │   AlloCiné Website                      │
+│         │       │       ├─► PuppeteerTransport            │
+│         │       │       │       ▼                        │
+│         │       │       │   AlloCiné Website              │
+│         │       │       │                                │
+│         │       │       └─► FetchTransport (JSON / HTML)  │
+│         │       │               ▼                        │
+│         │       │           AlloCiné Website              │
 │         │       │                                        │
 │         │       ├─► theater-parser.ts (HTML → data)      │
 │         │       ├─► movie-parser.ts (HTML → data)        │

--- a/scraper/src/scraper/http-client.test.ts
+++ b/scraper/src/scraper/http-client.test.ts
@@ -1,12 +1,22 @@
 // Tests for HTTP client error handling
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { fetchShowtimesJson, fetchMoviePage } from './http-client.js';
+import { fetchShowtimesJson, fetchMoviePage, fetchTheaterPage } from './http-client.js';
 import { HttpError, RateLimitError } from '../utils/errors.js';
 
 // Mock global fetch
 const mockFetch = vi.fn();
 global.fetch = mockFetch as any;
+
+// Mock puppeteer so a missing SSRF guard fails fast (sentinel) instead of
+// trying to launch a real browser in CI. The SSRF validation must run BEFORE
+// puppeteer.launch — so any test below that sees the sentinel indicates the
+// URL guard did not run.
+vi.mock('puppeteer-core', () => ({
+  default: {
+    launch: vi.fn().mockRejectedValue(new Error('SENTINEL_PUPPETEER_LAUNCH')),
+  },
+}));
 
 describe('HTTP Client - Error Handling', () => {
   beforeEach(() => {
@@ -193,6 +203,32 @@ describe('HTTP Client - Error Handling', () => {
         const result = await fetchMoviePage(12345);
         expect(result).toBe(mockHtml);
       });
+    });
+  });
+
+  describe('fetchTheaterPage - URL validation (SSRF guard)', () => {
+    it('rejects URL with a non-allocine host before launching a browser', async () => {
+      await expect(
+        fetchTheaterPage('https://evil.com/theater/foo')
+      ).rejects.toThrow(/SSRF/i);
+    });
+
+    it('rejects http:// on the allocine host (TLS downgrade)', async () => {
+      await expect(
+        fetchTheaterPage('http://www.allocine.fr/theater/foo')
+      ).rejects.toThrow(/SSRF/i);
+    });
+
+    it('rejects an internal/loopback address (SSRF to internal service)', async () => {
+      await expect(
+        fetchTheaterPage('http://localhost:8080/admin')
+      ).rejects.toThrow(/SSRF/i);
+    });
+
+    it('rejects a malformed URL', async () => {
+      await expect(
+        fetchTheaterPage('not-a-url')
+      ).rejects.toThrow(/SSRF/i);
     });
   });
 });

--- a/scraper/src/scraper/http-client.ts
+++ b/scraper/src/scraper/http-client.ts
@@ -3,7 +3,7 @@
 
 import puppeteer, { type Browser } from 'puppeteer-core';
 import { logger } from '../utils/logger.js';
-import { ALLOCINE_BASE_URL } from './utils.js';
+import { ALLOCINE_BASE_URL, isValidAllocineUrl } from './utils.js';
 import { HttpError, RateLimitError } from '../utils/errors.js';
 
 const USER_AGENT =
@@ -80,6 +80,10 @@ export interface TheaterInitialData {
  * separately via the JSON API (fetchShowtimesJson).
  */
 export async function fetchTheaterPage(theaterBaseUrl: string): Promise<TheaterInitialData> {
+  if (!isValidAllocineUrl(theaterBaseUrl)) {
+    throw new Error(`SSRF guard: invalid Allociné URL: ${theaterBaseUrl}`);
+  }
+
   const browser = await getBrowser();
   const context = await browser.createBrowserContext();
   const page = await context.newPage();


### PR DESCRIPTION
## What

Closes the SSRF gap in `scraper/src/scraper/http-client.ts::fetchTheaterPage` described in #1214 (option b — the fix). A malicious theater config could point `fetchTheaterPage` at an internal address because the function handed the URL straight to Puppeteer with no validation, while its fetch-based siblings (`fetchShowtimesJson`, `fetchMoviePage`) already validated.

**Before**: any URL accepted, Puppeteer launched.
**After**: `https://www.allocine.fr/...` accepted; everything else throws before any I/O.

## Why not option (a)

The ticket recommends the deepening (extract a `Transport` adapter interface) as the higher-leverage change. That's filed as #1225 and intentionally not bundled here. Per the ticket itself: *"(b) is a fix; (a) is the deepening."* This PR ships the security fix in the smallest reviewable shape; the adapter extraction is a separate cycle that can land behind a feature flag if needed.

## Commits

1. `test(scraper): add SSRF-rejection tests for fetchTheaterPage` — red phase; 4 cases (wrong host, TLS downgrade, internal/loopback, malformed) with a sentinel `vi.mock('puppeteer-core')` so the test is hermetic and proves the guard must run BEFORE `puppeteer.launch`.
2. `fix(scraper): reject non-allocine URLs in fetchTheaterPage` — green phase; reuses the existing `isValidAllocineUrl` (no new dependency) to keep the SSRF rule in one place.
3. `docs(scraper): show two transports in http-client.ts` — corrects the directory-tree comment and the data-flow diagram, both of which claimed a single "Puppeteer/Cheerio" arrow.

## Verification

- `cd scraper && npx vitest run` → 227/227 (was 223; +4 from this PR)
- `cd server && npm run test:coverage` → 887/887, coverage gate met
- `tsc --noEmit` clean on all three workspaces
- Pre-push hook passed

## Follow-ups

- #1225 — extract the `Transport` adapter interface (the deepening).

🤖 Generated with [opencode](https://opencode.ai)

Co-Authored-By: opencode <noreply@opencode.ai>