### PR TITLE
fix(ci): check skip-ci only in commit subject, not body

### DIFF
--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -18,10 +18,16 @@ jobs:
   create-version-tag:
     name: Create Version Tag
     runs-on: ubuntu-latest
-    # Skip the version-bump commit itself (it contains [skip ci])
-    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
 
     steps:
+      - name: Skip on version-bump commits (check subject only, not body)
+        run: |
+          SUBJECT="$(echo '${{ github.event.head_commit.message }}' | head -n 1)"
+          if echo "$SUBJECT" | grep -qE '\[(skip|no) ci\]'; then
+            echo "Skipping — version-bump commit detected (subject contains [skip ci])"
+            exit 78
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Problem

The `version-tag.yml` workflow was skipping pushes when the merge commit **body** contained `[skip ci]` as literal text — even when it was inside a PR template example.

**Root cause**: `if: ${{ !contains(github.event.head_commit.message, [skip ci]) }}` at the job level performs a naive substring match against the **full** commit message (subject + body).  GitHub convention reserves `[skip ci]` for the **subject line** only.

**Consequence**: PR #1245 (`chore(release): 4.7.4 → 4.8.0 …`) was merged to main. Its PR template body contained the literal string:
```
5. Commit `chore(release): bump version to v4.8.0 [skip ci]`
```
The workflow matched this and silently skipped — no tag, no release, no Docker build.  This PRs version bump was applied manually as a workaround.

## Solution

Move the skip-guard from a job-level `if:` expression to a **first-step shell guard** that only inspects the **subject line** (first line) of `head_commit.message`:

```yaml
steps:
  - name: Skip on version-bump commits (check subject only, not body)
    run: |
      SUBJECT="$(echo ${{ github.event.head_commit.message }} | head -n 1)"
      if echo "$SUBJECT" | grep -qE \[(skip|no) ci\]; then
        echo "Skipping — version-bump commit detected (subject contains [skip ci])"
        exit 78
      fi
```

The automatic bump commits still have `[skip ci]` in their subject
(`chore(release): bump version to vX.Y.Z [skip ci]`) and will be correctly skipped.

Uses `exit 78` for a **neutral** skip (job shows as cancelled/cancelled, workflow stays green).

## Verification

- `[skip ci]` in subject → skipped ✓ (automatic bump commits)
- `[skip ci]` in body only → runs ✓ (PR merge commits with template examples)
- No `[skip ci]` anywhere → runs ✓ (normal pushes)