### PR TITLE
refactor(scraper): extract validateExternalUrl SSRF utility (cycle 1 of #1225)

### DIFF
--- a/scraper/src/scraper/http-client.ts
+++ b/scraper/src/scraper/http-client.ts
@@ -3,7 +3,7 @@
 
 import puppeteer, { type Browser } from 'puppeteer-core';
 import { logger } from '../utils/logger.js';
-import { ALLOCINE_BASE_URL, isValidAllocineUrl } from './utils.js';
+import { ALLOCINE_BASE_URL, validateExternalUrl } from './utils.js';
 import { HttpError, RateLimitError } from '../utils/errors.js';
 
 const USER_AGENT =
@@ -80,9 +80,7 @@ export interface TheaterInitialData {
  * separately via the JSON API (fetchShowtimesJson).
  */
 export async function fetchTheaterPage(theaterBaseUrl: string): Promise<TheaterInitialData> {
-  if (!isValidAllocineUrl(theaterBaseUrl)) {
-    throw new Error(`SSRF guard: invalid Allociné URL: ${theaterBaseUrl}`);
-  }
+  validateExternalUrl(theaterBaseUrl);
 
   const browser = await getBrowser();
   const context = await browser.createBrowserContext();
@@ -123,14 +121,10 @@ export async function fetchShowtimesJson(theaterId: string, date: string): Promi
   validateTheaterId(theaterId);
   validateDate(date);
 
-  // Construct URL via URL object and re-validate hostname to satisfy SSRF guard.
-  // Even though theaterId and date are already strictly validated above, building
-  // the URL with new URL() and asserting the final hostname prevents any future
-  // taint from reaching the fetch call.
+  // Construct URL from validated inputs + the constant base, then re-validate
+  // via the shared rule so any future drift in ALLOCINE_BASE_URL is caught.
   const constructed = new URL(`/_/showtimes/theater-${theaterId}/d-${date}/`, ALLOCINE_BASE_URL);
-  if (constructed.hostname !== 'www.allocine.fr' || constructed.protocol !== 'https:') {
-    throw new Error(`SSRF guard: unexpected host in constructed URL ${constructed.href}`);
-  }
+  validateExternalUrl(constructed.href);
   const url = constructed.href;
   logger.info('Fetching showtimes JSON', { url });
 
@@ -168,11 +162,10 @@ export async function fetchMoviePage(movieId: number): Promise<string> {
   // Validate input before using in URL to prevent SSRF
   validateMovieId(movieId);
 
-  // Construct URL via URL object and re-validate hostname (SSRF guard).
+  // Construct URL from validated inputs + the constant base, then re-validate
+  // via the shared rule so any future drift in ALLOCINE_BASE_URL is caught.
   const constructed = new URL(`/film/fichefilm_gen_cfilm=${movieId}.html`, ALLOCINE_BASE_URL);
-  if (constructed.hostname !== 'www.allocine.fr' || constructed.protocol !== 'https:') {
-    throw new Error(`SSRF guard: unexpected host in constructed URL ${constructed.href}`);
-  }
+  validateExternalUrl(constructed.href);
   const url = constructed.href;
 
   logger.info('Fetching movie page', { url });

--- a/scraper/src/scraper/utils.ts
+++ b/scraper/src/scraper/utils.ts
@@ -62,3 +62,14 @@ export function isValidAllocineUrl(url: string): boolean {
     return false;
   }
 }
+
+/**
+ * Throws if the URL is not a valid https://www.allocine.fr/... URL.
+ * The single source of truth for the SSRF rule — every outbound
+ * fetch path must call this before any I/O.
+ */
+export function validateExternalUrl(url: string): void {
+  if (!isValidAllocineUrl(url)) {
+    throw new Error(`SSRF guard: invalid Allociné URL: ${url}`);
+  }
+}

--- a/scraper/tests/unit/scraper/utils.test.ts
+++ b/scraper/tests/unit/scraper/utils.test.ts
@@ -4,6 +4,7 @@ import {
   isStaleResponse,
   isValidAllocineUrl,
   cleanTheaterUrl,
+  validateExternalUrl,
   ALLOCINE_BASE_URL,
 } from '../../../src/scraper/utils.js';
 
@@ -127,5 +128,31 @@ describe('isStaleResponse', () => {
       { date: '2026-02-21' } as any,
     ];
     expect(isStaleResponse('2026-02-22', '2026-02-22', showtimes)).toBe(true);
+  });
+});
+
+describe('validateExternalUrl', () => {
+  it('accepts an https allocine.fr URL', () => {
+    expect(() =>
+      validateExternalUrl('https://www.allocine.fr/seance/salle_gen_csalle=C0072.html')
+    ).not.toThrow();
+  });
+
+  it('rejects a non-allocine host', () => {
+    expect(() => validateExternalUrl('https://evil.com/theater/foo')).toThrow(/SSRF/i);
+  });
+
+  it('rejects http:// on the allocine host (TLS downgrade)', () => {
+    expect(() =>
+      validateExternalUrl('http://www.allocine.fr/theater/foo')
+    ).toThrow(/SSRF/i);
+  });
+
+  it('rejects an internal/loopback address (SSRF target)', () => {
+    expect(() => validateExternalUrl('http://localhost:8080/admin')).toThrow(/SSRF/i);
+  });
+
+  it('rejects a malformed URL', () => {
+    expect(() => validateExternalUrl('not-a-url')).toThrow(/SSRF/i);
   });
 });


### PR DESCRIPTION
## What

Cycle 1 of #1225. Lifts the SSRF rule (URL must be `https://www.allocine.fr/...`) from three call sites in `scraper/src/scraper/http-client.ts` into a single `validateExternalUrl(url)` utility in `scraper/src/scraper/utils.ts`.

**Before**:
- `fetchTheaterPage` — inline `isValidAllocineUrl` check (added in #1214 / #1226).
- `fetchShowtimesJson` — inline `if (hostname !== 'www.allocine.fr' || protocol !== 'https:')` check on the constructed URL.
- `fetchMoviePage` — same inline check, different error string.

Three copies, two different error messages, zero test coverage on the two fetch-based ones.

**After**:
- One `validateExternalUrl(url): void` that throws with a single canonical error string.
- 5-case test (valid, wrong host, TLS downgrade, loopback, malformed) at `scraper/tests/unit/scraper/utils.test.ts`.
- The three call sites delegate to it. The duplicated inline checks are gone.

## Why this isn't the full deepening

The ticket's full deliverable is the `Transport` adapter interface (`PuppeteerTransport` + `FetchTransport`). Cycle 1 is the **precondition**: with the rule centralized, both transports can validate by calling the same function. Cycle 2 will extract the interface itself.

Splitting it this way keeps each PR small enough to review and bisect. Cycle 2 will close #1225.

## Verification

- `cd scraper && npx vitest run` → 232/232 (was 227; +5 from this PR)
- `tsc --noEmit` clean
- Pre-push hook passed (server 887/887 + coverage gate, scraper 232/232)

## Follow-ups

- Cycle 2 of #1225: extract the `Transport` interface; `PuppeteerTransport` and `FetchTransport` call `validateExternalUrl` from this PR.

🤖 Generated with [opencode](https://opencode.ai)

Co-Authored-By: opencode <noreply@opencode.ai>