### PR TITLE
refactor(server): extract SSE transport into standalone bridge (#1236)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -145,5 +145,5 @@ The concept is implemented as a single deep module: `server/src/services/session
 
 **What a Session is *not*:**
 - Not the **access token** itself. The access token is one credential *inside* a Session; `AuthService.mintAccessToken` is the canonical minter, and `SessionService` is its sole caller in the request cycle.
-- Not an **SSE subscriber session**. The word "session" is reused loosely for a live SSE subscriber connection (see `ScraperService.subscribeToProgress`); that is a transport-lifetime concept, unrelated to user-auth Sessions. The two share only the word.
+- Not an **SSE subscriber session**. The word "session" is reused loosely for a live SSE subscriber connection (see `attachProgressStream` in `services/sse-bridge.ts`); that is a transport-lifetime concept, unrelated to user-auth Sessions. The two share only the word.
 - Not a **ScrapeRun** (one scrape execution) or a **Showtime** (a movie showing) — see those entries.

--- a/server/src/routes/scraper.test.ts
+++ b/server/src/routes/scraper.test.ts
@@ -3,10 +3,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import request from 'supertest';
 import express from 'express';
 import { TheaterNotFoundError } from '../utils/errors.js';
+import { progressTracker } from '../services/progress-tracker.js';
 
 const mockTriggerScrape = vi.fn();
 const mockGetStatus = vi.fn();
-const mockSubscribeToProgress = vi.fn();
+const mockAttachProgressStream = vi.fn();
 const mockPublishScheduleChange = vi.fn();
 
 let currentMockUser = { role_name: 'admin', is_system_role: true, permissions: [], id: 1, username: 'admin' };
@@ -18,11 +19,14 @@ vi.mock('../services/scraper-service.js', () => {
       return {
         triggerScrape: mockTriggerScrape,
         getStatus: mockGetStatus,
-        subscribeToProgress: mockSubscribeToProgress,
       };
     }),
   };
 });
+
+vi.mock('../services/sse-bridge.js', () => ({
+  attachProgressStream: mockAttachProgressStream,
+}));
 
 vi.mock('../db/internal/client.js', () => ({
   db: { query: vi.fn() }
@@ -191,6 +195,25 @@ describe('Routes - Scraper', () => {
       } finally {
         shouldRejectAuth = false;
       }
+    });
+  });
+
+  describe('GET /api/scraper/progress', () => {
+    it('wires the response to the SSE bridge with the progress tracker', async () => {
+      // The real bridge keeps the stream open; end res so supertest completes.
+      mockAttachProgressStream.mockImplementation((res: any) => {
+        res.end();
+        return vi.fn();
+      });
+
+      const app = await setupApp();
+      await request(app).get('/api/scraper/progress');
+
+      expect(mockAttachProgressStream).toHaveBeenCalledTimes(1);
+      const [resArg, sinkArg, onCloseArg] = mockAttachProgressStream.mock.calls[0];
+      expect(resArg).toBeDefined();
+      expect(sinkArg).toBe(progressTracker);
+      expect(typeof onCloseArg).toBe('function');
     });
   });
 

--- a/server/src/routes/scraper.ts
+++ b/server/src/routes/scraper.ts
@@ -5,6 +5,8 @@ import type { DB } from '../db/index.js';
 import { requireAuth, isAdminUser, type AuthRequest } from '../middleware/auth.js';
 import { scraperLimiter } from '../middleware/rate-limit.js';
 import { ScraperService } from '../services/scraper-service.js';
+import { attachProgressStream } from '../services/sse-bridge.js';
+import { progressTracker } from '../services/progress-tracker.js';
 import { AuthError, NotFoundError, ValidationError } from '../utils/errors.js';
 import { getScrapeReport } from '../db/report-queries.js';
 import { getPendingScrapeAttempts } from '../db/scrape-attempt-queries.js';
@@ -156,9 +158,7 @@ router.get('/status', scraperLimiter, requireAuth, async (req, res, next) => {
 // GET /api/scraper/progress - SSE endpoint for real-time progress
 router.get('/progress', scraperLimiter, (req, res, next) => {
   try {
-    const scraperService = scraperServiceFromRequest(req as AuthRequest);
-
-    const cleanup = scraperService.subscribeToProgress(res, () => {
+    const cleanup = attachProgressStream(res, progressTracker, () => {
       // Optional additional cleanup on route level if needed
     });
 

--- a/server/src/services/scraper-service.test.ts
+++ b/server/src/services/scraper-service.test.ts
@@ -12,9 +12,6 @@ vi.mock('./redis-client.js');
 vi.mock('./progress-tracker.js', () => ({
   progressTracker: {
     reset: vi.fn(),
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-    getListenerCount: vi.fn().mockReturnValue(1),
   },
 }));
 
@@ -111,23 +108,6 @@ describe('ScraperService', () => {
           pendingAttempts: [],
         },
       }));
-    });
-  });
-
-  describe('subscribeToProgress', () => {
-    it('should add listener and return cleanup function', () => {
-      const mockRes = { setHeader: vi.fn() };
-      const mockOnClose = vi.fn();
-      
-      const cleanup = scraperService.subscribeToProgress(mockRes, mockOnClose);
-      
-      expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Type', 'text/event-stream');
-      expect(progressTracker.addListener).toHaveBeenCalledWith(mockRes);
-      
-      cleanup();
-      
-      expect(progressTracker.removeListener).toHaveBeenCalledWith(mockRes);
-      expect(mockOnClose).toHaveBeenCalled();
     });
   });
 });

--- a/server/src/services/scraper-service.ts
+++ b/server/src/services/scraper-service.ts
@@ -3,7 +3,6 @@ import { progressTracker } from './progress-tracker.js';
 import { createScrapeReport, getLatestScrapeReport } from '../db/report-queries.js';
 import { getTheaters } from '../db/theater-queries.js';
 import type { DB } from '../db/index.js';
-import { logger } from '../utils/logger.js';
 import { TheaterNotFoundError } from '../utils/errors.js';
 import type { ScrapeAttempt } from '../db/scrape-attempt-queries.js';
 
@@ -84,25 +83,6 @@ export class ScraperService {
     return {
       isRunning: latestReport?.status === 'running',
       latestReport,
-    };
-  }
-
-  /**
-   * Subscribes an HTTP response stream to the progress tracker events.
-   */
-  subscribeToProgress(res: any, onClose: () => void) {
-    res.setHeader('Content-Type', 'text/event-stream');
-    res.setHeader('Cache-Control', 'no-cache');
-    res.setHeader('Connection', 'keep-alive');
-    res.setHeader('X-Accel-Buffering', 'no'); // Disable nginx buffering
-
-    progressTracker.addListener(res);
-    logger.info(`📡 SSE client connected (${progressTracker.getListenerCount()} total)`);
-
-    return () => {
-      progressTracker.removeListener(res);
-      logger.info(`📡 SSE client disconnected (${progressTracker.getListenerCount()} remaining)`);
-      onClose();
     };
   }
 }

--- a/server/src/services/sse-bridge.test.ts
+++ b/server/src/services/sse-bridge.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Response } from 'express';
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn() },
+}));
+
+import { logger } from '../utils/logger.js';
+import { attachProgressStream, type ProgressListenerSink } from './sse-bridge.js';
+
+function makeSink(count = 1): ProgressListenerSink {
+  return {
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    getListenerCount: vi.fn().mockReturnValue(count),
+  };
+}
+
+function makeRes() {
+  return { setHeader: vi.fn() } as unknown as Response;
+}
+
+describe('attachProgressStream', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sets the SSE transport headers on the response', () => {
+    attachProgressStream(makeRes(), makeSink());
+
+    const res = makeRes();
+    attachProgressStream(res, makeSink());
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/event-stream');
+    expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-cache');
+    expect(res.setHeader).toHaveBeenCalledWith('Connection', 'keep-alive');
+    expect(res.setHeader).toHaveBeenCalledWith('X-Accel-Buffering', 'no');
+  });
+
+  it('registers the response as a listener on the sink', () => {
+    const res = makeRes();
+    const sink = makeSink();
+
+    attachProgressStream(res, sink);
+
+    expect(sink.addListener).toHaveBeenCalledWith(res);
+    expect(sink.addListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs the connect line with the sink listener count', () => {
+    attachProgressStream(makeRes(), makeSink(3));
+
+    expect(logger.info).toHaveBeenCalledWith('📡 SSE client connected (3 total)');
+  });
+
+  it('returns a cleanup that removes the listener', () => {
+    const res = makeRes();
+    const sink = makeSink();
+    const cleanup = attachProgressStream(res, sink);
+
+    cleanup();
+
+    expect(sink.removeListener).toHaveBeenCalledWith(res);
+    expect(sink.removeListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs the disconnect line with the post-removal count on cleanup', () => {
+    const sink = makeSink(0);
+    const cleanup = attachProgressStream(makeRes(), sink);
+
+    cleanup();
+
+    expect(logger.info).toHaveBeenCalledWith('📡 SSE client disconnected (0 remaining)');
+  });
+
+  it('invokes onClose on cleanup when provided', () => {
+    const onClose = vi.fn();
+    const cleanup = attachProgressStream(makeRes(), makeSink(), onClose);
+
+    cleanup();
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not require onClose (no throw on cleanup)', () => {
+    const cleanup = attachProgressStream(makeRes(), makeSink());
+
+    expect(() => cleanup()).not.toThrow();
+  });
+});

--- a/server/src/services/sse-bridge.ts
+++ b/server/src/services/sse-bridge.ts
@@ -1,0 +1,43 @@
+import type { Response } from 'express';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Minimal listener surface the SSE bridge needs from a progress source.
+ * Implemented by {@link ProgressTracker} (`services/progress-tracker.ts`);
+ * stubbable in tests without a fake Express `res` or the tracker singleton.
+ */
+export interface ProgressListenerSink {
+  addListener(res: Response): void;
+  removeListener(res: Response): void;
+  getListenerCount(): number;
+}
+
+/**
+ * Attach an Express response as an SSE progress stream.
+ *
+ * Owns the transport detail — the SSE response headers and the add/remove
+ * listener lifecycle against `sink` — and returns a disconnect cleanup the
+ * caller wires to `req.on('close', ...)`. Extracted from `ScraperService` so
+ * the dispatcher stays single-concept (C4 of epic #1232). The API does not
+ * scrape: it fans `ProgressEvent`s from the Redis pub/sub bridge to SSE
+ * clients through this seam (`CONTEXT.md`).
+ */
+export function attachProgressStream(
+  res: Response,
+  sink: ProgressListenerSink,
+  onClose?: () => void,
+): () => void {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no'); // Disable nginx buffering
+
+  sink.addListener(res);
+  logger.info(`📡 SSE client connected (${sink.getListenerCount()} total)`);
+
+  return () => {
+    sink.removeListener(res);
+    logger.info(`📡 SSE client disconnected (${sink.getListenerCount()} remaining)`);
+    onClose?.();
+  };
+}


### PR DESCRIPTION
Closes #1236 (candidate **C4** of epic #1232).

## What

`ScraperService` bundled two unrelated concerns behind one class:

- **ScrapeJob dispatch** — `triggerScrape` / `triggerResume` / `getStatus` (validate theater → create ScrapeReport → reset tracker → publish job)
- **SSE transport** — `subscribeToProgress`: `text/event-stream` + `Cache-Control` + `Connection` + `X-Accel-Buffering` headers and the add/remove-listener lifecycle against `progressTracker`

They shared a module by name, not by concept. Extracted the transport into a standalone **`services/sse-bridge.ts`** whose `attachProgressStream(res, sink, onClose?)` owns the transport detail and returns a disconnect cleanup. `ScraperService` retains dispatch + status only.

## Why a sink interface

The bridge depends on a `ProgressListenerSink` interface (`addListener` / `removeListener` / `getListenerCount`), implemented by `ProgressTracker`. That makes the bridge unit-testable with a stub sink rather than a fake Express `res` or the tracker singleton (AC #4). Per `CONTEXT.md`, the API does not scrape — it fans `ProgressEvent`s from the Redis pub/sub bridge to SSE clients through this seam.

## Behavior preserved (no wire-format or route changes)

The `/api/scraper/progress` endpoint behaves identically:
- same four headers, same order
- same `📡 SSE client connected/disconnected (N total|remaining)` log lines
- cleanup still wired to `req.on('close')`
- route consumers unchanged (the route now calls the bridge directly with the `progressTracker` singleton)

`CONTEXT.md` SSE cross-reference updated from `ScraperService.subscribeToProgress` to `attachProgressStream` in `services/sse-bridge.ts`.

## Test

- New `sse-bridge.test.ts` (7 tests): headers, listener registration, connect/disconnect logging, cleanup removes listener, optional `onClose`.
- New `/progress` route test asserting the route wires `attachProgressStream` with the real `progressTracker`.
- Removed the now-obsolete `subscribeToProgress` unit test from `scraper-service.test.ts`.

## Verification

- `cd server && npx tsc --noEmit` — clean
- `cd scraper && npx tsc --noEmit` — clean
- `npm run test:coverage --workspace=allo-scrapper-server` — 939 tests pass; coverage 99.21% stmts / 94.01% branches, gate exit 0
- `npm run test:run --workspace=allo-scrapper-scraper` — 254 tests pass

## Notes

- Based on `refactor/1232-architecture-deepening` per the epic's branching note (same as #1239 / #1240); targets the same branch.
- No new dependencies. Did NOT deepen the remaining dispatcher into a single `dispatch(intent)` entry — explicitly marked speculative in #1232.