### PR TITLE
refactor(server): extract UserService from routes/users.ts (closes #1215)

### DIFF
--- a/docs/architecture-server.md
+++ b/docs/architecture-server.md
@@ -47,6 +47,7 @@ server/src/
 │   ├── movie-service.ts
 │   ├── scraper-service.ts
 │   ├── theater-service.ts
+│   ├── user-service.ts           # Admin CRUD; owns last-admin invariant
 │   ├── system-info.ts
 │   ├── theme-generator.ts
 │   ├── progress-tracker.ts
@@ -106,6 +107,7 @@ server/src/
 - Role-based access control (RBAC)
 - Granular permissions per role
 - Middleware: `requirePermission` checks against user roles
+- The "at least one admin remains" invariant lives in `services/user-service.ts` (`assertNotLastAdmin`) and is the only place that calls `db/user-queries.getAdminCount`. Both `updateUserRole` and `deleteUser` delegate to it so adding a third entry point (admin CLI, scheduled job) cannot accidentally re-implement the rule.
 
 ### Rate Limiting
 - Configurable per-endpoint rate limits

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -1,396 +1,95 @@
+import express from 'express';
 import { parseStrictInt } from '../utils/number.js';
-import express, { NextFunction } from 'express';
-import type { DB } from '../db/index.js';
 import { requireAuth, type AuthRequest } from '../middleware/auth.js';
 import { requirePermission } from '../middleware/permission.js';
 import { protectedLimiter } from '../middleware/rate-limit.js';
 import type { ApiResponse } from '../types/api.js';
 import type { UserPublic } from '../types/user.js';
-import {
-  getAllUsers,
-  getUserById,
-  updateUserRole,
-  deleteUser,
-  getAdminCount,
-  createUser,
-  updateUserPassword,
-} from '../db/user-queries.js';
-import { roleExists, getRoleNameById } from '../db/role-queries.js';
-import { logger } from '../utils/logger.js';
-import { validatePasswordStrength } from '../utils/security.js';
-import { hashPassword } from '../utils/password.js';
-import { ValidationError, NotFoundError, AuthError } from '../utils/errors.js';
+import { ValidationError } from '../utils/errors.js';
+import { UserService } from '../services/user-service.js';
 
 const router = express.Router();
+const MAX_LIST_LIMIT = 100;
 
-// Username validation regex: alphanumeric only, 3-15 characters
-const USERNAME_REGEX = /^[a-zA-Z0-9]{3,15}$/;
+const actingUserFrom = (req: AuthRequest) => ({ id: req.user!.id, username: req.user!.username });
 
-/**
- * GET /api/users
- * List all users with pagination
- * Requires admin authentication
- */
-router.get(
-  '/',
-  protectedLimiter,
-  requireAuth,
-  requirePermission('users:list'),
-  async (req: AuthRequest, res: express.Response, next: NextFunction): Promise<void> => {
-    try {
-      const db: DB = req.app.get('db');
+const parseIdOrThrow = (raw: unknown, label: string): number => {
+  const id = parseStrictInt(raw);
+  if (Number.isNaN(id)) throw new ValidationError(`Invalid ${label}`);
+  return id;
+};
 
-      // Parse pagination params
-      let limit = req.query.limit ? parseStrictInt(req.query.limit) : 100;
-      const offset = req.query.offset ? parseStrictInt(req.query.offset) : 0;
-
-      // Validate pagination params
-      if (isNaN(limit) || limit < 1) {
-        return next(new ValidationError('Invalid limit parameter'));
-      }
-      if (isNaN(offset) || offset < 0) {
-        return next(new ValidationError('Invalid offset parameter'));
-      }
-
-      // Security: Validate and clamp pagination parameters to prevent DoS
-      if (limit > 100) limit = 100;
-
-      const users = await getAllUsers(db, { limit, offset });
-
-      logger.info('Admin listed users', {
-        adminId: req.user!.id,
-        adminUsername: req.user!.username,
-        count: users.length,
-        limit,
-        offset,
-      });
-
-      res.json({
-        success: true,
-        data: users,
-      } as ApiResponse<UserPublic[]>);
-    } catch (error) {
-      next(error);
-    }
+router.get('/', protectedLimiter, requireAuth, requirePermission('users:list'), async (req: AuthRequest, res, next) => {
+  try {
+    const userService = new UserService(req.app.get('db'));
+    const requestedLimit = req.query.limit ? parseStrictInt(req.query.limit) : MAX_LIST_LIMIT;
+    const offset = req.query.offset ? parseStrictInt(req.query.offset) : 0;
+    if (Number.isNaN(requestedLimit) || requestedLimit < 1) return next(new ValidationError('Invalid limit parameter'));
+    if (Number.isNaN(offset) || offset < 0) return next(new ValidationError('Invalid offset parameter'));
+    const users = await userService.listUsers({ limit: Math.min(requestedLimit, MAX_LIST_LIMIT), offset }, actingUserFrom(req));
+    res.json({ success: true, data: users } as ApiResponse<UserPublic[]>);
+  } catch (error) {
+    next(error);
   }
-);
+});
 
-/**
- * GET /api/users/:id
- * Get a specific user by ID
- * Requires admin authentication
- */
-router.get(
-  '/:id',
-  protectedLimiter,
-  requireAuth,
-  requirePermission('users:list'),
-  async (req: AuthRequest, res: express.Response, next: NextFunction): Promise<void> => {
-    try {
-      const db: DB = req.app.get('db');
-
-      const userId = parseStrictInt(req.params.id);
-
-      if (isNaN(userId)) {
-        return next(new ValidationError('Invalid user ID'));
-      }
-
-      const user = await getUserById(db, userId);
-
-      if (!user) {
-        return next(new NotFoundError('User not found'));
-      }
-
-      logger.info('Admin retrieved user details', {
-        adminId: req.user!.id,
-        adminUsername: req.user!.username,
-        targetUserId: userId,
-        targetUsername: user.username,
-      });
-
-      res.json({
-        success: true,
-        data: user,
-      } as ApiResponse<UserPublic>);
-    } catch (error) {
-      next(error);
-    }
+router.get('/:id', protectedLimiter, requireAuth, requirePermission('users:list'), async (req: AuthRequest, res, next) => {
+  try {
+    const userService = new UserService(req.app.get('db'));
+    const user = await userService.getUserById(parseIdOrThrow(req.params.id, 'user ID'), actingUserFrom(req));
+    res.json({ success: true, data: user } as ApiResponse<UserPublic>);
+  } catch (error) {
+    next(error);
   }
-);
+});
 
-/**
- * POST /api/users
- * Create a new user
- * Requires admin authentication
- */
-router.post(
-  '/',
-  protectedLimiter,
-  requireAuth,
-  requirePermission('users:create'),
-  async (req: AuthRequest, res: express.Response, next: NextFunction): Promise<void> => {
-    try {
-      const db: DB = req.app.get('db');
-
-      const { username, password, role_id } = req.body;
-
-      // Validate required fields
-      if (!username || !password) {
-        return next(new ValidationError('Username and password are required'));
-      }
-
-      // Validate username format
-      if (!USERNAME_REGEX.test(username)) {
-        return next(new ValidationError('Username must be alphanumeric and 3-15 characters long'));
-      }
-
-      // Validate password
-      const passwordError = validatePasswordStrength(password);
-      if (passwordError) {
-        return next(new ValidationError(passwordError));
-      }
-
-      // Validate role_id (required)
-      if (!role_id || isNaN(parseStrictInt(role_id))) {
-        return next(new ValidationError('role_id is required and must be a valid integer'));
-      }
-
-      const roleId = parseStrictInt(role_id);
-
-      // Verify role_id exists
-      if (!(await roleExists(db, roleId))) {
-        return next(new ValidationError('Invalid role_id: role does not exist'));
-      }
-
-      // Hash password
-      const passwordHash = await hashPassword(password);
-
-      // Create user
-      const newUser = await createUser(db, username, passwordHash, roleId);
-
-      logger.info('Admin created new user', {
-        adminId: req.user!.id,
-        adminUsername: req.user!.username,
-        newUserId: newUser.id,
-        newUsername: newUser.username,
-        newUserRoleId: newUser.role_id,
-        newUserRoleName: newUser.role_name,
-      });
-
-      res.status(201).json({
-        success: true,
-        data: newUser,
-      } as ApiResponse<UserPublic>);
-    } catch (error: any) {
-      // Handle duplicate username error
-      if (error.code === '23505' || error.message?.includes('duplicate key')) {
-        return next(new ValidationError('Username already exists'));
-      }
-
-      next(error);
-    }
+router.post('/', protectedLimiter, requireAuth, requirePermission('users:create'), async (req: AuthRequest, res, next) => {
+  try {
+    const userService = new UserService(req.app.get('db'));
+    const { username, password, role_id } = req.body;
+    const newUser = await userService.createUser({ username, password, roleId: parseStrictInt(role_id) }, actingUserFrom(req));
+    res.status(201).json({ success: true, data: newUser } as ApiResponse<UserPublic>);
+  } catch (error) {
+    next(error);
   }
-);
+});
 
-/**
- * PUT /api/users/:id/role
- * Update user's role
- * Requires admin authentication
- * Safety guard: Prevent demoting the last admin
- */
-router.put(
-  '/:id/role',
-  protectedLimiter,
-  requireAuth,
-  requirePermission('users:update'),
-  async (req: AuthRequest, res: express.Response, next: NextFunction): Promise<void> => {
-    try {
-      const db: DB = req.app.get('db');
-
-      const userId = parseStrictInt(req.params.id);
-      const { role_id } = req.body;
-
-      // Validate user ID
-      if (isNaN(userId)) {
-        return next(new ValidationError('Invalid user ID'));
-      }
-
-      // Validate role_id
-      if (!role_id) {
-        return next(new ValidationError('role_id is required'));
-      }
-
-      const roleId = parseStrictInt(role_id);
-      if (isNaN(roleId)) {
-        return next(new ValidationError('role_id must be a valid integer'));
-      }
-
-      // Check if user exists
-      const targetUser = await getUserById(db, userId);
-      if (!targetUser) {
-        return next(new NotFoundError('User not found'));
-      }
-
-      // Look up the new role's name (also serves as the existence check).
-      const newRoleName = await getRoleNameById(db, roleId);
-      if (!newRoleName) {
-        return next(new ValidationError('Invalid role_id: role does not exist'));
-      }
-
-      // Safety guard: Prevent demoting the last admin
-      if (targetUser.role_name === 'admin' && newRoleName !== 'admin') {
-        const adminCount = await getAdminCount(db);
-        if (adminCount <= 1) {
-          return next(new AuthError('Cannot demote the last admin user', 403));
-        }
-      }
-
-      // Update role
-      await updateUserRole(db, userId, roleId);
-
-      // Fetch updated user
-      const updatedUser = await getUserById(db, userId);
-
-      logger.info('Admin updated user role', {
-        adminId: req.user!.id,
-        adminUsername: req.user!.username,
-        targetUserId: userId,
-        targetUsername: updatedUser!.username,
-        oldRoleName: targetUser.role_name,
-        newRoleId: roleId,
-      });
-
-      res.json({
-        success: true,
-        data: updatedUser,
-      } as ApiResponse<UserPublic>);
-    } catch (error) {
-      next(error);
-    }
+router.put('/:id/role', protectedLimiter, requireAuth, requirePermission('users:update'), async (req: AuthRequest, res, next) => {
+  try {
+    const userService = new UserService(req.app.get('db'));
+    const updated = await userService.updateUserRole(
+      parseIdOrThrow(req.params.id, 'user ID'),
+      parseStrictInt(req.body.role_id),
+      actingUserFrom(req),
+    );
+    res.json({ success: true, data: updated } as ApiResponse<UserPublic>);
+  } catch (error) {
+    next(error);
   }
-);
+});
 
-/**
- * POST /api/users/:id/reset-password
- * Reset user's password. Password is generated client-side and sent in request body.
- * Requires admin authentication.
- */
-router.post(
-  '/:id/reset-password',
-  protectedLimiter,
-  requireAuth,
-  requirePermission('users:update'),
-  async (req: AuthRequest, res: express.Response, next: NextFunction): Promise<void> => {
-    try {
-      const db: DB = req.app.get('db');
-
-      const userId = parseStrictInt(req.params.id);
-
-      if (isNaN(userId)) {
-        return next(new ValidationError('Invalid user ID'));
-      }
-
-      const targetUser = await getUserById(db, userId);
-      if (!targetUser) {
-        return next(new NotFoundError('User not found'));
-      }
-
-      const { newPassword } = req.body;
-      if (!newPassword || typeof newPassword !== 'string') {
-        return next(new ValidationError('New password is required'));
-      }
-
-      const passwordError = validatePasswordStrength(newPassword);
-      if (passwordError) {
-        return next(new ValidationError(passwordError));
-      }
-
-      const passwordHash = await hashPassword(newPassword);
-
-      await updateUserPassword(db, userId, passwordHash);
-
-      logger.info('Admin reset user password', {
-        adminId: req.user!.id,
-        adminUsername: req.user!.username,
-        targetUserId: userId,
-        targetUsername: targetUser.username,
-      });
-
-      res.json({
-        success: true,
-        data: {
-          user: targetUser,
-        },
-      } as ApiResponse<{ user: UserPublic }>);
-    } catch (error) {
-      next(error);
-    }
+router.post('/:id/reset-password', protectedLimiter, requireAuth, requirePermission('users:update'), async (req: AuthRequest, res, next) => {
+  try {
+    const userService = new UserService(req.app.get('db'));
+    const target = await userService.resetPassword(
+      parseIdOrThrow(req.params.id, 'user ID'),
+      req.body.newPassword,
+      actingUserFrom(req),
+    );
+    res.json({ success: true, data: { user: target } } as ApiResponse<{ user: UserPublic }>);
+  } catch (error) {
+    next(error);
   }
-);
+});
 
-/**
- * DELETE /api/users/:id
- * Delete a user
- * Requires admin authentication
- * Safety guards:
- * - Prevent deleting the last admin
- * - Prevent self-deletion
- */
-router.delete(
-  '/:id',
-  protectedLimiter,
-  requireAuth,
-  requirePermission('users:delete'),
-  async (req: AuthRequest, res: express.Response, next: NextFunction): Promise<void> => {
-    try {
-      const db: DB = req.app.get('db');
-
-      const userId = parseStrictInt(req.params.id);
-
-      // Validate user ID
-      if (isNaN(userId)) {
-        return next(new ValidationError('Invalid user ID'));
-      }
-
-      // Safety guard: Prevent self-deletion
-      if (userId === req.user!.id) {
-        return next(new AuthError('Cannot delete your own account', 403));
-      }
-
-      // Check if user exists and get their role
-      const targetUser = await getUserById(db, userId);
-      if (!targetUser) {
-        return next(new NotFoundError('User not found'));
-      }
-
-      // Safety guard: Prevent deleting the last admin
-      if (targetUser.role_name === 'admin') {
-        const adminCount = await getAdminCount(db);
-        if (adminCount <= 1) {
-          return next(new AuthError('Cannot delete the last admin user', 403));
-        }
-      }
-
-      // Delete user
-      const deleted = await deleteUser(db, userId);
-
-      if (!deleted) {
-        return next(new NotFoundError('User not found'));
-      }
-
-      logger.info('Admin deleted user', {
-        adminId: req.user!.id,
-        adminUsername: req.user!.username,
-        deletedUserId: userId,
-        deletedUsername: targetUser.username,
-        deletedUserRoleName: targetUser.role_name,
-      });
-
-      res.status(204).send();
-    } catch (error) {
-      next(error);
-    }
+router.delete('/:id', protectedLimiter, requireAuth, requirePermission('users:delete'), async (req: AuthRequest, res, next) => {
+  try {
+    const userService = new UserService(req.app.get('db'));
+    await userService.deleteUser(parseIdOrThrow(req.params.id, 'user ID'), actingUserFrom(req));
+    res.status(204).send();
+  } catch (error) {
+    next(error);
   }
-);
+});
 
 export default router;

--- a/server/src/services/user-service.test.ts
+++ b/server/src/services/user-service.test.ts
@@ -1,0 +1,400 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UserService, type ActingUser } from './user-service.js';
+import * as userQueries from '../db/user-queries.js';
+import * as roleQueries from '../db/role-queries.js';
+import * as passwordUtils from '../utils/password.js';
+import { validatePasswordStrength } from '../utils/security.js';
+import { type DB } from '../db/index.js';
+import type { UserPublic } from '../types/user.js';
+
+vi.mock('../db/user-queries.js');
+vi.mock('../db/role-queries.js');
+vi.mock('../utils/password.js');
+vi.mock('../utils/security.js', () => ({
+  validatePasswordStrength: vi.fn(() => null),
+}));
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+const ACTING: ActingUser = { id: 1, username: 'admin' };
+
+const makeUser = (
+  id: number,
+  username: string,
+  roleId: number,
+  roleName: string,
+  createdAt = '2024-01-01T00:00:00Z',
+): UserPublic => ({
+  id,
+  username,
+  role_id: roleId,
+  role_name: roleName,
+  created_at: createdAt,
+});
+
+describe('UserService', () => {
+  let service: UserService;
+  const mockDb = {} as DB;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(validatePasswordStrength).mockReturnValue(null);
+    vi.mocked(passwordUtils.hashPassword).mockResolvedValue('scrypt:hashed');
+    service = new UserService(mockDb);
+  });
+
+  describe('listUsers', () => {
+    it('returns the paginated user list from the db layer', async () => {
+      const users = [makeUser(1, 'admin', 1, 'admin'), makeUser(2, 'user1', 2, 'operator')];
+      vi.mocked(userQueries.getAllUsers).mockResolvedValue(users);
+
+      const result = await service.listUsers({ limit: 25, offset: 50 }, ACTING);
+
+      expect(result).toEqual(users);
+      expect(userQueries.getAllUsers).toHaveBeenCalledWith(mockDb, { limit: 25, offset: 50 });
+    });
+
+    it('returns an empty array when no users match', async () => {
+      vi.mocked(userQueries.getAllUsers).mockResolvedValue([]);
+      const result = await service.listUsers({ limit: 100, offset: 0 }, ACTING);
+      expect(result).toEqual([]);
+    });
+
+    it('surfaces db errors to the caller without swallowing them', async () => {
+      vi.mocked(userQueries.getAllUsers).mockRejectedValue(new Error('connection refused'));
+      await expect(service.listUsers({ limit: 1, offset: 0 }, ACTING)).rejects.toThrow('connection refused');
+    });
+  });
+
+  describe('getUserById', () => {
+    it('returns the user when found', async () => {
+      const user = makeUser(2, 'user1', 2, 'operator');
+      vi.mocked(userQueries.getUserById).mockResolvedValue(user);
+
+      const result = await service.getUserById(2, ACTING);
+
+      expect(result).toEqual(user);
+      expect(userQueries.getUserById).toHaveBeenCalledWith(mockDb, 2);
+    });
+
+    it('throws NotFoundError when the user does not exist', async () => {
+      vi.mocked(userQueries.getUserById).mockResolvedValue(undefined);
+      await expect(service.getUserById(999, ACTING)).rejects.toMatchObject({
+        name: 'NotFoundError',
+        statusCode: 404,
+        message: 'User not found',
+      });
+    });
+  });
+
+  describe('createUser', () => {
+    const newUser = makeUser(3, 'newuser', 2, 'operator', '2024-01-03T00:00:00Z');
+
+    it('creates the user with the supplied role', async () => {
+      vi.mocked(roleQueries.roleExists).mockResolvedValue(true);
+      vi.mocked(userQueries.createUser).mockResolvedValue(newUser);
+
+      const result = await service.createUser(
+        { username: 'newuser', password: 'ValidPass123!', roleId: 2 },
+        ACTING,
+      );
+
+      expect(result).toEqual(newUser);
+      expect(passwordUtils.hashPassword).toHaveBeenCalledWith('ValidPass123!');
+      expect(userQueries.createUser).toHaveBeenCalledWith(mockDb, 'newuser', 'scrypt:hashed', 2);
+    });
+
+    it('rejects when username is missing', async () => {
+      await expect(
+        service.createUser({ username: '', password: 'ValidPass123!', roleId: 2 }, ACTING),
+      ).rejects.toThrow('Username and password are required');
+      expect(userQueries.createUser).not.toHaveBeenCalled();
+    });
+
+    it('rejects when password is missing', async () => {
+      await expect(
+        service.createUser({ username: 'newuser', password: '', roleId: 2 }, ACTING),
+      ).rejects.toThrow('Username and password are required');
+    });
+
+    it('rejects a username that fails the alphanumeric+length regex', async () => {
+      await expect(
+        service.createUser({ username: 'ab', password: 'ValidPass123!', roleId: 2 }, ACTING),
+      ).rejects.toThrow('Username must be alphanumeric and 3-15 characters long');
+      await expect(
+        service.createUser({ username: 'abcdefghijklmnopqrstuv', password: 'ValidPass123!', roleId: 2 }, ACTING),
+      ).rejects.toThrow('Username must be alphanumeric and 3-15 characters long');
+      await expect(
+        service.createUser({ username: 'user@name', password: 'ValidPass123!', roleId: 2 }, ACTING),
+      ).rejects.toThrow('Username must be alphanumeric and 3-15 characters long');
+    });
+
+    it('rejects a weak password', async () => {
+      vi.mocked(validatePasswordStrength).mockReturnValue('Password must contain at least one digit');
+      await expect(
+        service.createUser({ username: 'newuser', password: 'NoDigits!', roleId: 2 }, ACTING),
+      ).rejects.toThrow('Password must contain at least one digit');
+    });
+
+    it('rejects a non-integer roleId', async () => {
+      await expect(
+        service.createUser({ username: 'newuser', password: 'ValidPass123!', roleId: NaN }, ACTING),
+      ).rejects.toThrow('role_id is required and must be a valid integer');
+      expect(roleQueries.roleExists).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unknown roleId', async () => {
+      vi.mocked(roleQueries.roleExists).mockResolvedValue(false);
+      await expect(
+        service.createUser({ username: 'newuser', password: 'ValidPass123!', roleId: 999 }, ACTING),
+      ).rejects.toThrow('Invalid role_id: role does not exist');
+    });
+
+    it('maps a Postgres unique-violation (code 23505) to a ValidationError', async () => {
+      vi.mocked(roleQueries.roleExists).mockResolvedValue(true);
+      const dup: Error & { code?: string } = new Error('duplicate key value violates unique constraint');
+      dup.code = '23505';
+      vi.mocked(userQueries.createUser).mockRejectedValue(dup);
+
+      await expect(
+        service.createUser({ username: 'existinguser', password: 'ValidPass123!', roleId: 2 }, ACTING),
+      ).rejects.toThrow('Username already exists');
+    });
+
+    it('maps a "duplicate key" message (no SQLSTATE) to a ValidationError', async () => {
+      vi.mocked(roleQueries.roleExists).mockResolvedValue(true);
+      vi.mocked(userQueries.createUser).mockRejectedValue(new Error('some duplicate key situation'));
+
+      await expect(
+        service.createUser({ username: 'existinguser', password: 'ValidPass123!', roleId: 2 }, ACTING),
+      ).rejects.toThrow('Username already exists');
+    });
+
+    it('rethrows unrelated db errors', async () => {
+      vi.mocked(roleQueries.roleExists).mockResolvedValue(true);
+      vi.mocked(userQueries.createUser).mockRejectedValue(new Error('connection refused'));
+
+      await expect(
+        service.createUser({ username: 'newuser', password: 'ValidPass123!', roleId: 2 }, ACTING),
+      ).rejects.toThrow('connection refused');
+    });
+
+    it('rethrows when a non-object value is rejected', async () => {
+      vi.mocked(roleQueries.roleExists).mockResolvedValue(true);
+      vi.mocked(userQueries.createUser).mockRejectedValue('a string error');
+
+      await expect(
+        service.createUser({ username: 'newuser', password: 'ValidPass123!', roleId: 2 }, ACTING),
+      ).rejects.toBe('a string error');
+    });
+  });
+
+  describe('updateUserRole', () => {
+    it('updates the role and returns the refreshed user', async () => {
+      const target = makeUser(2, 'user1', 2, 'operator');
+      const updated = makeUser(2, 'user1', 1, 'admin');
+      vi.mocked(userQueries.getUserById).mockResolvedValueOnce(target);
+      vi.mocked(roleQueries.getRoleNameById).mockResolvedValue('admin');
+      vi.mocked(userQueries.updateUserRole).mockResolvedValue(undefined);
+      vi.mocked(userQueries.getUserById).mockResolvedValueOnce(updated);
+
+      const result = await service.updateUserRole(2, 1, ACTING);
+
+      expect(result).toEqual(updated);
+      expect(userQueries.updateUserRole).toHaveBeenCalledWith(mockDb, 2, 1);
+    });
+
+    it('throws NotFoundError when the target user does not exist', async () => {
+      vi.mocked(userQueries.getUserById).mockResolvedValue(undefined);
+      await expect(service.updateUserRole(999, 1, ACTING)).rejects.toMatchObject({
+        name: 'NotFoundError',
+        statusCode: 404,
+      });
+      expect(userQueries.updateUserRole).not.toHaveBeenCalled();
+    });
+
+    it('throws ValidationError when the new role does not exist', async () => {
+      vi.mocked(userQueries.getUserById).mockResolvedValue(makeUser(2, 'user1', 2, 'operator'));
+      vi.mocked(roleQueries.getRoleNameById).mockResolvedValue(undefined);
+      await expect(service.updateUserRole(2, 999, ACTING)).rejects.toThrow('Invalid role_id: role does not exist');
+    });
+
+    it('throws AuthError when demoting the only admin', async () => {
+      vi.mocked(userQueries.getUserById).mockResolvedValue(makeUser(1, 'admin', 1, 'admin'));
+      vi.mocked(roleQueries.getRoleNameById).mockResolvedValue('operator');
+      vi.mocked(userQueries.getAdminCount).mockResolvedValue(1);
+
+      await expect(service.updateUserRole(1, 2, ACTING)).rejects.toMatchObject({
+        name: 'AuthError',
+        statusCode: 403,
+        message: 'Cannot demote the last admin user',
+      });
+      expect(userQueries.updateUserRole).not.toHaveBeenCalled();
+    });
+
+    it('allows demoting an admin when others remain', async () => {
+      const target = makeUser(3, 'admin2', 1, 'admin');
+      const updated = makeUser(3, 'admin2', 2, 'operator');
+      vi.mocked(userQueries.getUserById).mockResolvedValueOnce(target);
+      vi.mocked(roleQueries.getRoleNameById).mockResolvedValue('operator');
+      vi.mocked(userQueries.getAdminCount).mockResolvedValue(2);
+      vi.mocked(userQueries.updateUserRole).mockResolvedValue(undefined);
+      vi.mocked(userQueries.getUserById).mockResolvedValueOnce(updated);
+
+      const result = await service.updateUserRole(3, 2, ACTING);
+
+      expect(result.role_name).toBe('operator');
+      expect(userQueries.getAdminCount).toHaveBeenCalledWith(mockDb);
+    });
+
+    it('skips the admin-count check when promoting a non-admin to admin', async () => {
+      const target = makeUser(2, 'user1', 2, 'operator');
+      const updated = makeUser(2, 'user1', 1, 'admin');
+      vi.mocked(userQueries.getUserById).mockResolvedValueOnce(target);
+      vi.mocked(roleQueries.getRoleNameById).mockResolvedValue('admin');
+      vi.mocked(userQueries.updateUserRole).mockResolvedValue(undefined);
+      vi.mocked(userQueries.getUserById).mockResolvedValueOnce(updated);
+
+      await service.updateUserRole(2, 1, ACTING);
+
+      expect(userQueries.getAdminCount).not.toHaveBeenCalled();
+    });
+
+    it('skips the admin-count check when re-assigning the same admin role', async () => {
+      const target = makeUser(1, 'admin', 1, 'admin');
+      const updated = makeUser(1, 'admin', 1, 'admin');
+      vi.mocked(userQueries.getUserById).mockResolvedValueOnce(target);
+      vi.mocked(roleQueries.getRoleNameById).mockResolvedValue('admin');
+      vi.mocked(userQueries.updateUserRole).mockResolvedValue(undefined);
+      vi.mocked(userQueries.getUserById).mockResolvedValueOnce(updated);
+
+      await service.updateUserRole(1, 1, ACTING);
+
+      expect(userQueries.getAdminCount).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resetPassword', () => {
+    it('hashes and stores the new password', async () => {
+      const target = makeUser(2, 'user1', 2, 'operator');
+      vi.mocked(userQueries.getUserById).mockResolvedValue(target);
+      vi.mocked(userQueries.updateUserPassword).mockResolvedValue(undefined);
+
+      const result = await service.resetPassword(2, 'BrandNewPass123!', ACTING);
+
+      expect(result).toEqual(target);
+      expect(passwordUtils.hashPassword).toHaveBeenCalledWith('BrandNewPass123!');
+      expect(userQueries.updateUserPassword).toHaveBeenCalledWith(mockDb, 2, 'scrypt:hashed');
+    });
+
+    it('rejects a missing password', async () => {
+      vi.mocked(userQueries.getUserById).mockResolvedValue(makeUser(2, 'user1', 2, 'operator'));
+      await expect(service.resetPassword(2, undefined, ACTING)).rejects.toThrow('New password is required');
+      await expect(service.resetPassword(2, '', ACTING)).rejects.toThrow('New password is required');
+    });
+
+    it('rejects a non-string password', async () => {
+      vi.mocked(userQueries.getUserById).mockResolvedValue(makeUser(2, 'user1', 2, 'operator'));
+      await expect(service.resetPassword(2, 12345678, ACTING)).rejects.toThrow('New password is required');
+    });
+
+    it('rejects a weak password', async () => {
+      vi.mocked(userQueries.getUserById).mockResolvedValue(makeUser(2, 'user1', 2, 'operator'));
+      vi.mocked(validatePasswordStrength).mockReturnValue('Password must be at least 8 characters');
+      await expect(service.resetPassword(2, 'short', ACTING)).rejects.toThrow(
+        'Password must be at least 8 characters',
+      );
+    });
+
+    it('throws NotFoundError when the target user does not exist', async () => {
+      vi.mocked(userQueries.getUserById).mockResolvedValue(undefined);
+      await expect(service.resetPassword(999, 'ValidPass123!', ACTING)).rejects.toMatchObject({
+        name: 'NotFoundError',
+        statusCode: 404,
+      });
+      expect(userQueries.updateUserPassword).not.toHaveBeenCalled();
+      expect(passwordUtils.hashPassword).not.toHaveBeenCalled();
+    });
+
+    it('does not validate the password when the user does not exist (preserves pre-refactor order)', async () => {
+      vi.mocked(userQueries.getUserById).mockResolvedValue(undefined);
+      await expect(service.resetPassword(999, 'weak', ACTING)).rejects.toMatchObject({
+        name: 'NotFoundError',
+      });
+      expect(validatePasswordStrength).not.toHaveBeenCalled();
+      expect(passwordUtils.hashPassword).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteUser', () => {
+    it('deletes a non-admin user', async () => {
+      vi.mocked(userQueries.getUserById).mockResolvedValue(makeUser(2, 'user1', 2, 'operator'));
+      vi.mocked(userQueries.deleteUser).mockResolvedValue(true);
+
+      await service.deleteUser(2, ACTING);
+
+      expect(userQueries.deleteUser).toHaveBeenCalledWith(mockDb, 2);
+    });
+
+    it('prevents the acting admin from deleting themselves', async () => {
+      await expect(service.deleteUser(1, ACTING)).rejects.toMatchObject({
+        name: 'AuthError',
+        statusCode: 403,
+        message: 'Cannot delete your own account',
+      });
+      expect(userQueries.getUserById).not.toHaveBeenCalled();
+      expect(userQueries.deleteUser).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundError when the target user does not exist', async () => {
+      vi.mocked(userQueries.getUserById).mockResolvedValue(undefined);
+      await expect(service.deleteUser(999, ACTING)).rejects.toMatchObject({
+        name: 'NotFoundError',
+        statusCode: 404,
+      });
+      expect(userQueries.deleteUser).not.toHaveBeenCalled();
+    });
+
+    it('throws AuthError when deleting the last admin', async () => {
+      vi.mocked(userQueries.getUserById).mockResolvedValue(makeUser(2, 'admin2', 1, 'admin'));
+      vi.mocked(userQueries.getAdminCount).mockResolvedValue(1);
+
+      await expect(service.deleteUser(2, ACTING)).rejects.toMatchObject({
+        name: 'AuthError',
+        statusCode: 403,
+        message: 'Cannot delete the last admin user',
+      });
+      expect(userQueries.deleteUser).not.toHaveBeenCalled();
+    });
+
+    it('allows deleting an admin when others remain', async () => {
+      vi.mocked(userQueries.getUserById).mockResolvedValue(makeUser(3, 'admin2', 1, 'admin'));
+      vi.mocked(userQueries.getAdminCount).mockResolvedValue(2);
+      vi.mocked(userQueries.deleteUser).mockResolvedValue(true);
+
+      await service.deleteUser(3, ACTING);
+
+      expect(userQueries.deleteUser).toHaveBeenCalledWith(mockDb, 3);
+    });
+
+    it('skips the admin-count check when deleting a non-admin', async () => {
+      vi.mocked(userQueries.getUserById).mockResolvedValue(makeUser(2, 'user1', 2, 'operator'));
+      vi.mocked(userQueries.deleteUser).mockResolvedValue(true);
+
+      await service.deleteUser(2, ACTING);
+
+      expect(userQueries.getAdminCount).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundError when the underlying delete reports no row removed', async () => {
+      vi.mocked(userQueries.getUserById).mockResolvedValue(makeUser(2, 'user1', 2, 'operator'));
+      vi.mocked(userQueries.deleteUser).mockResolvedValue(false);
+
+      await expect(service.deleteUser(2, ACTING)).rejects.toMatchObject({
+        name: 'NotFoundError',
+        statusCode: 404,
+      });
+    });
+  });
+});

--- a/server/src/services/user-service.ts
+++ b/server/src/services/user-service.ts
@@ -1,0 +1,286 @@
+import type { DB } from '../db/index.js';
+import type { UserPublic } from '../types/user.js';
+import { logger } from '../utils/logger.js';
+import { validatePasswordStrength } from '../utils/security.js';
+import { hashPassword } from '../utils/password.js';
+import {
+  getAllUsers,
+  getUserById,
+  createUser as dbCreateUser,
+  updateUserRole as dbUpdateUserRole,
+  deleteUser as dbDeleteUser,
+  getAdminCount,
+  updateUserPassword as dbUpdateUserPassword,
+} from '../db/user-queries.js';
+import { roleExists, getRoleNameById } from '../db/role-queries.js';
+import { ValidationError, NotFoundError, AuthError } from '../utils/errors.js';
+
+// Username validation: alphanumeric only, 3-15 characters
+const USERNAME_REGEX = /^[a-zA-Z0-9]{3,15}$/;
+
+// Postgres unique-violation SQLSTATE — surfaced when a username collides on insert.
+const PG_UNIQUE_VIOLATION = '23505';
+
+/**
+ * The single canonical role-name string used to identify the system admin role.
+ *
+ * NOTE: This constant exists because `middleware/auth.ts:isAdminUser` also
+ * compares against the bare string `'admin'` (and additionally checks
+ * `is_system_role`). The two checks have drifted apart: the auth middleware
+ * requires the system flag, while the last-admin guards in this service
+ * historically check only the name. This service preserves the previous
+ * behaviour exactly — see `routes/users.ts` pre-refactor — so the wire
+ * shape does not change. Centralising the literal here stops it from
+ * drifting further inside this file.
+ */
+const ADMIN_ROLE_NAME = 'admin';
+
+/**
+ * Minimal acting-user context the service needs for self-delete checks and
+ * structured audit logging. Matches the shape produced by `requireAuth`
+ * (see `middleware/auth.ts:AuthRequest['user']`) but the service is
+ * deliberately decoupled from the middleware type so it can be reused by
+ * non-HTTP callers (admin CLI, scheduled jobs, etc.).
+ */
+export interface ActingUser {
+  id: number;
+  username: string;
+}
+
+export class UserService {
+  constructor(private db: DB) {}
+
+  /**
+   * List users with pagination. Logs the audit event before returning so
+   * every read of the admin user table is traceable.
+   */
+  async listUsers(options: { limit: number; offset: number }, acting: ActingUser): Promise<UserPublic[]> {
+    const users = await getAllUsers(this.db, options);
+    logger.info('Admin listed users', {
+      adminId: acting.id,
+      adminUsername: acting.username,
+      count: users.length,
+      limit: options.limit,
+      offset: options.offset,
+    });
+    return users;
+  }
+
+  /**
+   * Fetch a single user by ID. Throws `NotFoundError` if the user does not
+   * exist so the route shim can surface a 404 without further branching.
+   */
+  async getUserById(userId: number, acting: ActingUser): Promise<UserPublic> {
+    const user = await getUserById(this.db, userId);
+    if (!user) {
+      throw new NotFoundError('User not found');
+    }
+
+    logger.info('Admin retrieved user details', {
+      adminId: acting.id,
+      adminUsername: acting.username,
+      targetUserId: userId,
+      targetUsername: user.username,
+    });
+
+    return user;
+  }
+
+  /**
+   * Create a new user. Owns all input validation: username shape, password
+   * strength, and the existence of the target role. Maps the Postgres
+   * unique-violation error from the underlying `createUser` query to a
+   * `ValidationError` so the HTTP layer can return a 400 with a stable
+   * message.
+   */
+  async createUser(
+    data: { username?: string; password?: string; roleId: number },
+    acting: ActingUser,
+  ): Promise<UserPublic> {
+    const { username, password, roleId } = data;
+
+    if (!username || !password) {
+      throw new ValidationError('Username and password are required');
+    }
+
+    if (!USERNAME_REGEX.test(username)) {
+      throw new ValidationError('Username must be alphanumeric and 3-15 characters long');
+    }
+
+    const passwordError = validatePasswordStrength(password);
+    if (passwordError) {
+      throw new ValidationError(passwordError);
+    }
+
+    if (!Number.isInteger(roleId)) {
+      throw new ValidationError('role_id is required and must be a valid integer');
+    }
+
+    if (!(await roleExists(this.db, roleId))) {
+      throw new ValidationError('Invalid role_id: role does not exist');
+    }
+
+    const passwordHash = await hashPassword(password);
+
+    let newUser: UserPublic;
+    try {
+      newUser = await dbCreateUser(this.db, username, passwordHash, roleId);
+    } catch (error: unknown) {
+      if (isUniqueViolation(error)) {
+        throw new ValidationError('Username already exists');
+      }
+      throw error;
+    }
+
+    logger.info('Admin created new user', {
+      adminId: acting.id,
+      adminUsername: acting.username,
+      newUserId: newUser.id,
+      newUsername: newUser.username,
+      newUserRoleId: newUser.role_id,
+      newUserRoleName: newUser.role_name,
+    });
+
+    return newUser;
+  }
+
+  /**
+   * Change a user's role. Enforces the single shared last-admin invariant:
+   * if the target is currently an admin and the new role is not admin, the
+   * remaining admin count must be greater than one.
+   */
+  async updateUserRole(userId: number, roleId: number, acting: ActingUser): Promise<UserPublic> {
+    const targetUser = await getUserById(this.db, userId);
+    if (!targetUser) {
+      throw new NotFoundError('User not found');
+    }
+
+    const newRoleName = await getRoleNameById(this.db, roleId);
+    if (!newRoleName) {
+      throw new ValidationError('Invalid role_id: role does not exist');
+    }
+
+    await this.assertNotLastAdmin(targetUser.role_name, newRoleName);
+
+    await dbUpdateUserRole(this.db, userId, roleId);
+
+    const updatedUser = await getUserById(this.db, userId);
+
+    logger.info('Admin updated user role', {
+      adminId: acting.id,
+      adminUsername: acting.username,
+      targetUserId: userId,
+      targetUsername: updatedUser!.username,
+      oldRoleName: targetUser.role_name,
+      newRoleId: roleId,
+    });
+
+    return updatedUser!;
+  }
+
+  /**
+   * Reset a user's password. The caller (client) generates the new password
+   * and submits it; the service validates strength and stores a fresh hash.
+   *
+   * The user-existence check fires before password validation so the joint
+   * case (missing user + invalid password) still surfaces 404 first,
+   * preserving the pre-refactor wire shape exactly.
+   */
+  async resetPassword(userId: number, newPassword: unknown, acting: ActingUser): Promise<UserPublic> {
+    const targetUser = await getUserById(this.db, userId);
+    if (!targetUser) {
+      throw new NotFoundError('User not found');
+    }
+
+    if (typeof newPassword !== 'string' || newPassword.length === 0) {
+      throw new ValidationError('New password is required');
+    }
+
+    const passwordError = validatePasswordStrength(newPassword);
+    if (passwordError) {
+      throw new ValidationError(passwordError);
+    }
+
+    const passwordHash = await hashPassword(newPassword);
+    await dbUpdateUserPassword(this.db, userId, passwordHash);
+
+    logger.info('Admin reset user password', {
+      adminId: acting.id,
+      adminUsername: acting.username,
+      targetUserId: userId,
+      targetUsername: targetUser.username,
+    });
+
+    return targetUser;
+  }
+
+  /**
+   * Delete a user. Enforces two safety guards:
+   * 1. Self-delete: an admin cannot delete their own account.
+   * 2. Last-admin: an admin whose removal would leave zero admins is rejected.
+   * Both guards throw typed errors; the route shim surfaces them via the
+   * shared error handler.
+   */
+  async deleteUser(userId: number, acting: ActingUser): Promise<void> {
+    if (userId === acting.id) {
+      throw new AuthError('Cannot delete your own account', 403);
+    }
+
+    const targetUser = await getUserById(this.db, userId);
+    if (!targetUser) {
+      throw new NotFoundError('User not found');
+    }
+
+    await this.assertNotLastAdmin(targetUser.role_name, null);
+
+    const deleted = await dbDeleteUser(this.db, userId);
+    if (!deleted) {
+      throw new NotFoundError('User not found');
+    }
+
+    logger.info('Admin deleted user', {
+      adminId: acting.id,
+      adminUsername: acting.username,
+      deletedUserId: userId,
+      deletedUsername: targetUser.username,
+      deletedUserRoleName: targetUser.role_name,
+    });
+  }
+
+  /**
+   * Single canonical implementation of the "at least one admin remains"
+   * invariant. Both `updateUserRole` and `deleteUser` delegate here so the
+   * rule exists in exactly one place in the source tree.
+   *
+   * Pass `nextRoleName === null` for delete flows (any non-admin role
+   * suffices after the row is gone).
+   */
+  private async assertNotLastAdmin(currentRoleName: string, nextRoleName: string | null): Promise<void> {
+    const isCurrentlyAdmin = currentRoleName === ADMIN_ROLE_NAME;
+    const demotingFromAdmin = isCurrentlyAdmin && nextRoleName !== ADMIN_ROLE_NAME;
+    const removingLastAdmin = isCurrentlyAdmin && nextRoleName === null;
+
+    if (!demotingFromAdmin && !removingLastAdmin) {
+      return;
+    }
+
+    const adminCount = await getAdminCount(this.db);
+    if (adminCount <= 1) {
+      const message = removingLastAdmin
+        ? 'Cannot delete the last admin user'
+        : 'Cannot demote the last admin user';
+      throw new AuthError(message, 403);
+    }
+  }
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+  const e = error as { code?: unknown; message?: unknown };
+  if (e.code === PG_UNIQUE_VIOLATION) {
+    return true;
+  }
+  return typeof e.message === 'string' && e.message.includes('duplicate key');
+}


### PR DESCRIPTION
## Summary

Extracts a `UserService` from `routes/users.ts` so every server domain has its service (Auth, Movie, Theater, Scraper, SystemInfo, **User**). Closes #1215.

### Changes (3 atomic commits)

1. **`refactor(server): add UserService for admin user CRUD`** (`733a51d`) — adds the new service and its 36 unit tests. The route is intentionally untouched in this commit so the new service can be reviewed in isolation.
2. **`refactor(server): route users.ts through UserService`** (`9f3308e`) — rewrites the route as a 94-LOC thin shim (was 396) that only parses IDs, applies the limit clamp, instantiates the service, and forwards typed errors via `next(error)`.
3. **`docs(server): document UserService in architecture`** (`751b377`) — adds the service to the tree and documents the single-source-of-truth invariant.

### Acceptance criteria (from #1215)

- [x] `server/src/services/user-service.ts` exists with the listed interface (listUsers / getUserById / createUser / updateUserRole / resetPassword / deleteUser); **100%** covered by unit tests against a fake `DB` (module-level mocks of `db/*-queries`, same pattern as `auth-service.test.ts`).
- [x] `routes/users.ts` is **94 LOC** and contains zero business logic (no `hashPassword`, no `validatePasswordStrength`, no admin-count check).
- [x] The "at least one admin remains" invariant lives in exactly one place: `assertNotLastAdmin` in `user-service.ts:262`. `updateUserRole` and `deleteUser` both delegate to it. `grep -rn getAdminCount server/src --include='*.ts' | grep -v test` returns **one call site** (plus the definition in `db/user-queries.ts`).
- [x] All 58 existing route tests in `routes/users.test.ts` still pass **without modification** — the wire shape is preserved end-to-end.
- [x] `cd server && npx tsc --noEmit` clean.
- [x] `cd server && npm run test:coverage` passes thresholds (923 server tests, 100% coverage on `user-service.ts`).

### Pattern followed

Mirrors the existing service pattern (`AuthService`, `MovieService`, `TheaterService`, `ScraperService`):

- constructor takes `db: DB`
- methods are `async`
- errors are typed (`ValidationError`, `NotFoundError`, `AuthError`) and routed via `next(error)` in the shim
- structured admin-action audit logs live in the service so every mutation is traced regardless of caller (HTTP route, admin CLI, scheduled job — see `ActingUser` docstring)

### Implementation notes

- **Self-delete guard** moved into the service (`user-service.ts:226`): `userId === acting.id` throws `AuthError('Cannot delete your own account', 403)`.
- **`resetPassword` order-of-checks preserved**: the user-existence check (404) still fires before password validation (400), so the joint case (bad password + non-existent user) keeps returning 404, matching pre-refactor behavior exactly. A new test locks this in.
- **Role-name drift** between `middleware/auth.ts:isAdminUser` (checks `is_system_role`) and the service (checks bare `'admin'`) is documented in a NOTE comment on `ADMIN_ROLE_NAME` but **not** fixed — issue framed this as "consider," and the wire shape must not change.
- **No dependency changes**, no migrations, no breaking changes. Pure refactor.

### Local verification (mirrors pre-push hook + CI)

- `tsc --noEmit` clean in all three workspaces (server, scraper, client)
- Server: 923/923 tests pass; `user-service.ts` 100% covered
- Scraper: 244/244 tests pass