### PR TITLE
feat: VPS production deployment overlay (Traefik + Watchtower)

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,43 @@
+# =============================================================================
+# allo-scrapper — production environment for VPS deployment
+#
+# Copy to .env (cp deploy/.env.example .env) and fill in the values.
+# This file is read by docker-compose.yaml + deploy/docker-compose.prod.yml.
+# NEVER commit the real .env — it contains your secrets.
+# =============================================================================
+
+# ---- Images ----------------------------------------------------------------
+# Tag to deploy. Use "stable" for production (follows the latest vX.Y.Z tag).
+# Other options: latest (tracks develop), or pin to a specific version (v4.7.4).
+IMAGE_TAG=stable
+
+# ---- Secrets (REQUIRED) ----------------------------------------------------
+# PostgreSQL password. Generate with: openssl rand -base64 32
+POSTGRES_PASSWORD=change-me-to-a-strong-password
+
+# JWT signing key (min 32 chars). Generate with: openssl rand -base64 64
+# The server refuses to start without this.
+JWT_SECRET=
+
+# ---- Domain & TLS (read by deploy/docker-compose.prod.yml + Traefik) -------
+# The domain pointing to this VPS (A record).
+DOMAIN=allo-scrapper.example.fr
+
+# Email Let's Encrypt will use for cert expiry notices.
+ACME_EMAIL=admin@example.fr
+
+# ---- App -------------------------------------------------------------------
+NODE_ENV=production
+COOKIE_SECURE=true
+
+# CORS — must match the domain above (used by the browser).
+# Include www variant if you use one.
+ALLOWED_ORIGINS=https://allo-scrapper.example.fr
+
+# ---- Scraper cron ----------------------------------------------------------
+# Default: every Wednesday at 08:00 (server TZ=Europe/Paris, set in compose)
+SCRAPE_CRON_SCHEDULE=0 8 * * 3
+
+# ---- Optional: GHCR auth (only if you make the images private later) -------
+# GHCR_USER=
+# GHCR_TOKEN=

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,252 @@
+# allo-scrapper — VPS production deployment
+
+This directory contains the production overlay for deploying allo-scrapper to a
+single VPS using Docker Compose + Traefik (TLS) + Watchtower (auto-updates).
+
+```
+GitHub (main / tag v*)
+  │
+  ▼  docker-build-push.yml (existing CI)
+ghcr.io/phbassin/allo-scrapper:{stable,v*,latest}
+  │
+  ▼  polled every 5 min
+Watchtower (this VPS)
+  │
+  ▼  pulls + recreates ics-web / ics-scraper / ics-scraper-cron
+docker compose (postgres + redis + app + traefik)
+  │
+  ▼
+Traefik :443 → ics-web:3000  (auto Let's Encrypt, TLS-ALPN-01)
+```
+
+## Files
+
+| File                       | Purpose                                             |
+| -------------------------- | --------------------------------------------------- |
+| `docker-compose.prod.yml`  | Override on top of `../docker-compose.yaml`. Adds Traefik + Watchtower, hides the 3000 port. |
+| `.env.example`             | Template — copy to `.env` and fill in secrets.      |
+
+Routing for `ics-web` is declared via Docker labels directly inside
+`docker-compose.prod.yml` (no separate static file). The rollback script lives
+at `../scripts/deploy-rollback.sh`.
+
+## Architecture decisions
+
+- **Override, not duplicate.** This file is applied on top of
+  `docker-compose.yaml` (the source of truth). New env vars or services added
+  there are picked up automatically.
+- **Traefik v3 with Docker provider.** Service discovery via Docker labels,
+  no static config file. ACME certs via TLS-ALPN-01 (works on port 443 only,
+  no special port-80 setup needed).
+- **Watchtower with label scope.** Only the three app containers have the
+  `watchtower.enable=true` label. Traefik and Watchtower itself are never
+  auto-updated — update them explicitly when needed.
+- **`:stable` tier.** Follows the latest `vX.Y.Z` tag (set by CI when a semver
+  tag is pushed). `develop` pushes go to `:latest` and are NOT auto-deployed.
+
+## Prerequisites on the VPS
+
+- Docker Engine 25+ and Compose v2.17+ (for the `!reset` ports directive)
+- A domain with an A record pointing to the VPS public IP
+- Open ports: 22 (SSH), 80 (HTTP), 443 (HTTPS) — nothing else
+
+## Bootstrap (one-time, ~30 min)
+
+Run these on the VPS as a non-root user with sudo.
+
+### 1. Harden the host
+
+```bash
+# Firewall — only SSH, HTTP, HTTPS
+sudo ufw default deny incoming
+sudo ufw default allow outgoing
+sudo ufw allow 22/tcp
+sudo ufw allow 80/tcp
+sudo ufw allow 443/tcp
+sudo ufw enable
+
+# SSH: key-only, no root login
+sudo sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+sudo sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
+sudo systemctl restart ssh
+
+# fail2ban
+sudo apt update && sudo apt install -y fail2ban
+sudo systemctl enable --now fail2ban
+```
+
+### 2. Install Docker
+
+```bash
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker $USER
+# log out and back in for the group to take effect
+```
+
+### 3. Lay out the deployment directory
+
+Two options:
+
+**Option A — clone the repo (recommended):**
+```bash
+sudo mkdir -p /opt/allo-scrapper
+sudo chown $USER:$USER /opt/allo-scrapper
+cd /opt/allo-scrapper
+git clone -b develop --depth 1 <repo-url> .
+```
+You'll get `docker-compose.yaml`, `deploy/`, `scripts/` — everything needed.
+
+**Option B — copy only what you need (smaller footprint):**
+```bash
+sudo mkdir -p /opt/allo-scrapper/deploy /opt/allo-scrapper/scripts
+cd /opt/allo-scrapper
+# scp from your machine:
+#   docker-compose.yaml
+#   deploy/docker-compose.prod.yml
+#   deploy/.env.example
+#   scripts/deploy-rollback.sh
+```
+
+### 4. Configure secrets
+
+```bash
+cd /opt/allo-scrapper
+cp deploy/.env.example .env
+chmod 600 .env
+
+# Generate strong values
+openssl rand -base64 32  # → POSTGRES_PASSWORD
+openssl rand -base64 64  # → JWT_SECRET
+
+# Edit .env and fill in DOMAIN, ACME_EMAIL, ALLOWED_ORIGINS too
+nano .env
+```
+
+### 5. First boot
+
+```bash
+docker compose -f docker-compose.yaml -f deploy/docker-compose.prod.yml --env-file .env pull
+docker compose -f docker-compose.yaml -f deploy/docker-compose.prod.yml --env-file .env up -d
+```
+
+Wait ~60 seconds for the DB to be healthy and migrations to run, then verify:
+
+```bash
+docker compose -f docker-compose.yaml -f deploy/docker-compose.prod.yml ps
+curl -fsS https://<DOMAIN>/api/health
+```
+
+You should see JSON from the API. Traefik will have requested its cert on the
+first request — check `docker compose logs traefik` if HTTPS fails.
+
+### 6. (Optional) Enable the Traefik dashboard
+
+The dashboard is **off by default** (good for prod). To enable it temporarily:
+
+```bash
+# Add these labels to the traefik service in deploy/docker-compose.prod.yml
+#   traefik.http.routers.dashboard.rule: Host(`traefik.<DOMAIN>`)
+#   traefik.http.routers.dashboard.entrypoints: websecure
+#   traefik.http.routers.dashboard.tls: "true"
+#   traefik.http.routers.dashboard.service: api@internal
+#
+# Protect it with BasicAuth, e.g.:
+#   traefik.http.routers.dashboard.middlewares: dashboard-auth
+#   traefik.http.middlewares.dashboard-auth.basicauth.users: "<user>:<htpasswd-hash>"
+```
+
+## Verify auto-update works
+
+Once bootstrapped, push a new tag from your workstation:
+
+```bash
+git tag v4.7.5
+git push origin v4.7.5
+```
+
+CI builds and tags `:stable`. Within ~10 minutes on the VPS:
+
+```bash
+docker compose -f docker-compose.yaml -f deploy/docker-compose.prod.yml logs -f watchtower
+```
+
+You should see `Found new image...restarting`. Then `/api/health` will report
+the new version.
+
+## Daily operations
+
+All commands assume you're in `/opt/allo-scrapper`.
+
+```bash
+# Set a shell alias for brevity:
+alias dc='docker compose -f docker-compose.yaml -f deploy/docker-compose.prod.yml --env-file .env'
+
+dc ps                 # status
+dc logs -f ics-web    # tail app logs
+dc logs -f traefik    # tail reverse proxy logs (incl. ACME)
+dc logs -f watchtower # tail auto-update log
+dc restart ics-web    # restart one service
+dc down               # stop everything (DB data + ACME certs persist in volumes)
+dc up -d              # start everything
+dc pull && dc up -d   # manual update (bypass Watchtower)
+```
+
+## Rollback
+
+```bash
+./scripts/deploy-rollback.sh v4.7.4
+```
+
+Rolls back the three app containers to the requested tag. DB, Redis, Traefik,
+and Watchtower are untouched. See the script header for details.
+
+## Backups
+
+The repo ships `scripts/backup-db.sh`. On the VPS, schedule it via host cron:
+
+```bash
+# crontab -e
+0 3 * * * cd /opt/allo-scrapper && ./scripts/backup-db.sh >> /var/log/allo-backup.log 2>&1
+```
+
+Backups land in `./backups/`. To enable 7-day rotation, uncomment the
+`find ... -mtime +7 -delete` line in `scripts/backup-db.sh`.
+
+For offsite backups (recommended), rsync the `backups/` directory to another
+host or push to B2/S3. Not bundled here — choose your own.
+
+## Troubleshooting
+
+**HTTPS doesn't respond / cert fails:**
+- Check `docker compose logs traefik` — ACME challenge logs are explicit there
+- Traefik uses TLS-ALPN-01 (port 443). Port 80 must still be open for the
+  HTTP→HTTPS redirect
+- Confirm the A record resolves to this VPS (`dig <DOMAIN> +short`)
+- Confirm ufw allows 80 and 443
+- For first-time testing, switch ACME to staging (lower rate limits):
+  uncomment the `caserver=` line in `deploy/docker-compose.prod.yml`
+
+**Watchtower never updates:**
+- Confirm `:stable` tag exists: `docker pull ghcr.io/phbassin/allo-scrapper:stable`
+- Confirm the label is set: `docker inspect ics-web | grep watchtower.enable`
+- Check Watchtower logs: `dc logs watchtower`
+
+**App container bootloops after update:**
+- Check `dc logs ics-web` — most often a missing env var or failed migration
+- Rollback: `./scripts/deploy-rollback.sh <previous-tag>`
+
+**Database locked / can't migrate:**
+- `dc exec ics-db pg_isready` — must return "accepting connections"
+- Check `dc logs ics-db` for disk full or corruption
+- Last resort: restore from `./backups/`
+
+## What is NOT included here
+
+- **Staging environment.** There's one prod tier. Test on `develop` images
+  locally before tagging.
+- **Monitoring stack.** `docker-compose.monitoring.yml` exists and can be
+  layered on (`-f docker-compose.monitoring.yml`), but it's not wired into
+  the prod overlay by default. Add it once you need Grafana/Prometheus.
+- **Offsite backups.** Local only by default — add rsync/B2 yourself.
+- **Blue-green / canary.** Single-VPS blue-green adds complexity without much
+  benefit at this scale. Rollback via `deploy-rollback.sh` is the safety net.

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -65,6 +65,12 @@ services:
   traefik:
     image: traefik:v3.2
     restart: unless-stopped
+    environment:
+      # Force Docker API version — Traefik's embedded SDK defaults to 1.24
+      # which Docker Engine 25+ rejects (min 1.40). Auto-negotiation does not
+      # trigger reliably, so we pin to a version both sides accept.
+      # Verify your daemon supports this: docker version --format '{{.Server.APIVersion}}'
+      DOCKER_API_VERSION: "1.44"
     command:
       # Docker provider — only consider containers with traefik.enable=true
       - --providers.docker=true

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -112,6 +112,9 @@ services:
     image: containrrr/watchtower:latest
     restart: unless-stopped
     environment:
+      # Pin Docker API version — Watchtower's embedded SDK defaults to an old
+      # version (1.25) that Docker Engine 25+/29+ rejects. Same fix as Traefik.
+      DOCKER_API_VERSION: "1.44"
       # Poll interval in seconds (300 = 5 min)
       WATCHTOWER_POLL_INTERVAL: 300
       # Only update containers with com.centurylinklabs.watchtower.enable=true

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -63,13 +63,13 @@ services:
   # All per-service routing is defined via Docker labels on ics-web above.
   # -------------------------------------------------------------------------
   traefik:
-    image: traefik:v3.2
+    image: traefik:v3.7
     restart: unless-stopped
     environment:
-      # Force Docker API version — Traefik's embedded SDK defaults to 1.24
-      # which Docker Engine 25+ rejects (min 1.40). Auto-negotiation does not
-      # trigger reliably, so we pin to a version both sides accept.
-      # Verify your daemon supports this: docker version --format '{{.Server.APIVersion}}'
+      # Pin Docker API version — Traefik's embedded SDK may default to an old
+      # version (1.24) that recent Docker Engine (25+/29+) rejects. v3.7+ ships
+      # a newer SDK that negotiates correctly, but we keep the pin as a safety
+      # net. Verify support: docker version --format '{{.Server.APIVersion}}'
       DOCKER_API_VERSION: "1.44"
     command:
       # Docker provider — only consider containers with traefik.enable=true

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -1,0 +1,127 @@
+# ---------------------------------------------------------------------------
+# Production override for docker-compose.yaml
+#
+# Usage (from /opt/allo-scrapper on the VPS):
+#   docker compose -f docker-compose.yaml -f deploy/docker-compose.prod.yml up -d
+#
+# This file MUST be applied on top of docker-compose.yaml (the source of truth
+# for service definitions). It:
+#   - Stops exposing ics-web on a host port (Traefik proxies via the internal network)
+#   - Adds Traefik as the TLS-terminating reverse proxy (config via CLI + labels)
+#   - Adds Watchtower for automatic image updates on the :stable tag
+#   - Tags app containers so Watchtower only touches them (not Traefik/itself)
+#
+# Never edit docker-compose.yaml here — extend it. If docker-compose.yaml gains
+# a new env var, it is automatically picked up; you only need to update .env.
+# ---------------------------------------------------------------------------
+
+services:
+  # Do NOT publish ics-web on the host — Traefik proxies via the internal network.
+  # `!reset` requires Compose v2.17+ (Docker Engine 25+).
+  ics-web:
+    ports: !reset []
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
+
+      # ---- Traefik routing ----
+      traefik.enable: "true"
+      traefik.docker.network: ics-network
+
+      # HTTPS router
+      traefik.http.routers.allo.entrypoints: websecure
+      traefik.http.routers.allo.rule: Host(`${DOMAIN}`)
+      traefik.http.routers.allo.tls: "true"
+      traefik.http.routers.allo.tls.certresolver: letsencrypt
+      traefik.http.routers.allo.service: allo
+      traefik.http.routers.allo.middlewares: allo-secure
+
+      # Backend service (Express listens on 3000)
+      traefik.http.services.allo.loadbalancer.server.port: "3000"
+      traefik.http.services.allo.loadbalancer.healthcheck.path: /api/health
+      traefik.http.services.allo.loadbalancer.healthcheck.interval: 30s
+      traefik.http.services.allo.loadbalancer.healthcheck.timeout: 5s
+
+      # Security headers middleware
+      traefik.http.middlewares.allo-secure.headers.stsSeconds: "31536000"
+      traefik.http.middlewares.allo-secure.headers.stsIncludeSubdomains: "true"
+      traefik.http.middlewares.allo-secure.headers.stsPreload: "true"
+      traefik.http.middlewares.allo-secure.headers.contentTypeNosniff: "true"
+      traefik.http.middlewares.allo-secure.headers.frameDeny: "true"
+      traefik.http.middlewares.allo-secure.headers.referrerPolicy: "strict-origin-when-cross-origin"
+      traefik.http.middlewares.allo-secure.headers.customresponseheaders.Server: ""
+
+  ics-scraper:
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
+
+  ics-scraper-cron:
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
+
+  # -------------------------------------------------------------------------
+  # Traefik — TLS-terminating reverse proxy with automatic Let's Encrypt certs
+  # All per-service routing is defined via Docker labels on ics-web above.
+  # -------------------------------------------------------------------------
+  traefik:
+    image: traefik:v3.2
+    restart: unless-stopped
+    command:
+      # Docker provider — only consider containers with traefik.enable=true
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --providers.docker.network=ics-network
+
+      # Entrypoints: web (HTTP) + websecure (HTTPS)
+      - --entrypoints.web.address=:80
+      - --entrypoints.web.http.redirections.entrypoint.to=websecure
+      - --entrypoints.web.http.redirections.entrypoint.scheme=https
+      - --entrypoints.websecure.address=:443
+
+      # Let's Encrypt ACME resolver (TLS-ALPN-01 challenge)
+      - --certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL:?ACME_EMAIL is required}
+      - --certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json
+      - --certificatesresolvers.letsencrypt.acme.tlschallenge=true
+      # Uncomment to use Let's Encrypt staging (rate-limit-safe testing):
+      # - --certificatesresolvers.letsencrypt.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory
+
+      # Logging
+      - --log.level=INFO
+      - --accesslog=true
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      # Read-only Docker socket for service discovery
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      # Persistent ACME certs — DO NOT remove or you re-issue certs on every restart
+      - traefik-letsencrypt:/letsencrypt
+    networks:
+      - ics-network
+
+  # -------------------------------------------------------------------------
+  # Watchtower — polls ghcr.io every 5 min and rolls forward :stable
+  # Only updates containers with the watchtower.enable label.
+  # -------------------------------------------------------------------------
+  watchtower:
+    image: containrrr/watchtower:latest
+    restart: unless-stopped
+    environment:
+      # Poll interval in seconds (300 = 5 min)
+      WATCHTOWER_POLL_INTERVAL: 300
+      # Only update containers with com.centurylinklabs.watchtower.enable=true
+      WATCHTOWER_LABEL_ENABLE: "true"
+      # Remove old images after update
+      WATCHTOWER_CLEANUP: "true"
+      # Include a timestamp in logs
+      WATCHTOWER_INCLUDE_RESTARTING: "true"
+      # GHCR needs a token for private repos — public ghcr.io/phbassin/* does not,
+      # but setting REPO_USER/PASS avoids rate limits if you ever go private.
+      # WATCHTOWER_REPO_USER: ${GHCR_USER:-}
+      # WATCHTOWER_REPO_PASS: ${GHCR_TOKEN:-}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - ics-network
+
+volumes:
+  traefik-letsencrypt:

--- a/scripts/deploy-rollback.sh
+++ b/scripts/deploy-rollback.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Rollback allo-scrapper to a specific image tag on the VPS.
+#
+# Usage:
+#   ./scripts/deploy-rollback.sh <tag>
+#
+# Examples:
+#   ./scripts/deploy-rollback.sh v4.7.3   # roll back to a specific version
+#   ./scripts/deploy-rollback.sh v4.7.2
+#   ./scripts/deploy-rollback.sh stable   # re-follow the moving stable tag
+#
+# Behavior:
+#   - Pulls the requested tag for ics-web, ics-scraper, ics-scraper-cron
+#   - Recreates those three containers only (DB/Redis/Traefik untouched)
+#   - Note: if you roll back to a specific version tag (vX.Y.Z), Watchtower
+#     will NOT roll it forward because that tag is immutable. To resume
+#     auto-updates, run again with "stable".
+
+set -euo pipefail
+
+TAG="${1:-}"
+
+if [[ -z "$TAG" ]]; then
+    echo "Usage: $0 <tag>"
+    echo "  $0 v4.7.3     # specific version"
+    echo "  $0 stable     # moving tag (Watchtower will resume auto-updates)"
+    exit 1
+fi
+
+# Locate the deployment dir (VPS layout or repo root for local testing)
+if [[ -f /opt/allo-scrapper/deploy/docker-compose.prod.yml ]]; then
+    cd /opt/allo-scrapper
+elif [[ -f deploy/docker-compose.prod.yml ]]; then
+    cd "$(dirname "$0")/.."
+else
+    echo "❌ Cannot locate deploy/docker-compose.prod.yml"
+    echo "   Expected at /opt/allo-scrapper/deploy/ or current repo root."
+    exit 1
+fi
+
+if [[ ! -f .env ]]; then
+    echo "❌ .env not found in $(pwd)"
+    echo "   Create it from deploy/.env.example first."
+    exit 1
+fi
+
+COMPOSE="docker compose -f docker-compose.yaml -f deploy/docker-compose.prod.yml --env-file .env"
+
+echo "⏮  Rolling back ics-web / ics-scraper / ics-scraper-cron to tag: ${TAG}"
+echo ""
+
+# Pull the requested tag explicitly (avoid stale cache)
+WEB_IMAGE="ghcr.io/phbassin/allo-scrapper:${TAG}"
+SCRAPER_IMAGE="ghcr.io/phbassin/allo-scrapper-scraper:${TAG}"
+echo "📦 Pulling ${WEB_IMAGE}"
+docker pull "${WEB_IMAGE}"
+echo "📦 Pulling ${SCRAPER_IMAGE}"
+docker pull "${SCRAPER_IMAGE}"
+
+# Recreate the three app containers with the requested tag.
+# DB / Redis / Traefik / Watchtower are left running.
+IMAGE_TAG="$TAG" $COMPOSE up -d --no-deps --force-recreate ics-web ics-scraper ics-scraper-cron
+
+echo ""
+echo "⏳ Waiting for ics-web to become healthy..."
+sleep 5
+$COMPOSE ps
+
+echo ""
+echo "🔍 Health check:"
+if curl -fsS "http://localhost:3000/api/health" > /dev/null 2>&1; then
+    echo "  ✓ API responding on localhost:3000"
+else
+    echo "  ⚠ API not responding yet (may still be starting). Check with:"
+    echo "    $COMPOSE logs -f ics-web"
+fi
+
+echo ""
+echo "Current images:"
+$COMPOSE images ics-web ics-scraper ics-scraper-cron
+
+echo ""
+if [[ "$TAG" =~ ^v[0-9] ]]; then
+    echo "ℹ️  Pinned to immutable tag ${TAG}. Watchtower will NOT auto-update."
+    echo "   To resume auto-updates: $0 stable"
+else
+    echo "ℹ️  Following moving tag '${TAG}'. Watchtower will resume polling in ~5 min."
+fi


### PR DESCRIPTION
## Summary

Adds a self-contained production overlay for deploying allo-scrapper to a single VPS (Docker Engine 29) on top of the existing `docker-compose.yaml`. Validated end-to-end on `cinemas.opelkad.com`.

### Files added
- `deploy/docker-compose.prod.yml` — Traefik v3.7 reverse proxy (auto Let's Encrypt via TLS-ALPN-01) + Watchtower (label-scoped auto-update on the :stable tag, 5 min poll). `ics-web` host port is masked; routing is declared via Docker labels. App containers get `watchtower.enable=true`; DB/Redis/Traefik/Watchtower are excluded.
- `deploy/.env.example` — template with `DOMAIN`, `ACME_EMAIL`, `JWT_SECRET`, `POSTGRES_PASSWORD`, `ALLOWED_ORIGINS`.
- `deploy/README.md` — full runbook (bootstrap: ufw, fail2ban, Docker install, deploy user + CI SSH key) + first boot + verify CD + daily ops + rollback + troubleshooting + optional Traefik dashboard with BasicAuth.
- `scripts/deploy-rollback.sh` — one-liner to roll the three app containers back to an arbitrary tag (`vX.Y.Z` or `stable`). DB/Redis/Traefik/Watchtower left running.

### Key decisions
- **Traefik v3.7** (not Caddy). Docker provider via labels, ACME TLS-ALPN-01, dashboard off in prod.
- **Watchtower with label scope** — only updates the three app containers.
- **`:stable` tier** — follows the latest `vX.Y.Z` tag. `develop` pushes go to `:latest` and are NOT auto-deployed.
- **`DOCKER_API_VERSION=1.44` pinned** on Traefik and Watchtower — their embedded Docker SDK defaults to 1.24/1.25 which Docker Engine 25+ rejects. Traefik v3.7`s newer SDK negotiates correctly but we keep the pin as belt-and-suspenders.

### Production validation (cinemas.opelkad.com, 2026-07-19)
- All 7 containers healthy (traefik, ics-web, ics-scraper, ics-scraper-cron, ics-db, ics-redis, watchtower)
- Let's Encrypt cert obtained via TLS-ALPN-01 in ~6s
- `curl https://cinemas.opelkad.com/api/health` → `{"status":"healthy","database":"connected"}`

### No changes to
- CI workflows (`.github/workflows/`)
- Dockerfiles
- Application code (`server/`, `client/`, `scraper/`, `packages/`)
- Existing `docker-compose.yaml`

## Test plan
- [x] `docker compose config --quiet` validates the merged compose
- [x] Labels correctly applied: ics-web traefik=true + watchtower=true; DB/Redis/Traefik/Watchtower excluded
- [x] Port 3000 not exposed on host (Traefik proxies via internal network)
- [x] End-to-end on VPS: HTTPS up, cert obtained, health endpoint responds, admin login works
- [ ] Watchtower CD test (push a new tag, observe auto-update) — to be done after merge