### PR TITLE
feat(client): unified filter bar with inline search, day selector, and reset button

### DIFF
--- a/client/src/components/DaySelector.test.tsx
+++ b/client/src/components/DaySelector.test.tsx
@@ -101,4 +101,16 @@ describe('DaySelector — bouton Maintenant', () => {
 
     expect(screen.getByRole('button', { name: /maintenant/i })).not.toHaveAttribute('data-now-active', 'true');
   });
+
+  it('does not render the "Tous les jours" button', () => {
+    render(
+      <DaySelector
+        weekStart={WEEK_START}
+        selectedDate={null}
+        onSelectDate={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByTestId('day-selector-all')).not.toBeInTheDocument();
+  });
 });

--- a/client/src/components/DaySelector.tsx
+++ b/client/src/components/DaySelector.tsx
@@ -69,18 +69,6 @@ function DaySelector({ weekStart, selectedDate, onSelectDate, onNow, isNowActive
           <span className="text-[11px] font-bold mt-0.5">Maintenant</span>
         </button>
 
-        <button
-          onClick={() => onSelectDate(null)}
-          className={`px-3 py-2 text-sm rounded-lg transition font-semibold cursor-pointer active:scale-95 flex flex-col items-center justify-center min-w-[68px] ${
-            selectedDate === null && !isNowActive
-              ? 'bg-primary text-black'
-              : 'bg-gray-50 text-gray-700 hover:bg-gray-100'
-          }`}
-          data-testid="day-selector-all"
-        >
-          <span className="text-[11px] font-bold leading-tight text-center">Tous les jours</span>
-        </button>
-
         {days.map((day) => (
           <button
             key={day.date}

--- a/client/src/components/FilterBar.test.tsx
+++ b/client/src/components/FilterBar.test.tsx
@@ -1,0 +1,122 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import FilterBar from './FilterBar';
+
+// Mock MovieSearchBar
+vi.mock('./MovieSearchBar', () => ({
+  default: ({ onFilter }: any) => (
+    <input
+      data-testid="search-input"
+      placeholder="Rechercher un film..."
+      onChange={(e) => onFilter?.([{ id: 1, title: e.target.value, genres: [], actors: [], source_url: '' }])}
+    />
+  ),
+}));
+
+// Mock DaySelector
+vi.mock('./DaySelector', () => ({
+  default: ({ onSelectDate, onNow, isNowActive, selectedDate }: any) => (
+    <div data-testid="day-selector">
+      <button data-testid="day-now" onClick={() => onNow?.('2026-03-30', '14:00')}>
+        Maintenant {isNowActive ? '(actif)' : ''}
+      </button>
+      <button data-testid="day-mon" onClick={() => onSelectDate('2026-03-30')}>
+        Lun {selectedDate === '2026-03-30' ? '(select)' : ''}
+      </button>
+    </div>
+  ),
+}));
+
+describe('FilterBar', () => {
+  const WEEK_START = '2026-03-25';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderFilterBar = (props: {
+    weekStart?: string;
+    selectedDate?: string;
+    onSelectDate?: any;
+    onNow?: any;
+    isNowActive?: boolean;
+    onFilter?: any;
+    onReset?: any;
+  } = {}) =>
+    render(
+      <MemoryRouter>
+        <FilterBar
+          weekStart={WEEK_START}
+          selectedDate=""
+          onSelectDate={vi.fn()}
+          onNow={vi.fn()}
+          isNowActive={false}
+          onFilter={vi.fn()}
+          onReset={vi.fn()}
+          {...props}
+        />
+      </MemoryRouter>
+    );
+
+  it('renders the search bar, day selector, and reset button', () => {
+    renderFilterBar();
+
+    expect(screen.getByTestId('search-input')).toBeInTheDocument();
+    expect(screen.getByTestId('day-selector')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-reset')).toBeInTheDocument();
+  });
+
+  it('calls onReset when reset button is clicked', () => {
+    const onReset = vi.fn();
+    renderFilterBar({ onReset });
+
+    fireEvent.click(screen.getByTestId('filter-reset'));
+    expect(onReset).toHaveBeenCalledOnce();
+  });
+
+  it('calls onFilter when search input changes', async () => {
+    const onFilter = vi.fn();
+    renderFilterBar({ onFilter });
+
+    const input = screen.getByTestId('search-input');
+    fireEvent.change(input, { target: { value: 'Inception' } });
+
+    await waitFor(() => {
+      expect(onFilter).toHaveBeenCalled();
+    });
+  });
+
+  it('passes onSelectDate to DaySelector', () => {
+    const onSelectDate = vi.fn();
+    renderFilterBar({ onSelectDate });
+
+    fireEvent.click(screen.getByTestId('day-mon'));
+    expect(onSelectDate).toHaveBeenCalledWith('2026-03-30');
+  });
+
+  it('passes onNow to DaySelector', () => {
+    const onNow = vi.fn();
+    renderFilterBar({ onNow });
+
+    fireEvent.click(screen.getByTestId('day-now'));
+    expect(onNow).toHaveBeenCalledWith('2026-03-30', '14:00');
+  });
+
+  it('passes isNowActive to DaySelector', () => {
+    renderFilterBar({ isNowActive: true });
+    expect(screen.getByText(/Maintenant.*actif/)).toBeInTheDocument();
+  });
+
+  it('reset button is always visible', () => {
+    renderFilterBar();
+    expect(screen.getByTestId('filter-reset')).toBeInTheDocument();
+  });
+
+  it('renders with flex layout (search flex-grow)', () => {
+    renderFilterBar();
+    const container = screen.getByTestId('filter-bar');
+    expect(container.className).toContain('flex');
+  });
+});

--- a/client/src/components/FilterBar.test.tsx
+++ b/client/src/components/FilterBar.test.tsx
@@ -6,9 +6,10 @@ import FilterBar from './FilterBar';
 
 // Mock MovieSearchBar
 vi.mock('./MovieSearchBar', () => ({
-  default: ({ onFilter }: any) => (
+  default: ({ onFilter, resetKey }: any) => (
     <input
       data-testid="search-input"
+      data-reset-key={resetKey ?? 0}
       placeholder="Rechercher un film..."
       onChange={(e) => onFilter?.([{ id: 1, title: e.target.value, genres: [], actors: [], source_url: '' }])}
     />
@@ -118,5 +119,18 @@ describe('FilterBar', () => {
     renderFilterBar();
     const container = screen.getByTestId('filter-bar');
     expect(container.className).toContain('flex');
+  });
+
+  it('uses responsive layout (column on mobile, row on desktop)', () => {
+    renderFilterBar();
+    const container = screen.getByTestId('filter-bar');
+    expect(container.className).toContain('flex-col');
+    expect(container.className).toContain('sm:flex-row');
+  });
+
+  it('forwards resetKey to MovieSearchBar', () => {
+    renderFilterBar({ resetKey: 3 } as any);
+    const input = screen.getByTestId('search-input');
+    expect(input.getAttribute('data-reset-key')).toBe('3');
   });
 });

--- a/client/src/components/FilterBar.tsx
+++ b/client/src/components/FilterBar.tsx
@@ -9,7 +9,7 @@ interface FilterBarProps {
   onSelectDate: (date: string | null) => void;
   onNow: (date: string, time: string) => void;
   isNowActive: boolean;
-  onFilter: (movies: Movie[]) => void;
+  onFilter: (movies: Movie[] | null) => void;
   onReset: () => void;
 }
 

--- a/client/src/components/FilterBar.tsx
+++ b/client/src/components/FilterBar.tsx
@@ -11,6 +11,7 @@ interface FilterBarProps {
   isNowActive: boolean;
   onFilter: (movies: Movie[] | null) => void;
   onReset: () => void;
+  resetKey?: number;
 }
 
 function FilterBar({
@@ -21,21 +22,23 @@ function FilterBar({
   isNowActive,
   onFilter,
   onReset,
+  resetKey,
 }: FilterBarProps) {
   return (
     <div
-      className="flex items-center gap-3 bg-white rounded-xl border border-gray-100 p-3 shadow-sm"
+      className="flex flex-col sm:flex-row sm:items-center gap-3 bg-white rounded-xl border border-gray-100 p-3 shadow-sm"
       data-testid="filter-bar"
     >
-      <div className="flex-1 min-w-0">
+      <div className="w-full sm:flex-1 sm:min-w-0">
         <MovieSearchBar
           placeholder="Rechercher un film..."
           className="w-full"
           onFilter={onFilter}
+          resetKey={resetKey}
         />
       </div>
 
-      <div className="flex-shrink-0">
+      <div className="flex items-center gap-3 sm:flex-shrink-0">
         <DaySelector
           weekStart={weekStart}
           selectedDate={selectedDate || null}
@@ -43,16 +46,16 @@ function FilterBar({
           onNow={onNow}
           isNowActive={isNowActive}
         />
-      </div>
 
-      <button
-        onClick={onReset}
-        className="flex-shrink-0 px-3 py-2 text-sm rounded-lg bg-gray-50 text-gray-700 hover:bg-gray-100 transition font-semibold cursor-pointer active:scale-95"
-        data-testid="filter-reset"
-        aria-label="Réinitialiser les filtres"
-      >
-        <span className="text-base leading-none">🔄</span>
-      </button>
+        <button
+          onClick={onReset}
+          className="flex-shrink-0 px-3 py-2 text-sm rounded-lg bg-gray-50 text-gray-700 hover:bg-gray-100 transition font-semibold cursor-pointer active:scale-95"
+          data-testid="filter-reset"
+          aria-label="Réinitialiser les filtres"
+        >
+          <span className="text-base leading-none">🔄</span>
+        </button>
+      </div>
     </div>
   );
 }

--- a/client/src/components/FilterBar.tsx
+++ b/client/src/components/FilterBar.tsx
@@ -6,7 +6,7 @@ import type { Movie } from '../types';
 interface FilterBarProps {
   weekStart: string;
   selectedDate: string;
-  onSelectDate: (date: string) => void;
+  onSelectDate: (date: string | null) => void;
   onNow: (date: string, time: string) => void;
   isNowActive: boolean;
   onFilter: (movies: Movie[]) => void;
@@ -39,7 +39,7 @@ function FilterBar({
         <DaySelector
           weekStart={weekStart}
           selectedDate={selectedDate || null}
-          onSelectDate={(date) => onSelectDate(date || '')}
+          onSelectDate={onSelectDate}
           onNow={onNow}
           isNowActive={isNowActive}
         />

--- a/client/src/components/FilterBar.tsx
+++ b/client/src/components/FilterBar.tsx
@@ -1,0 +1,60 @@
+import { memo } from 'react';
+import MovieSearchBar from './MovieSearchBar';
+import DaySelector from './DaySelector';
+import type { Movie } from '../types';
+
+interface FilterBarProps {
+  weekStart: string;
+  selectedDate: string;
+  onSelectDate: (date: string) => void;
+  onNow: (date: string, time: string) => void;
+  isNowActive: boolean;
+  onFilter: (movies: Movie[]) => void;
+  onReset: () => void;
+}
+
+function FilterBar({
+  weekStart,
+  selectedDate,
+  onSelectDate,
+  onNow,
+  isNowActive,
+  onFilter,
+  onReset,
+}: FilterBarProps) {
+  return (
+    <div
+      className="flex items-center gap-3 bg-white rounded-xl border border-gray-100 p-3 shadow-sm"
+      data-testid="filter-bar"
+    >
+      <div className="flex-1 min-w-0">
+        <MovieSearchBar
+          placeholder="Rechercher un film..."
+          className="w-full"
+          onFilter={onFilter}
+        />
+      </div>
+
+      <div className="flex-shrink-0">
+        <DaySelector
+          weekStart={weekStart}
+          selectedDate={selectedDate || null}
+          onSelectDate={(date) => onSelectDate(date || '')}
+          onNow={onNow}
+          isNowActive={isNowActive}
+        />
+      </div>
+
+      <button
+        onClick={onReset}
+        className="flex-shrink-0 px-3 py-2 text-sm rounded-lg bg-gray-50 text-gray-700 hover:bg-gray-100 transition font-semibold cursor-pointer active:scale-95"
+        data-testid="filter-reset"
+        aria-label="Réinitialiser les filtres"
+      >
+        <span className="text-base leading-none">🔄</span>
+      </button>
+    </div>
+  );
+}
+
+export default memo(FilterBar);

--- a/client/src/components/MovieSearchBar.test.tsx
+++ b/client/src/components/MovieSearchBar.test.tsx
@@ -36,7 +36,7 @@ describe('MovieSearchBar — inline filter mode', () => {
     vi.clearAllMocks();
   });
 
-  const renderSearchBar = (props: { onFilter?: (movies: Movie[]) => void } = {}) =>
+  const renderSearchBar = (props: { onFilter?: (movies: Movie[] | null) => void } = {}) =>
     render(
       <MemoryRouter>
         <MovieSearchBar {...props} />
@@ -58,7 +58,7 @@ describe('MovieSearchBar — inline filter mode', () => {
     });
   });
 
-  it('calls onFilter with empty array when query is cleared', async () => {
+  it('calls onFilter with null when query is cleared (inactive)', async () => {
     const onFilter = vi.fn();
     const mockResults = [makeMovie(1, 'Inception')];
     (searchMovies as any).mockResolvedValue(mockResults);
@@ -74,6 +74,20 @@ describe('MovieSearchBar — inline filter mode', () => {
 
     onFilter.mockClear();
     await userEvent.clear(input);
+
+    await waitFor(() => {
+      expect(onFilter).toHaveBeenCalledWith(null);
+    });
+  });
+
+  it('calls onFilter with empty array when search yields no matches (active empty)', async () => {
+    const onFilter = vi.fn();
+    (searchMovies as any).mockResolvedValue([]);
+
+    renderSearchBar({ onFilter });
+
+    const input = screen.getByTestId('search-input');
+    await userEvent.type(input, 'zzz');
 
     await waitFor(() => {
       expect(onFilter).toHaveBeenCalledWith([]);

--- a/client/src/components/MovieSearchBar.test.tsx
+++ b/client/src/components/MovieSearchBar.test.tsx
@@ -1,0 +1,119 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import MovieSearchBar from './MovieSearchBar';
+import type { Movie } from '../types';
+
+// Mock the API client
+vi.mock('../api/client', () => ({
+  searchMovies: vi.fn(),
+}));
+
+// Mock useDebounce to return immediately (no delay in tests)
+vi.mock('../hooks/useDebounce', () => ({
+  useDebounce: (value: any) => value,
+}));
+
+// Mock highlightText
+vi.mock('../utils/highlight', () => ({
+  highlightText: (text: string) => text,
+}));
+
+import { searchMovies } from '../api/client';
+
+const makeMovie = (id: number, title: string): Movie => ({
+  id,
+  title,
+  genres: ['Action'],
+  actors: [],
+  source_url: '',
+});
+
+describe('MovieSearchBar — inline filter mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderSearchBar = (props: { onFilter?: (movies: Movie[]) => void } = {}) =>
+    render(
+      <MemoryRouter>
+        <MovieSearchBar {...props} />
+      </MemoryRouter>
+    );
+
+  it('calls onFilter with search results when user types', async () => {
+    const onFilter = vi.fn();
+    const mockResults = [makeMovie(1, 'Inception'), makeMovie(2, 'Interstellar')];
+    (searchMovies as any).mockResolvedValue(mockResults);
+
+    renderSearchBar({ onFilter });
+
+    const input = screen.getByTestId('search-input');
+    await userEvent.type(input, 'In');
+
+    await waitFor(() => {
+      expect(onFilter).toHaveBeenCalledWith(mockResults);
+    });
+  });
+
+  it('calls onFilter with empty array when query is cleared', async () => {
+    const onFilter = vi.fn();
+    const mockResults = [makeMovie(1, 'Inception')];
+    (searchMovies as any).mockResolvedValue(mockResults);
+
+    renderSearchBar({ onFilter });
+
+    const input = screen.getByTestId('search-input');
+    await userEvent.type(input, 'In');
+
+    await waitFor(() => {
+      expect(onFilter).toHaveBeenCalled();
+    });
+
+    onFilter.mockClear();
+    await userEvent.clear(input);
+
+    await waitFor(() => {
+      expect(onFilter).toHaveBeenCalledWith([]);
+    });
+  });
+
+  it('still renders navigation links in dropdown when onFilter is provided', async () => {
+    const onFilter = vi.fn();
+    const mockResults = [makeMovie(1, 'Inception')];
+    (searchMovies as any).mockResolvedValue(mockResults);
+
+    renderSearchBar({ onFilter });
+
+    const input = screen.getByTestId('search-input');
+    await userEvent.type(input, 'In');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('search-results')).toBeInTheDocument();
+    });
+
+    // The dropdown should contain a link to the movie page
+    const link = screen.getByRole('link', { name: /Inception/i });
+    expect(link).toHaveAttribute('href', '/movie/1');
+  });
+
+  it('does not call onFilter when onFilter is not provided (backward compat)', async () => {
+    const mockResults = [makeMovie(1, 'Inception')];
+    (searchMovies as any).mockResolvedValue(mockResults);
+
+    renderSearchBar(); // no onFilter
+
+    const input = screen.getByTestId('search-input');
+    await userEvent.type(input, 'In');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('search-results')).toBeInTheDocument();
+    });
+
+    // onFilter shouldn't be called because it wasn't provided
+    // (no error thrown means the code handles the missing prop gracefully)
+    expect(screen.getByRole('link', { name: /Inception/i })).toBeInTheDocument();
+  });
+});

--- a/client/src/components/MovieSearchBar.test.tsx
+++ b/client/src/components/MovieSearchBar.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useState } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
@@ -129,5 +130,58 @@ describe('MovieSearchBar — inline filter mode', () => {
     // onFilter shouldn't be called because it wasn't provided
     // (no error thrown means the code handles the missing prop gracefully)
     expect(screen.getByRole('link', { name: /Inception/i })).toBeInTheDocument();
+  });
+
+  it('renders a "Voir la fiche" affordance in each dropdown result', async () => {
+    const onFilter = vi.fn();
+    const mockResults = [makeMovie(1, 'Inception'), makeMovie(2, 'Interstellar')];
+    (searchMovies as any).mockResolvedValue(mockResults);
+
+    renderSearchBar({ onFilter });
+
+    await userEvent.type(screen.getByTestId('search-input'), 'In');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('search-results')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('search-result-fiche-1')).toHaveTextContent('Voir la fiche');
+    expect(screen.getByTestId('search-result-fiche-2')).toHaveTextContent('Voir la fiche');
+  });
+
+  it('clears local input state when resetKey prop changes', async () => {
+    const onFilter = vi.fn();
+    (searchMovies as any).mockResolvedValue([makeMovie(1, 'Inception')]);
+
+    function Harness() {
+      const [resetKey, setResetKey] = useState(0);
+      return (
+        <>
+          <MovieSearchBar onFilter={onFilter} resetKey={resetKey} />
+          <button data-testid="bump-reset" onClick={() => setResetKey(k => k + 1)}>
+            bump
+          </button>
+        </>
+      );
+    }
+
+    render(
+      <MemoryRouter>
+        <Harness />
+      </MemoryRouter>
+    );
+
+    const input = screen.getByTestId('search-input') as HTMLInputElement;
+    await userEvent.type(input, 'In');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('search-results')).toBeInTheDocument();
+    });
+    expect(input.value).toBe('In');
+
+    await userEvent.click(screen.getByTestId('bump-reset'));
+
+    expect(input.value).toBe('');
+    expect(screen.queryByTestId('search-results')).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/MovieSearchBar.tsx
+++ b/client/src/components/MovieSearchBar.tsx
@@ -8,11 +8,13 @@ import type { Movie } from '../types';
 interface MovieSearchBarProps {
   className?: string;
   placeholder?: string;
+  onFilter?: (movies: Movie[]) => void;
 }
 
 export default function MovieSearchBar({ 
   className = '', 
-  placeholder = 'Rechercher un film...' 
+  placeholder = 'Rechercher un film...',
+  onFilter,
 }: MovieSearchBarProps) {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<Movie[]>([]);
@@ -28,6 +30,7 @@ export default function MovieSearchBar({
       if (!debouncedQuery || debouncedQuery.trim().length < 2) {
         setResults([]);
         setIsOpen(false);
+        onFilter?.([]);
         return;
       }
 
@@ -37,9 +40,11 @@ export default function MovieSearchBar({
         setResults(movies);
         setIsOpen(true);
         setSelectedIndex(-1);
+        onFilter?.(movies);
       } catch (error) {
         console.error('Search error:', error);
         setResults([]);
+        onFilter?.([]);
       } finally {
         setIsLoading(false);
       }

--- a/client/src/components/MovieSearchBar.tsx
+++ b/client/src/components/MovieSearchBar.tsx
@@ -51,7 +51,7 @@ export default function MovieSearchBar({
     }
 
     performSearch();
-  }, [debouncedQuery]);
+  }, [debouncedQuery, onFilter]);
 
   // Close dropdown when clicking outside
   useEffect(() => {

--- a/client/src/components/MovieSearchBar.tsx
+++ b/client/src/components/MovieSearchBar.tsx
@@ -8,7 +8,7 @@ import type { Movie } from '../types';
 interface MovieSearchBarProps {
   className?: string;
   placeholder?: string;
-  onFilter?: (movies: Movie[]) => void;
+  onFilter?: (movies: Movie[] | null) => void;
 }
 
 export default function MovieSearchBar({ 
@@ -30,7 +30,7 @@ export default function MovieSearchBar({
       if (!debouncedQuery || debouncedQuery.trim().length < 2) {
         setResults([]);
         setIsOpen(false);
-        onFilter?.([]);
+        onFilter?.(null);
         return;
       }
 

--- a/client/src/components/MovieSearchBar.tsx
+++ b/client/src/components/MovieSearchBar.tsx
@@ -9,20 +9,34 @@ interface MovieSearchBarProps {
   className?: string;
   placeholder?: string;
   onFilter?: (movies: Movie[] | null) => void;
+  resetKey?: number;
 }
 
 export default function MovieSearchBar({ 
   className = '', 
   placeholder = 'Rechercher un film...',
   onFilter,
+  resetKey = 0,
 }: MovieSearchBarProps) {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<Movie[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(-1);
+  const [lastResetKey, setLastResetKey] = useState(resetKey);
   const debouncedQuery = useDebounce(query, 300);
   const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // Reset internal state when parent bumps resetKey (e.g. FilterBar reset click).
+  // Canonical "adjust state during render when a prop changes" pattern — see
+  // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  if (resetKey !== lastResetKey) {
+    setLastResetKey(resetKey);
+    setQuery('');
+    setResults([]);
+    setIsOpen(false);
+    setSelectedIndex(-1);
+  }
 
   // Perform search when debounced query changes
   useEffect(() => {
@@ -222,6 +236,9 @@ export default function MovieSearchBar({
                       </span>
                     </div>
                   )}
+                  <span className="inline-block mt-1.5 text-xs text-primary font-semibold" data-testid={`search-result-fiche-${movie.id}`}>
+                    Voir la fiche →
+                  </span>
                 </div>
               </Link>
             ))

--- a/client/src/components/StickyElements.test.tsx
+++ b/client/src/components/StickyElements.test.tsx
@@ -64,17 +64,15 @@ const renderWithProviders = (ui: React.ReactElement) => {
 };
 
 describe('Sticky Elements Stickiness', () => {
-  it('HomePage search/date container should be sticky with offset', async () => {
+  it('HomePage filter bar should be rendered', async () => {
     (clientApi.getTheaters as any).mockResolvedValue([]);
     (clientApi.getWeeklyMovies as any).mockResolvedValue({ movies: [], weekStart: '2024-01-01' });
 
     renderWithProviders(<HomePage />);
 
-    const stickySection = await screen.findByTestId('sticky-search-date-container');
-    expect(stickySection).toBeInTheDocument();
-    expect(stickySection).toHaveClass('sticky');
-    expect(stickySection).toHaveClass('z-40');
-    expect(stickySection).toHaveStyle({ top: 'var(--layout-header-offset, 64px)' });
+    const filterBar = await screen.findByTestId('filter-bar');
+    expect(filterBar).toBeInTheDocument();
+    expect(filterBar).toHaveClass('flex');
   });
 
   it('TheaterPage date selector should be sticky with offset', async () => {

--- a/client/src/components/StickyElements.test.tsx
+++ b/client/src/components/StickyElements.test.tsx
@@ -64,15 +64,17 @@ const renderWithProviders = (ui: React.ReactElement) => {
 };
 
 describe('Sticky Elements Stickiness', () => {
-  it('HomePage filter bar should be rendered', async () => {
+  it('HomePage filter bar container should be sticky with offset', async () => {
     (clientApi.getTheaters as any).mockResolvedValue([]);
     (clientApi.getWeeklyMovies as any).mockResolvedValue({ movies: [], weekStart: '2024-01-01' });
 
     renderWithProviders(<HomePage />);
 
-    const filterBar = await screen.findByTestId('filter-bar');
-    expect(filterBar).toBeInTheDocument();
-    expect(filterBar).toHaveClass('flex');
+    const stickySection = await screen.findByTestId('sticky-search-date-container');
+    expect(stickySection).toBeInTheDocument();
+    expect(stickySection).toHaveClass('sticky');
+    expect(stickySection).toHaveClass('z-40');
+    expect(stickySection).toHaveStyle({ top: 'var(--layout-header-offset, 64px)' });
   });
 
   it('TheaterPage date selector should be sticky with offset', async () => {

--- a/client/src/hooks/useDateTimeFilter.test.ts
+++ b/client/src/hooks/useDateTimeFilter.test.ts
@@ -29,4 +29,15 @@ describe('useDateTimeFilter', () => {
     expect(result.current.selectedDate).toBe('2026-03-15');
     expect(result.current.afterTime).toBe('20:30');
   });
+
+  it('resetAll clears selectedDate and afterTime', () => {
+    const { result } = renderHook(() => useDateTimeFilter());
+    act(() => result.current.selectNow('2026-03-15', '14:00'));
+    expect(result.current.selectedDate).toBe('2026-03-15');
+    expect(result.current.afterTime).toBe('14:00');
+
+    act(() => result.current.resetAll());
+    expect(result.current.selectedDate).toBe('');
+    expect(result.current.afterTime).toBeNull();
+  });
 });

--- a/client/src/hooks/useDateTimeFilter.ts
+++ b/client/src/hooks/useDateTimeFilter.ts
@@ -7,6 +7,7 @@ export interface DateTimeFilter {
   setAfterTime: (time: string | null) => void;
   selectDate: (date: string) => void;
   selectNow: (date: string, time: string) => void;
+  resetAll: () => void;
 }
 
 export function useDateTimeFilter(initialDate = ''): DateTimeFilter {
@@ -23,5 +24,10 @@ export function useDateTimeFilter(initialDate = ''): DateTimeFilter {
     setAfterTime(time);
   }, []);
 
-  return { selectedDate, setSelectedDate, afterTime, setAfterTime, selectDate, selectNow };
+  const resetAll = useCallback(() => {
+    setSelectedDate('');
+    setAfterTime(null);
+  }, []);
+
+  return { selectedDate, setSelectedDate, afterTime, setAfterTime, selectDate, selectNow, resetAll };
 }

--- a/client/src/pages/HomePage.test.tsx
+++ b/client/src/pages/HomePage.test.tsx
@@ -172,6 +172,25 @@ describe('HomePage — bouton Maintenant', () => {
     vi.useRealTimers();
   });
 
+  it('renders the FilterBar instead of the old sticky container', async () => {
+    renderHomePage();
+    await waitFor(() => expect(screen.queryByTestId('filter-bar')).toBeInTheDocument());
+    expect(screen.getByTestId('filter-bar')).toBeInTheDocument();
+    expect(screen.queryByTestId('sticky-search-date-container')).not.toBeInTheDocument();
+  });
+
+  it('renders the reset button in the FilterBar', async () => {
+    renderHomePage();
+    await waitFor(() => expect(screen.queryByTestId('filter-reset')).toBeInTheDocument());
+    expect(screen.getByTestId('filter-reset')).toBeInTheDocument();
+  });
+
+  it('does not render the old "Tous les jours" button', async () => {
+    renderHomePage();
+    await waitFor(() => expect(screen.queryByTestId('filter-bar')).toBeInTheDocument());
+    expect(screen.queryByTestId('day-selector-all')).not.toBeInTheDocument();
+  });
+
   it('renders the Maintenant button in the DaySelector', async () => {
     renderHomePage();
     await waitFor(() => expect(screen.queryByRole('button', { name: /maintenant/i })).toBeInTheDocument());

--- a/client/src/pages/HomePage.test.tsx
+++ b/client/src/pages/HomePage.test.tsx
@@ -39,6 +39,7 @@ vi.mock('../api/client', () => ({
   getMoviesByDate: vi.fn(),
   getTheaters: vi.fn(),
   addTheater: vi.fn(),
+  searchMovies: vi.fn(),
 }));
 
 describe('HomePage', () => {
@@ -228,5 +229,23 @@ describe('HomePage — bouton Maintenant', () => {
     await waitFor(() => {
       expect(screen.getByText('Film Futur')).toBeInTheDocument();
     });
+  });
+
+  it('reset button clears the search input text (end-to-end)', async () => {
+    (clientApi.searchMovies as any).mockResolvedValue([
+      { id: 101, title: 'Film Passé', genres: [], actors: [], source_url: '' },
+    ]);
+
+    renderHomePage();
+    await waitFor(() => expect(screen.getByTestId('search-input')).toBeInTheDocument());
+
+    const input = screen.getByTestId('search-input') as HTMLInputElement;
+    await fireEvent.change(input, { target: { value: 'Film' } });
+
+    await waitFor(() => expect(input.value).toBe('Film'));
+
+    fireEvent.click(screen.getByTestId('filter-reset'));
+
+    await waitFor(() => expect(input.value).toBe(''));
   });
 });

--- a/client/src/pages/HomePage.test.tsx
+++ b/client/src/pages/HomePage.test.tsx
@@ -172,11 +172,11 @@ describe('HomePage — bouton Maintenant', () => {
     vi.useRealTimers();
   });
 
-  it('renders the FilterBar instead of the old sticky container', async () => {
+  it('renders the FilterBar inside the sticky container', async () => {
     renderHomePage();
     await waitFor(() => expect(screen.queryByTestId('filter-bar')).toBeInTheDocument());
     expect(screen.getByTestId('filter-bar')).toBeInTheDocument();
-    expect(screen.queryByTestId('sticky-search-date-container')).not.toBeInTheDocument();
+    expect(screen.getByTestId('sticky-search-date-container')).toBeInTheDocument();
   });
 
   it('renders the reset button in the FilterBar', async () => {

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -15,6 +15,7 @@ export default function HomePage() {
   const { selectedDate, afterTime, selectDate, selectNow, resetAll } = useDateTimeFilter();
   const { isAuthenticated, hasPermission } = useContext(AuthContext);
   const [searchResults, setSearchResults] = useState<Movie[] | null>(null);
+  const [resetKey, setResetKey] = useState(0);
 
   const { data: theaters = [], isLoading: isLoadingTheaters } = useQuery({
     queryKey: ['theaters'],
@@ -61,6 +62,7 @@ export default function HomePage() {
   const handleReset = useCallback(() => {
     resetAll();
     setSearchResults(null);
+    setResetKey(k => k + 1);
   }, [resetAll]);
   const formatterDate = useMemo(() => new Intl.DateTimeFormat('fr-FR', {
     day: 'numeric',
@@ -141,6 +143,7 @@ export default function HomePage() {
             isNowActive={afterTime !== null}
             onFilter={handleFilter}
             onReset={handleReset}
+            resetKey={resetKey}
           />
         )}
       </div>

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -50,8 +50,8 @@ export default function HomePage() {
   const isLoading = isLoadingTheaters || isLoadingMovies;
   const error = moviesError instanceof Error ? moviesError.message : null;
 
-  const handleDateSelect = useCallback((date: string) => {
-    selectDate(date);
+  const handleDateSelect = useCallback((date: string | null) => {
+    selectDate(date || '');
   }, [selectDate]);
 
   const handleFilter = useCallback((movies: Movie[]) => {
@@ -107,7 +107,7 @@ export default function HomePage() {
 
   return (
     <div className="max-w-5xl mx-auto">
-      {/* Title and Date Info - Above sticky header */}
+      {/* Title and Date Info */}
       <div className="mb-4">
         <h1 className="text-4xl font-bold mb-3">
           {selectedDate ? 'Films du jour' : 'Au programme cette semaine'}

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -1,19 +1,20 @@
-import { useContext, useCallback, useMemo } from 'react';
+import { useContext, useCallback, useMemo, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getWeeklyMovies, getMoviesByDate, getTheaters, addTheater } from '../api/client.js';
 import MovieCard from '../components/MovieCard.js';
-import DaySelector from '../components/DaySelector.js';
-import MovieSearchBar from '../components/MovieSearchBar.js';
+import FilterBar from '../components/FilterBar.js';
 import ScrollToTop from '../components/ScrollToTop.js';
 import { AuthContext } from '../contexts/AuthContext.js';
 import TheatersQuickLinks from '../components/TheatersQuickLinks.js';
 import { LoadingSpinner, ErrorMessage } from '../components/ui/PageStates.js';
 import { useDateTimeFilter } from '../hooks/useDateTimeFilter.js';
+import type { Movie } from '../types';
 
 export default function HomePage() {
   const queryClient = useQueryClient();
-  const { selectedDate, afterTime, selectDate, selectNow } = useDateTimeFilter();
+  const { selectedDate, afterTime, selectDate, selectNow, resetAll } = useDateTimeFilter();
   const { isAuthenticated, hasPermission } = useContext(AuthContext);
+  const [searchResults, setSearchResults] = useState<Movie[]>([]);
 
   const { data: theaters = [], isLoading: isLoadingTheaters } = useQuery({
     queryKey: ['theaters'],
@@ -27,21 +28,40 @@ export default function HomePage() {
 
   const allMovies = useMemo(() => moviesData?.movies || [], [moviesData]);
   // When "Maintenant" is active, hide movies whose showtimes are all in the past
+  // When search is active, filter by search results
   const movies = useMemo(() => {
-    return afterTime
-      ? allMovies.filter(movie =>
-          movie.theaters.some(c => c.showtimes.some(s => s.time >= afterTime))
-        )
-      : allMovies;
-  }, [allMovies, afterTime]);
+    let filtered = allMovies;
+
+    if (afterTime) {
+      filtered = filtered.filter(movie =>
+        movie.theaters.some(c => c.showtimes.some(s => s.time >= afterTime))
+      );
+    }
+
+    if (searchResults.length > 0) {
+      const searchIds = new Set(searchResults.map(m => m.id));
+      filtered = filtered.filter(movie => searchIds.has(movie.id));
+    }
+
+    return filtered;
+  }, [allMovies, afterTime, searchResults]);
   const weekStart = moviesData?.weekStart || '';
 
   const isLoading = isLoadingTheaters || isLoadingMovies;
   const error = moviesError instanceof Error ? moviesError.message : null;
 
-  const handleDateSelect = useCallback((date: string | null) => {
-    selectDate(date || '');
+  const handleDateSelect = useCallback((date: string) => {
+    selectDate(date);
   }, [selectDate]);
+
+  const handleFilter = useCallback((movies: Movie[]) => {
+    setSearchResults(movies);
+  }, []);
+
+  const handleReset = useCallback(() => {
+    resetAll();
+    setSearchResults([]);
+  }, [resetAll]);
   const formatterDate = useMemo(() => new Intl.DateTimeFormat('fr-FR', {
     day: 'numeric',
     month: 'long',
@@ -106,30 +126,19 @@ export default function HomePage() {
         )}
       </div>
 
-      {/* Sticky Header Section - Compact */}
-      <div
-        className="sticky z-40 bg-gray-50/95 backdrop-blur-sm pt-3 pb-3 mb-4 shadow-sm -mx-4 px-4"
-        style={{ top: 'var(--layout-header-offset, 64px)' }}
-        data-testid="sticky-search-date-container"
-      >
-        {/* Search + Day Selector — single row */}
-        <div className="flex items-center gap-3">
-          <MovieSearchBar
-            placeholder="Rechercher un film..."
-            className="w-40 sm:w-52 flex-shrink-0"
+      {/* Unified Filter Bar */}
+      <div className="mb-4">
+        {weekStart && (
+          <FilterBar
+            weekStart={weekStart}
+            selectedDate={selectedDate}
+            onSelectDate={handleDateSelect}
+            onNow={selectNow}
+            isNowActive={afterTime !== null}
+            onFilter={handleFilter}
+            onReset={handleReset}
           />
-          {weekStart && (
-            <div className="flex-1 min-w-0">
-              <DaySelector
-                weekStart={weekStart}
-                selectedDate={selectedDate}
-                onSelectDate={handleDateSelect}
-                onNow={selectNow}
-                isNowActive={afterTime !== null}
-              />
-            </div>
-          )}
-        </div>
+        )}
       </div>
 
       {/* Quick Theater Links - Below sticky header */}

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -14,7 +14,7 @@ export default function HomePage() {
   const queryClient = useQueryClient();
   const { selectedDate, afterTime, selectDate, selectNow, resetAll } = useDateTimeFilter();
   const { isAuthenticated, hasPermission } = useContext(AuthContext);
-  const [searchResults, setSearchResults] = useState<Movie[]>([]);
+  const [searchResults, setSearchResults] = useState<Movie[] | null>(null);
 
   const { data: theaters = [], isLoading: isLoadingTheaters } = useQuery({
     queryKey: ['theaters'],
@@ -38,7 +38,7 @@ export default function HomePage() {
       );
     }
 
-    if (searchResults.length > 0) {
+    if (searchResults !== null) {
       const searchIds = new Set(searchResults.map(m => m.id));
       filtered = filtered.filter(movie => searchIds.has(movie.id));
     }
@@ -54,13 +54,13 @@ export default function HomePage() {
     selectDate(date || '');
   }, [selectDate]);
 
-  const handleFilter = useCallback((movies: Movie[]) => {
+  const handleFilter = useCallback((movies: Movie[] | null) => {
     setSearchResults(movies);
   }, []);
 
   const handleReset = useCallback(() => {
     resetAll();
-    setSearchResults([]);
+    setSearchResults(null);
   }, [resetAll]);
   const formatterDate = useMemo(() => new Intl.DateTimeFormat('fr-FR', {
     day: 'numeric',
@@ -126,8 +126,12 @@ export default function HomePage() {
         )}
       </div>
 
-      {/* Unified Filter Bar */}
-      <div className="mb-4">
+      {/* Sticky Unified Filter Bar — stays visible while scrolling */}
+      <div
+        className="sticky z-40 bg-gray-50/95 backdrop-blur-sm pt-3 pb-3 mb-4 shadow-sm -mx-4 px-4"
+        style={{ top: 'var(--layout-header-offset, 64px)' }}
+        data-testid="sticky-search-date-container"
+      >
         {weekStart && (
           <FilterBar
             weekStart={weekStart}


### PR DESCRIPTION
Closes #1247

## Summary
- Add `resetAll()` to `useDateTimeFilter` hook
- Remove "Tous les jours" button from `DaySelector` (reset handled by `FilterBar`)
- Add `onFilter` prop to `MovieSearchBar` for inline filtering
- New `FilterBar` component: flex layout with search (flex-grow), DaySelector, and always-visible reset button
- `HomePage` uses `FilterBar` with combined filtering (afterTime + search)

## Verification
- Client: 601 tests / 60 files
- Server: 921 tests / 58 files
- Scraper: 253 tests / 21 files
- TypeScript: all 3 workspaces clean
- Pre-push hook passed