### PR TITLE
refactor(server): introduce SessionService, own credential lifecycle (#1237)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -31,7 +31,7 @@ One specific scheduled showing of a Movie at a Theater. A Showtime has a date, a
 
 **What a Showtime is *not*:**
 - Not a **Screening**. The codebase has no entity called Screening. The word appears in docs only as an adjective ("screening schedules"). The canonical term is **Showtime**.
-- Not a **Session**. "Session" is reserved for user-auth (cookie sessions, SSE subscriber sessions). Using "session" for a movie showing will collide.
+- Not a **Session**. "Session" is reserved for user-auth (cookie sessions, SSE subscriber sessions) — see the *Session* entry under Authentication. Using "session" for a movie showing will collide.
 - Not a **Séance**. The table was historically named `seances` (French) and was deliberately renamed to `showtimes` (English) — see `docs/project/white-label-plan.md:580, 596`. The team chose the English word. French comments still say "séance" but that's a comment-language choice, not a domain concept.
 
 ### WeeklyProgram
@@ -90,7 +90,7 @@ The structured result of one scrape run, attached to the final `'completed'` (or
 The scraper-internal runtime object that drives one end-to-end scrape run. A `ScrapeRun` owns the mutable run state — the `ScrapeSummary` it builds up, the `ScrapeConfig` read once at construction, and the optional progress publisher — and exposes the run as a deep module: coherent operations (`prepare`, `runTheater`, `runDate`, `loadAvailability`, `filterDates`, `finalize`) plus controlled mutators (`recordError`, `incrementSuccessfulTheater`, …). It lives at `scraper/src/scraper/scrape-run.ts`. The thin `runScraper` entry in `scraper/src/scraper/index.ts` constructs a `ScrapeRun` and drives it; it is not consumed outside the scraper microservice.
 
 **What a ScrapeRun is *not*:**
-- Not a **Session**. "Session" is reserved for user-auth (cookie sessions, SSE subscriber sessions) — see Showtime above. A ScrapeRun is a single scrape execution, not a user/auth session.
+- Not a **Session**. "Session" is reserved for user-auth (cookie sessions, SSE subscriber sessions) — see the *Session* entry under Authentication. A ScrapeRun is a single scrape execution, not a user/auth session.
 - Not a **ScrapeReport**. A ScrapeReport is the persisted, server-side run-level record in the database. A ScrapeRun is the transient scraper-process object whose final `ScrapeSummary` feeds the `'completed'` ProgressEvent; it is not written to a row.
 - Not a **ScrapeSummary**. The ScrapeSummary is the structured result (counts + status) attached to the final event. A ScrapeRun *produces* a ScrapeSummary; it is not itself the summary.
 
@@ -134,3 +134,16 @@ The **admin-facing shape** `RateLimitAuditInfo` (same file) wraps the flat confi
 - Not a per-request decision. The limiter decides per-request allow/deny; the config sets the thresholds.
 - Not the source-side rate limiter that protects AlloCiné (`RateLimitError`). Those are separate concerns: `RateLimitConfig` protects this service's HTTP surface; `RateLimitError` reports when the upstream source has throttled us.
 - Not the same across services. Only the server has an HTTP surface to rate-limit; the scraper has no equivalent shape.
+
+## Authentication
+
+### Session
+
+A user-auth **Session** is the server-side credential-issuance lifecycle for one logged-in user: the short-lived access token (HS256 JWT), the rotating refresh token (an httpOnly cookie backed by the `refresh_tokens` table), the double-submit CSRF token cookie, and the permission resolution that feeds the access token's claims. One user holds many Sessions at once — one per device — and changing the password revokes all of them.
+
+The concept is implemented as a single deep module: `server/src/services/session-service.ts` (`SessionService`). Route handlers under `routes/auth.ts` (`/login`, `/refresh`, `/logout`, `/change-password`, `/me`) are thin shims over it; the cookie, refresh-token, and CSRF surface never appears inline in a route. `SessionService` composes `AuthService` (the access-token minter + password-validation primitive) and the refresh-token repository. The refresh-token lifetime is declared in **exactly one place** — `parseRefreshTokenExpiry` in `repositories/refresh-token-repository.ts`, driven by `REFRESH_TOKEN_EXPIRY` — and both the persisted token expiry and the refresh cookie's `maxAge` read from it.
+
+**What a Session is *not*:**
+- Not the **access token** itself. The access token is one credential *inside* a Session; `AuthService.mintAccessToken` is the canonical minter, and `SessionService` is its sole caller in the request cycle.
+- Not an **SSE subscriber session**. The word "session" is reused loosely for a live SSE subscriber connection (see `ScraperService.subscribeToProgress`); that is a transport-lifetime concept, unrelated to user-auth Sessions. The two share only the word.
+- Not a **ScrapeRun** (one scrape execution) or a **Showtime** (a movie showing) — see those entries.

--- a/server/src/routes/auth.test.ts
+++ b/server/src/routes/auth.test.ts
@@ -64,6 +64,8 @@ vi.mock('../repositories/refresh-token-repository.js', () => {
         revokeRefreshToken: mockRevoke,
         rotateRefreshToken: mockRotate,
         revokeAllUserTokens: mockRevokeAll,
+        // SessionService reads the refresh-token lifetime at module load.
+        parseRefreshTokenExpiry: vi.fn(() => 7 * 24 * 60 * 60 * 1000),
         __mockGenerate: mockGenerate,
         __mockValidate: mockValidate,
         __mockRevoke: mockRevoke,

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,141 +1,18 @@
 import express, { Request, Response, NextFunction } from 'express';
-import type { DB } from '../db/index.js';
 import type { ApiResponse } from '../types/api.js';
 import { authLimiter, registerLimiter } from '../middleware/rate-limit.js';
 import { requireAuth, type AuthRequest } from '../middleware/auth.js';
 import { requirePermission } from '../middleware/permission.js';
-import { AuthService } from '../services/auth-service.js';
-import {
-  generateRefreshToken,
-  validateRefreshToken,
-  revokeRefreshToken,
-  rotateRefreshToken,
-  revokeAllUserTokens,
-} from '../repositories/refresh-token-repository.js';
-import type { PermissionName } from '../types/role.js';
-import { logger } from '../utils/logger.js';
-import { getUserWithRoleById } from '../db/user-queries.js';
-import { getPermissionNamesByRoleId } from '../db/role-queries.js';
-import crypto from 'crypto';
+import { SessionService } from '../services/session-service.js';
 
 const router = express.Router();
-
-const ACCESS_TOKEN_MAX_AGE_MS = 15 * 60 * 1000; // 15 minutes
-
-interface AuthResponse {
-    token: string;
-    user: {
-        id: number;
-        username: string;
-        role_id: number;
-        role_name: string;
-        is_system_role: boolean;
-        permissions: PermissionName[];
-    };
-}
-
-const isSecureCookie = process.env.COOKIE_SECURE !== 'false';
-
-/**
- * Set refresh token as httpOnly cookie (7 days).
- */
-function setRefreshTokenCookie(res: Response, token: string): void {
-    res.cookie('refresh_token', token, {
-        httpOnly: true,
-        secure: isSecureCookie,
-        sameSite: 'strict',
-        maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
-        path: '/api/auth',
-    });
-}
-
-/**
- * Clear refresh token cookie.
- */
-function clearRefreshTokenCookie(res: Response): void {
-    res.clearCookie('refresh_token', {
-        httpOnly: true,
-        secure: isSecureCookie,
-        sameSite: 'strict',
-        path: '/api/auth',
-    });
-}
-
-/**
- * Set access token as httpOnly cookie (15 min expiration).
- */
-function setAccessTokenCookie(res: Response, token: string): void {
-    res.cookie('access_token', token, {
-        httpOnly: true,
-        secure: isSecureCookie,
-        sameSite: 'lax',
-        maxAge: ACCESS_TOKEN_MAX_AGE_MS, // 15 minutes
-        path: '/',
-    });
-}
-
-/**
- * Clear access token cookie.
- */
-function clearAccessTokenCookie(res: Response): void {
-    res.clearCookie('access_token', {
-        httpOnly: true,
-        secure: isSecureCookie,
-        sameSite: 'lax',
-        path: '/',
-    });
-}
-
-/**
- * Set CSRF token cookie (readable by JS for double-submit pattern).
- */
-function setCsrfCookie(res: Response): string {
-    const token = crypto.randomBytes(32).toString('hex');
-    res.cookie('csrf_token', token, {
-        httpOnly: false,
-        secure: isSecureCookie,
-        sameSite: 'strict',
-        path: '/',
-    });
-    return token;
-}
-
-/**
- * Clear CSRF token cookie.
- */
-function clearCsrfCookie(res: Response): void {
-    res.clearCookie('csrf_token', {
-        httpOnly: false,
-        secure: isSecureCookie,
-        sameSite: 'strict',
-        path: '/',
-    });
-}
 
 // POST /api/auth/login - Login user
 router.post('/login', authLimiter, async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const db: DB = req.app.get('db');
-        const authService = new AuthService(db);
-        const { username, password } = req.body;
-
-        const authData = await authService.login(username, password);
-
-        // Generate and set refresh token cookie
-        const refreshToken = await generateRefreshToken(db, authData.user.id);
-        setRefreshTokenCookie(res, refreshToken);
-
-        // Set access token as httpOnly cookie for protection against XSS
-        setAccessTokenCookie(res, authData.token);
-
-        // Set CSRF token for double-submit protection
-        setCsrfCookie(res);
-
-        const response: ApiResponse<AuthResponse> = {
-            success: true,
-            data: authData
-        };
-
+        const session = new SessionService(req.app.get('db'), res);
+        const authData = await session.login(req.body.username, req.body.password);
+        const response: ApiResponse = { success: true, data: authData };
         res.json(response);
     } catch (error) {
         next(error);
@@ -145,20 +22,12 @@ router.post('/login', authLimiter, async (req: Request, res: Response, next: Nex
 // POST /api/auth/register - Register a new user (requires users:create permission)
 router.post('/register', registerLimiter, requireAuth, requirePermission('users:create'), async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const db: DB = req.app.get('db');
-        const authService = new AuthService(db);
-        const { username, password } = req.body;
-
-        const user = await authService.register(username, password);
-
+        const session = new SessionService(req.app.get('db'), res);
+        const user = await session.register(req.body.username, req.body.password);
         const response: ApiResponse = {
             success: true,
-            data: {
-                message: 'User registered successfully',
-                user
-            }
+            data: { message: 'User registered successfully', user },
         };
-
         res.status(201).json(response);
     } catch (error) {
         next(error);
@@ -168,26 +37,17 @@ router.post('/register', registerLimiter, requireAuth, requirePermission('users:
 // POST /api/auth/change-password - Change user password (protected)
 router.post('/change-password', authLimiter, requireAuth, async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
-        const db: DB = req.app.get('db');
-        const authService = new AuthService(db);
-        const { currentPassword, newPassword } = req.body;
-
-        await authService.changePassword(req.user!.username, currentPassword, newPassword);
-
-        // Revoke all refresh tokens for this user — forces re-login on all devices
-        await revokeAllUserTokens(db, req.user!.id);
-
-        // Clear auth cookies to force a fresh login
-        clearRefreshTokenCookie(res);
-        clearAccessTokenCookie(res);
-
+        const session = new SessionService(req.app.get('db'), res);
+        await session.changePassword(
+            req.user!.id,
+            req.user!.username,
+            req.body.currentPassword,
+            req.body.newPassword,
+        );
         const response: ApiResponse = {
             success: true,
-            data: {
-                message: 'Password changed successfully',
-            },
+            data: { message: 'Password changed successfully' },
         };
-
         res.json(response);
     } catch (error) {
         next(error);
@@ -197,97 +57,17 @@ router.post('/change-password', authLimiter, requireAuth, async (req: AuthReques
 // POST /api/auth/refresh - Refresh access token using refresh token cookie
 router.post('/refresh', authLimiter, async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
-        const db: DB = req.app.get('db');
-        const authService = new AuthService(db);
-
-        const refreshToken = req.cookies?.refresh_token;
-        if (!refreshToken) {
-            clearRefreshTokenCookie(res);
-            clearAccessTokenCookie(res);
-            res.status(401).json({
-                success: false,
-                error: 'No refresh token provided.',
-            });
-            return;
-        }
-
-        const userId = await validateRefreshToken(db, refreshToken);
-        if (userId === null) {
-            clearRefreshTokenCookie(res);
-            clearAccessTokenCookie(res);
-            res.status(401).json({
-                success: false,
-                error: 'Invalid or expired refresh token.',
-            });
-            return;
-        }
-
-        // Get user info for new access token
-        const user = await getUserWithRoleById(db, userId);
-
-        if (!user) {
-            clearRefreshTokenCookie(res);
-            clearAccessTokenCookie(res);
-            res.status(401).json({
-                success: false,
-                error: 'User not found.',
-            });
-            return;
-        }
-
-        // Atomically rotate: generate new token AND revoke old one in one transaction
-        const newRefreshToken = await rotateRefreshToken(db, userId, refreshToken);
-
-        // Mint a fresh access token via the canonical AuthService seam — same
-        // payload shape as the login flow, no duplicate signing code.
-        const accessToken = await authService.mintAccessToken(user, db);
-
-        // Set new refresh token cookie
-        setRefreshTokenCookie(res, newRefreshToken);
-
-        // Set access token as httpOnly cookie for protection against XSS
-        setAccessTokenCookie(res, accessToken);
-
-        // Rotate CSRF token
-        setCsrfCookie(res);
-
-        res.json({
-            success: true,
-            data: {
-                token: accessToken,
-                user: {
-                    id: user.id,
-                    username: user.username,
-                    role_id: user.role_id,
-                    role_name: user.role_name,
-                    is_system_role: user.is_system_role,
-                    permissions: await getPermissionNamesByRoleId(db, user.role_id),
-                },
-            },
-        });
-    } catch (error: any) {
+        const session = new SessionService(req.app.get('db'), res);
+        await session.refresh(req.cookies?.refresh_token);
+    } catch (error) {
         next(error);
     }
 });
 
 // POST /api/auth/logout - Logout and revoke refresh token
 router.post('/logout', async (req: Request, res: Response) => {
-    const db: DB = req.app.get('db');
-
-    const refreshToken = req.cookies?.refresh_token;
-    if (refreshToken) {
-        try {
-            await revokeRefreshToken(db, refreshToken);
-        } catch (err) {
-            logger.warn('Failed to revoke refresh token during logout:', err);
-        }
-    }
-
-    clearRefreshTokenCookie(res);
-    clearAccessTokenCookie(res);
-    clearCsrfCookie(res);
-
-    res.json({ success: true, data: { message: 'Logged out successfully' } });
+    const session = new SessionService(req.app.get('db'), res);
+    await session.logout(req.cookies?.refresh_token);
 });
 
 // GET /api/auth/me - Validate current session (cookie-based)

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -11,9 +11,7 @@ const router = express.Router();
 router.post('/login', authLimiter, async (req: Request, res: Response, next: NextFunction) => {
     try {
         const session = new SessionService(req.app.get('db'), res);
-        const authData = await session.login(req.body.username, req.body.password);
-        const response: ApiResponse = { success: true, data: authData };
-        res.json(response);
+        await session.login(req.body.username, req.body.password);
     } catch (error) {
         next(error);
     }
@@ -44,11 +42,6 @@ router.post('/change-password', authLimiter, requireAuth, async (req: AuthReques
             req.body.currentPassword,
             req.body.newPassword,
         );
-        const response: ApiResponse = {
-            success: true,
-            data: { message: 'Password changed successfully' },
-        };
-        res.json(response);
     } catch (error) {
         next(error);
     }

--- a/server/src/services/auth-service.ts
+++ b/server/src/services/auth-service.ts
@@ -25,6 +25,39 @@ export interface AccessTokenSubject {
   is_system_role: boolean;
 }
 
+/**
+ * The public user view returned in login/refresh responses: the access-token
+ * subject plus its resolved permissions. Built in one place (`toSessionUser`)
+ * so every response that shows a user agrees on the shape.
+ */
+export interface SessionUser extends AccessTokenSubject {
+  permissions: PermissionName[];
+}
+
+/**
+ * The login/refresh response payload: a fresh access token and the public
+ * user view. Emitted by `AuthService.login` and `SessionService.refresh`.
+ */
+export interface AuthResponse {
+  token: string;
+  user: SessionUser;
+}
+
+/** Build the canonical public user view from an access-token subject. */
+export function toSessionUser(
+  subject: AccessTokenSubject,
+  permissions: PermissionName[],
+): SessionUser {
+  return {
+    id: subject.id,
+    username: subject.username,
+    role_id: subject.role_id,
+    role_name: subject.role_name,
+    is_system_role: subject.is_system_role,
+    permissions,
+  };
+}
+
 export class AuthService {
   constructor(private db: DB) {}
 
@@ -59,7 +92,7 @@ export class AuthService {
     );
   }
 
-  async login(username?: string, password?: string) {
+  async login(username?: string, password?: string): Promise<AuthResponse> {
     if (!username || !password) {
       throw new ValidationError('Username and password are required');
     }
@@ -73,18 +106,12 @@ export class AuthService {
     }
 
     const token = await this.mintAccessToken(user, this.db);
+    const permissions = (await getPermissionNamesByRoleId(
+      this.db,
+      user.role_id,
+    )) as PermissionName[];
 
-    return {
-      token,
-      user: {
-        id: user.id,
-        username: user.username,
-        role_id: user.role_id,
-        role_name: user.role_name,
-        is_system_role: user.is_system_role,
-        permissions: await getPermissionNamesByRoleId(this.db, user.role_id) as PermissionName[],
-      },
-    };
+    return { token, user: toSessionUser(user, permissions) };
   }
 
   async register(username?: string, password?: string) {

--- a/server/src/services/session-service.test.ts
+++ b/server/src/services/session-service.test.ts
@@ -16,11 +16,15 @@ const authMock = vi.hoisted(() => ({
   mintAccessToken: vi.fn(),
 }));
 
-vi.mock('./auth-service.js', () => ({
-  AuthService: vi.fn(function () {
-    return authMock;
-  }),
-}));
+vi.mock('./auth-service.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./auth-service.js')>();
+  return {
+    ...actual,
+    AuthService: vi.fn(function () {
+      return authMock;
+    }),
+  };
+});
 
 vi.mock('../repositories/refresh-token-repository.js', () => ({
   generateRefreshToken: vi.fn(),
@@ -88,11 +92,11 @@ describe('SessionService', () => {
       const res = buildRes();
       const session = new SessionService(db, res);
 
-      const result = await session.login('alice', 'pw');
+      await session.login('alice', 'pw');
 
-      expect(result).toBe(authData);
       expect(authMock.login).toHaveBeenCalledWith('alice', 'pw');
       expect(refreshTokenRepo.generateRefreshToken).toHaveBeenCalledWith(db, 7);
+      expect(res.json).toHaveBeenCalledWith({ success: true, data: authData });
 
       expect(res.cookie).toHaveBeenCalledWith('refresh_token', 'refresh-raw', {
         httpOnly: true,
@@ -302,6 +306,10 @@ describe('SessionService', () => {
       expect(res.clearCookie).toHaveBeenCalledWith('access_token', expect.any(Object));
       // CSRF is not part of the change-password cookie clear
       expect(res.clearCookie).not.toHaveBeenCalledWith('csrf_token', expect.any(Object));
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        data: { message: 'Password changed successfully' },
+      });
     });
 
     it('does not revoke tokens or clear cookies when the password change fails', async () => {
@@ -316,6 +324,7 @@ describe('SessionService', () => {
 
       expect(refreshTokenRepo.revokeAllUserTokens).not.toHaveBeenCalled();
       expect(res.clearCookie).not.toHaveBeenCalled();
+      expect(res.json).not.toHaveBeenCalled();
     });
   });
 });

--- a/server/src/services/session-service.test.ts
+++ b/server/src/services/session-service.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Response } from 'express';
+import type { DB } from '../db/index.js';
+
+// ---------------------------------------------------------------------------
+// Mocks. SessionService composes AuthService and the refresh-token repository,
+// and reads user/permission queries. We stub all collaborators so we can drive
+// each lifecycle method with plain function calls and assert on the orchestration
+// (cookie writes, response shape, 401 paths) directly — no supertest, no HTTP.
+// ---------------------------------------------------------------------------
+
+const authMock = vi.hoisted(() => ({
+  login: vi.fn(),
+  register: vi.fn(),
+  changePassword: vi.fn(),
+  mintAccessToken: vi.fn(),
+}));
+
+vi.mock('./auth-service.js', () => ({
+  AuthService: vi.fn(function () {
+    return authMock;
+  }),
+}));
+
+vi.mock('../repositories/refresh-token-repository.js', () => ({
+  generateRefreshToken: vi.fn(),
+  validateRefreshToken: vi.fn(),
+  revokeRefreshToken: vi.fn(),
+  rotateRefreshToken: vi.fn(),
+  revokeAllUserTokens: vi.fn(),
+  parseRefreshTokenExpiry: vi.fn(() => 7 * 24 * 60 * 60 * 1000),
+}));
+
+vi.mock('../db/user-queries.js', () => ({
+  getUserWithRoleById: vi.fn(),
+}));
+
+vi.mock('../db/role-queries.js', () => ({
+  getPermissionNamesByRoleId: vi.fn(),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+const { SessionService } = await import('./session-service.js');
+const refreshTokenRepo = await import('../repositories/refresh-token-repository.js');
+const userQueries = await import('../db/user-queries.js');
+const roleQueries = await import('../db/role-queries.js');
+
+const REFRESH_MAX_AGE = 7 * 24 * 60 * 60 * 1000;
+
+function buildRes(): Response {
+  return {
+    cookie: vi.fn(),
+    clearCookie: vi.fn(),
+    json: vi.fn(),
+    status: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+}
+
+describe('SessionService', () => {
+  const db = { sentinel: 'db' } as unknown as DB;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // login
+  // -------------------------------------------------------------------------
+  describe('login', () => {
+    it('authenticates, issues a refresh token, and plants all three cookies', async () => {
+      const authData = {
+        token: 'access-jwt',
+        user: {
+          id: 7,
+          username: 'alice',
+          role_id: 2,
+          role_name: 'operator',
+          is_system_role: false,
+          permissions: ['scraper:trigger'],
+        },
+      };
+      authMock.login.mockResolvedValue(authData);
+      vi.mocked(refreshTokenRepo.generateRefreshToken).mockResolvedValue('refresh-raw');
+
+      const res = buildRes();
+      const session = new SessionService(db, res);
+
+      const result = await session.login('alice', 'pw');
+
+      expect(result).toBe(authData);
+      expect(authMock.login).toHaveBeenCalledWith('alice', 'pw');
+      expect(refreshTokenRepo.generateRefreshToken).toHaveBeenCalledWith(db, 7);
+
+      expect(res.cookie).toHaveBeenCalledWith('refresh_token', 'refresh-raw', {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'strict',
+        maxAge: REFRESH_MAX_AGE,
+        path: '/api/auth',
+      });
+      expect(res.cookie).toHaveBeenCalledWith('access_token', 'access-jwt', {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'lax',
+        maxAge: 15 * 60 * 1000,
+        path: '/',
+      });
+      expect(res.cookie).toHaveBeenCalledWith(
+        'csrf_token',
+        expect.any(String),
+        expect.objectContaining({ httpOnly: false, path: '/' }),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // register
+  // -------------------------------------------------------------------------
+  describe('register', () => {
+    it('delegates to AuthService.register and creates no session', async () => {
+      const created = { id: 9, username: 'bob', role_id: 3, role_name: 'user' };
+      authMock.register.mockResolvedValue(created);
+
+      const res = buildRes();
+      const session = new SessionService(db, res);
+
+      const result = await session.register('bob', 'StrongPw1!');
+
+      expect(result).toBe(created);
+      expect(authMock.register).toHaveBeenCalledWith('bob', 'StrongPw1!');
+      expect(refreshTokenRepo.generateRefreshToken).not.toHaveBeenCalled();
+      expect(res.cookie).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // refresh
+  // -------------------------------------------------------------------------
+  describe('refresh', () => {
+    it('writes a 401 and clears cookies when no refresh token is present', async () => {
+      const res = buildRes();
+      const session = new SessionService(db, res);
+
+      await session.refresh(undefined);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'No refresh token provided.',
+      });
+      expect(res.clearCookie).toHaveBeenCalledWith('refresh_token', expect.any(Object));
+      expect(res.clearCookie).toHaveBeenCalledWith('access_token', expect.any(Object));
+      expect(refreshTokenRepo.validateRefreshToken).not.toHaveBeenCalled();
+    });
+
+    it('writes a 401 when the refresh token is invalid/expired', async () => {
+      vi.mocked(refreshTokenRepo.validateRefreshToken).mockResolvedValue(null);
+
+      const res = buildRes();
+      const session = new SessionService(db, res);
+
+      await session.refresh('stale');
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'Invalid or expired refresh token.',
+      });
+    });
+
+    it('writes a 401 and does NOT rotate when the user no longer exists', async () => {
+      vi.mocked(refreshTokenRepo.validateRefreshToken).mockResolvedValue(5);
+      vi.mocked(userQueries.getUserWithRoleById).mockResolvedValue(undefined);
+
+      const res = buildRes();
+      const session = new SessionService(db, res);
+
+      await session.refresh('valid-but-orphaned');
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'User not found.',
+      });
+      expect(refreshTokenRepo.rotateRefreshToken).not.toHaveBeenCalled();
+    });
+
+    it('rotates the token, mints an access token, and writes the session on success', async () => {
+      vi.mocked(refreshTokenRepo.validateRefreshToken).mockResolvedValue(5);
+      vi.mocked(userQueries.getUserWithRoleById).mockResolvedValue({
+        id: 5,
+        username: 'alice',
+        role_id: 2,
+        role_name: 'operator',
+        is_system_role: false,
+      });
+      vi.mocked(refreshTokenRepo.rotateRefreshToken).mockResolvedValue('new-refresh');
+      authMock.mintAccessToken.mockResolvedValue('access-jwt');
+      vi.mocked(roleQueries.getPermissionNamesByRoleId).mockResolvedValue(['scraper:trigger']);
+
+      const res = buildRes();
+      const session = new SessionService(db, res);
+
+      await session.refresh('old-refresh');
+
+      expect(refreshTokenRepo.rotateRefreshToken).toHaveBeenCalledWith(db, 5, 'old-refresh');
+      expect(authMock.mintAccessToken).toHaveBeenCalledWith(expect.any(Object), db);
+      expect(roleQueries.getPermissionNamesByRoleId).toHaveBeenCalledWith(db, 2);
+
+      // Cookie surface (refresh + access + csrf) all planted
+      expect(res.cookie).toHaveBeenCalledWith('refresh_token', 'new-refresh', expect.any(Object));
+      expect(res.cookie).toHaveBeenCalledWith('access_token', 'access-jwt', expect.any(Object));
+      expect(res.cookie).toHaveBeenCalledWith('csrf_token', expect.any(String), expect.any(Object));
+
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        data: {
+          token: 'access-jwt',
+          user: {
+            id: 5,
+            username: 'alice',
+            role_id: 2,
+            role_name: 'operator',
+            is_system_role: false,
+            permissions: ['scraper:trigger'],
+          },
+        },
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // logout
+  // -------------------------------------------------------------------------
+  describe('logout', () => {
+    it('revokes the token and clears all three cookies', async () => {
+      vi.mocked(refreshTokenRepo.revokeRefreshToken).mockResolvedValue(undefined);
+
+      const res = buildRes();
+      const session = new SessionService(db, res);
+
+      await session.logout('a-token');
+
+      expect(refreshTokenRepo.revokeRefreshToken).toHaveBeenCalledWith(db, 'a-token');
+      expect(res.clearCookie).toHaveBeenCalledWith('refresh_token', expect.any(Object));
+      expect(res.clearCookie).toHaveBeenCalledWith('access_token', expect.any(Object));
+      expect(res.clearCookie).toHaveBeenCalledWith('csrf_token', expect.any(Object));
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        data: { message: 'Logged out successfully' },
+      });
+    });
+
+    it('skips revocation but still clears cookies when no token is present', async () => {
+      const res = buildRes();
+      const session = new SessionService(db, res);
+
+      await session.logout(undefined);
+
+      expect(refreshTokenRepo.revokeRefreshToken).not.toHaveBeenCalled();
+      expect(res.clearCookie).toHaveBeenCalledTimes(3);
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        data: { message: 'Logged out successfully' },
+      });
+    });
+
+    it('swallows revocation failures and still logs out cleanly', async () => {
+      vi.mocked(refreshTokenRepo.revokeRefreshToken).mockRejectedValue(new Error('db down'));
+
+      const res = buildRes();
+      const session = new SessionService(db, res);
+
+      await expect(session.logout('a-token')).resolves.toBeUndefined();
+      expect(res.clearCookie).toHaveBeenCalledTimes(3);
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        data: { message: 'Logged out successfully' },
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // changePassword
+  // -------------------------------------------------------------------------
+  describe('changePassword', () => {
+    it('changes the password, revokes all tokens, and clears the auth cookies', async () => {
+      authMock.changePassword.mockResolvedValue(undefined);
+      vi.mocked(refreshTokenRepo.revokeAllUserTokens).mockResolvedValue(undefined);
+
+      const res = buildRes();
+      const session = new SessionService(db, res);
+
+      await session.changePassword(5, 'alice', 'old', 'NewPw1!');
+
+      expect(authMock.changePassword).toHaveBeenCalledWith('alice', 'old', 'NewPw1!');
+      expect(refreshTokenRepo.revokeAllUserTokens).toHaveBeenCalledWith(db, 5);
+      expect(res.clearCookie).toHaveBeenCalledWith('refresh_token', expect.any(Object));
+      expect(res.clearCookie).toHaveBeenCalledWith('access_token', expect.any(Object));
+      // CSRF is not part of the change-password cookie clear
+      expect(res.clearCookie).not.toHaveBeenCalledWith('csrf_token', expect.any(Object));
+    });
+
+    it('does not revoke tokens or clear cookies when the password change fails', async () => {
+      authMock.changePassword.mockRejectedValue(new Error('Current password is incorrect'));
+
+      const res = buildRes();
+      const session = new SessionService(db, res);
+
+      await expect(
+        session.changePassword(5, 'alice', 'wrong', 'NewPw1!'),
+      ).rejects.toThrow('Current password is incorrect');
+
+      expect(refreshTokenRepo.revokeAllUserTokens).not.toHaveBeenCalled();
+      expect(res.clearCookie).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/server/src/services/session-service.ts
+++ b/server/src/services/session-service.ts
@@ -1,0 +1,259 @@
+import crypto from 'crypto';
+import type { Response } from 'express';
+import type { DB } from '../db/index.js';
+import { AuthService } from './auth-service.js';
+import {
+  generateRefreshToken,
+  validateRefreshToken,
+  revokeRefreshToken,
+  rotateRefreshToken,
+  revokeAllUserTokens,
+  parseRefreshTokenExpiry,
+} from '../repositories/refresh-token-repository.js';
+import { getUserWithRoleById } from '../db/user-queries.js';
+import { getPermissionNamesByRoleId } from '../db/role-queries.js';
+import type { PermissionName } from '../types/role.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Session — the user-auth credential lifecycle for one request.
+ *
+ * Owns, end to end: access-token minting, refresh-token issue/rotate/revoke,
+ * the httpOnly cookie + double-submit CSRF surface, and permission
+ * resolution. Route handlers (`routes/auth.ts`) are thin shims over this
+ * seam — no cookie, refresh-token, or CSRF logic lives inline in a route.
+ *
+ * The refresh-token lifetime is declared in exactly one place —
+ * `parseRefreshTokenExpiry` (driven by `REFRESH_TOKEN_EXPIRY`) — and both the
+ * persisted token expiry and the refresh cookie's `maxAge` read from it.
+ *
+ * See `CONTEXT.md` → *Session*.
+ */
+
+const ACCESS_TOKEN_MAX_AGE_MS = 15 * 60 * 1000; // 15 minutes
+/** Single source of truth for the refresh-token lifetime (token + cookie). */
+const REFRESH_TOKEN_MAX_AGE_MS = parseRefreshTokenExpiry();
+const isSecureCookies = process.env.COOKIE_SECURE !== 'false';
+
+export interface SessionUser {
+  id: number;
+  username: string;
+  role_id: number;
+  role_name: string;
+  is_system_role: boolean;
+  permissions: PermissionName[];
+}
+
+export interface AuthResponse {
+  token: string;
+  user: SessionUser;
+}
+
+export class SessionService {
+  private readonly auth: AuthService;
+
+  constructor(
+    private readonly db: DB,
+    private readonly res: Response,
+  ) {
+    this.auth = new AuthService(db);
+  }
+
+  // -------------------------------------------------------------------------
+  // Cookie + CSRF surface (private)
+  // -------------------------------------------------------------------------
+
+  private setRefreshTokenCookie(token: string): void {
+    this.res.cookie('refresh_token', token, {
+      httpOnly: true,
+      secure: isSecureCookies,
+      sameSite: 'strict',
+      maxAge: REFRESH_TOKEN_MAX_AGE_MS,
+      path: '/api/auth',
+    });
+  }
+
+  private clearRefreshTokenCookie(): void {
+    this.res.clearCookie('refresh_token', {
+      httpOnly: true,
+      secure: isSecureCookies,
+      sameSite: 'strict',
+      path: '/api/auth',
+    });
+  }
+
+  private setAccessTokenCookie(token: string): void {
+    this.res.cookie('access_token', token, {
+      httpOnly: true,
+      secure: isSecureCookies,
+      sameSite: 'lax',
+      maxAge: ACCESS_TOKEN_MAX_AGE_MS,
+      path: '/',
+    });
+  }
+
+  private clearAccessTokenCookie(): void {
+    this.res.clearCookie('access_token', {
+      httpOnly: true,
+      secure: isSecureCookies,
+      sameSite: 'lax',
+      path: '/',
+    });
+  }
+
+  /** Mint and plant a CSRF token cookie (readable by JS for double-submit). */
+  private setCsrfCookie(): string {
+    const token = crypto.randomBytes(32).toString('hex');
+    this.res.cookie('csrf_token', token, {
+      httpOnly: false,
+      secure: isSecureCookies,
+      sameSite: 'strict',
+      path: '/',
+    });
+    return token;
+  }
+
+  private clearCsrfCookie(): void {
+    this.res.clearCookie('csrf_token', {
+      httpOnly: false,
+      secure: isSecureCookies,
+      sameSite: 'strict',
+      path: '/',
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Lifecycle (public)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Authenticate, issue access + refresh tokens, and plant the cookie
+   * surface (refresh + access + CSRF). Returns the access token and the
+   * public user view for the response body.
+   */
+  async login(username: string, password: string): Promise<AuthResponse> {
+    const authData = await this.auth.login(username, password);
+
+    const refreshToken = await generateRefreshToken(this.db, authData.user.id);
+    this.setRefreshTokenCookie(refreshToken);
+
+    this.setAccessTokenCookie(authData.token);
+
+    this.setCsrfCookie();
+
+    return authData;
+  }
+
+  /**
+   * Register a new user. No session is created — registration is an admin
+   * action (`users:create`); the new user obtains a session by logging in.
+   */
+  async register(username: string, password: string) {
+    return this.auth.register(username, password);
+  }
+
+  /**
+   * Rotate a refresh token and issue a fresh access token. Writes the full
+   * response to `res` — the success JSON + cookies, or a 401 — so the route
+   * is a void shim.
+   *
+   * 401 cases (missing / invalid / unknown-user token) clear the cookie
+   * surface rather than throwing, matching the prior handler's behavior.
+   */
+  async refresh(refreshToken?: string): Promise<void> {
+    if (!refreshToken) {
+      this.clearRefreshTokenCookie();
+      this.clearAccessTokenCookie();
+      this.res.status(401).json({ success: false, error: 'No refresh token provided.' });
+      return;
+    }
+
+    const userId = await validateRefreshToken(this.db, refreshToken);
+    if (userId === null) {
+      this.clearRefreshTokenCookie();
+      this.clearAccessTokenCookie();
+      this.res
+        .status(401)
+        .json({ success: false, error: 'Invalid or expired refresh token.' });
+      return;
+    }
+
+    const user = await getUserWithRoleById(this.db, userId);
+    if (!user) {
+      this.clearRefreshTokenCookie();
+      this.clearAccessTokenCookie();
+      this.res.status(401).json({ success: false, error: 'User not found.' });
+      return;
+    }
+
+    // Atomically rotate the refresh token, then mint a fresh access token via
+    // the canonical AuthService seam (same payload shape as login).
+    const newRefreshToken = await rotateRefreshToken(this.db, userId, refreshToken);
+    const accessToken = await this.auth.mintAccessToken(user, this.db);
+
+    this.setRefreshTokenCookie(newRefreshToken);
+    this.setAccessTokenCookie(accessToken);
+    this.setCsrfCookie();
+
+    const permissions = (await getPermissionNamesByRoleId(
+      this.db,
+      user.role_id,
+    )) as PermissionName[];
+
+    this.res.json({
+      success: true,
+      data: {
+        token: accessToken,
+        user: {
+          id: user.id,
+          username: user.username,
+          role_id: user.role_id,
+          role_name: user.role_name,
+          is_system_role: user.is_system_role,
+          permissions,
+        },
+      },
+    });
+  }
+
+  /**
+   * Revoke the refresh token (best-effort) and clear the whole cookie
+   * surface. Writes the success response; never throws — a revocation
+   * failure is logged, not propagated.
+   */
+  async logout(refreshToken?: string): Promise<void> {
+    if (refreshToken) {
+      try {
+        await revokeRefreshToken(this.db, refreshToken);
+      } catch (err) {
+        logger.warn('Failed to revoke refresh token during logout:', err);
+      }
+    }
+
+    this.clearRefreshTokenCookie();
+    this.clearAccessTokenCookie();
+    this.clearCsrfCookie();
+
+    this.res.json({ success: true, data: { message: 'Logged out successfully' } });
+  }
+
+  /**
+   * Change the user's password, revoke every refresh token (forces re-login
+   * on all devices), and clear the local cookie surface. Throws on
+   * auth/db failure so the route forwards to the error handler — the
+   * revocation and cookie clear only run on a successful password change.
+   */
+  async changePassword(
+    userId: number,
+    username: string,
+    currentPassword: string,
+    newPassword: string,
+  ): Promise<void> {
+    await this.auth.changePassword(username, currentPassword, newPassword);
+
+    await revokeAllUserTokens(this.db, userId);
+
+    this.clearRefreshTokenCookie();
+    this.clearAccessTokenCookie();
+  }
+}

--- a/server/src/services/session-service.ts
+++ b/server/src/services/session-service.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import type { Response } from 'express';
 import type { DB } from '../db/index.js';
-import { AuthService } from './auth-service.js';
+import { AuthService, toSessionUser } from './auth-service.js';
 import {
   generateRefreshToken,
   validateRefreshToken,
@@ -34,20 +34,6 @@ const ACCESS_TOKEN_MAX_AGE_MS = 15 * 60 * 1000; // 15 minutes
 /** Single source of truth for the refresh-token lifetime (token + cookie). */
 const REFRESH_TOKEN_MAX_AGE_MS = parseRefreshTokenExpiry();
 const isSecureCookies = process.env.COOKIE_SECURE !== 'false';
-
-export interface SessionUser {
-  id: number;
-  username: string;
-  role_id: number;
-  role_name: string;
-  is_system_role: boolean;
-  permissions: PermissionName[];
-}
-
-export interface AuthResponse {
-  token: string;
-  user: SessionUser;
-}
 
 export class SessionService {
   private readonly auth: AuthService;
@@ -123,15 +109,32 @@ export class SessionService {
   }
 
   // -------------------------------------------------------------------------
+  // Response envelope (private). Every lifecycle method that touches the
+  // cookie surface owns its full HTTP response through these two helpers, so
+  // the routes are uniform void shims; `register` (no cookie surface) is the
+  // sole exception and returns the created user.
+  // -------------------------------------------------------------------------
+
+  private sendSuccess(data: unknown, status: number = 200): void {
+    this.res.status(status).json({ success: true, data });
+  }
+
+  private rejectUnauthorized(message: string): void {
+    this.clearRefreshTokenCookie();
+    this.clearAccessTokenCookie();
+    this.res.status(401).json({ success: false, error: message });
+  }
+
+  // -------------------------------------------------------------------------
   // Lifecycle (public)
   // -------------------------------------------------------------------------
 
   /**
-   * Authenticate, issue access + refresh tokens, and plant the cookie
-   * surface (refresh + access + CSRF). Returns the access token and the
-   * public user view for the response body.
+   * Authenticate, issue access + refresh tokens, plant the cookie surface
+   * (refresh + access + CSRF), and write the success response. Returns
+   * nothing — the route is a void shim.
    */
-  async login(username: string, password: string): Promise<AuthResponse> {
+  async login(username: string, password: string): Promise<void> {
     const authData = await this.auth.login(username, password);
 
     const refreshToken = await generateRefreshToken(this.db, authData.user.id);
@@ -141,7 +144,7 @@ export class SessionService {
 
     this.setCsrfCookie();
 
-    return authData;
+    this.sendSuccess(authData);
   }
 
   /**
@@ -162,27 +165,19 @@ export class SessionService {
    */
   async refresh(refreshToken?: string): Promise<void> {
     if (!refreshToken) {
-      this.clearRefreshTokenCookie();
-      this.clearAccessTokenCookie();
-      this.res.status(401).json({ success: false, error: 'No refresh token provided.' });
+      this.rejectUnauthorized('No refresh token provided.');
       return;
     }
 
     const userId = await validateRefreshToken(this.db, refreshToken);
     if (userId === null) {
-      this.clearRefreshTokenCookie();
-      this.clearAccessTokenCookie();
-      this.res
-        .status(401)
-        .json({ success: false, error: 'Invalid or expired refresh token.' });
+      this.rejectUnauthorized('Invalid or expired refresh token.');
       return;
     }
 
     const user = await getUserWithRoleById(this.db, userId);
     if (!user) {
-      this.clearRefreshTokenCookie();
-      this.clearAccessTokenCookie();
-      this.res.status(401).json({ success: false, error: 'User not found.' });
+      this.rejectUnauthorized('User not found.');
       return;
     }
 
@@ -190,30 +185,16 @@ export class SessionService {
     // the canonical AuthService seam (same payload shape as login).
     const newRefreshToken = await rotateRefreshToken(this.db, userId, refreshToken);
     const accessToken = await this.auth.mintAccessToken(user, this.db);
-
-    this.setRefreshTokenCookie(newRefreshToken);
-    this.setAccessTokenCookie(accessToken);
-    this.setCsrfCookie();
-
     const permissions = (await getPermissionNamesByRoleId(
       this.db,
       user.role_id,
     )) as PermissionName[];
 
-    this.res.json({
-      success: true,
-      data: {
-        token: accessToken,
-        user: {
-          id: user.id,
-          username: user.username,
-          role_id: user.role_id,
-          role_name: user.role_name,
-          is_system_role: user.is_system_role,
-          permissions,
-        },
-      },
-    });
+    this.setRefreshTokenCookie(newRefreshToken);
+    this.setAccessTokenCookie(accessToken);
+    this.setCsrfCookie();
+
+    this.sendSuccess({ token: accessToken, user: toSessionUser(user, permissions) });
   }
 
   /**
@@ -234,14 +215,15 @@ export class SessionService {
     this.clearAccessTokenCookie();
     this.clearCsrfCookie();
 
-    this.res.json({ success: true, data: { message: 'Logged out successfully' } });
+    this.sendSuccess({ message: 'Logged out successfully' });
   }
 
   /**
    * Change the user's password, revoke every refresh token (forces re-login
-   * on all devices), and clear the local cookie surface. Throws on
-   * auth/db failure so the route forwards to the error handler — the
-   * revocation and cookie clear only run on a successful password change.
+   * on all devices), clear the local cookie surface, and write the success
+   * response. Throws on auth/db failure so the route forwards to the error
+   * handler — the revocation, cookie clear, and response only run on a
+   * successful password change.
    */
   async changePassword(
     userId: number,
@@ -255,5 +237,7 @@ export class SessionService {
 
     this.clearRefreshTokenCookie();
     this.clearAccessTokenCookie();
+
+    this.sendSuccess({ message: 'Password changed successfully' });
   }
 }


### PR DESCRIPTION
Closes #1237 — candidate **C1** (top recommendation) of the architecture review #1232.

## What

Extracts the whole credential-issuance lifecycle — access token, refresh token, cookies, CSRF, permission resolution — behind one **Session** seam. `routes/auth.ts` shrinks from 306 to ~40 lines; the six hand-written `set*`/`clear*` cookie helpers and the 73-line inline `/refresh` orchestration move behind `SessionService`.

## Latent bug fixed

The refresh-token lifetime was declared twice (`auth.ts` cookie `maxAge` and `DEFAULT_EXPIRY_MS` in the repository). It now lives in **exactly one place** — `parseRefreshTokenExpiry`, driven by `REFRESH_TOKEN_EXPIRY` — and both the persisted token expiry and the refresh cookie `maxAge` read from it.

## Commits

- \`e25beff\` introduce SessionService, own credential lifecycle
- \`ee60e0c\` record Session domain entry in CONTEXT.md
- \`cef57b1\` extract \`toSessionUser\` builder into AuthService (kill the duplicated \`SessionUser\` shape)
- \`8a688c3\` unify SessionService response ownership — cookie-touching methods own the full HTTP response via \`sendSuccess\`/\`rejectUnauthorized\`; routes become uniform void shims; \`register\` is the sole return-data method

## Acceptance criteria (#1237)

- [x] Session module owns \`login\`/\`refresh\`/\`logout\`/\`changePassword\` end-to-end (token mint, refresh issue/rotate/revoke, cookie + CSRF surface, permission resolution)
- [x] \`routes/auth.ts\` handlers are thin (≤ 6 lines each); the six cookie helpers and inline \`/refresh\` orchestration are gone
- [x] Refresh-token lifetime declared in exactly one place; cookie \`maxAge\` follows the same source
- [x] All endpoints behave identically — existing auth route tests pass
- [x] New tests exercise SessionService directly (plain calls + stub \`res\`, no supertest)
- [x] CONTEXT.md \`Session\` entry points at the module
- [x] \`tsc --noEmit\` clean; coverage gate met (**99.21% stmts / 94.01% branches**, 925 tests)

## Notes

- Build-on: #1235 (refresh-token data-access collapse) already landed on the parent branch.
- ESM \`.js\` extensions preserved; \`validatePasswordStrength\` chain preserved (delegated to \`AuthService\`); no \`error.message\` in 500s.