### PR TITLE
fix(server,scraper): use UTC in getCurrentWeekStart to avoid timezone edge case

### DIFF
--- a/scraper/src/utils/date.ts
+++ b/scraper/src/utils/date.ts
@@ -12,15 +12,18 @@
 
 function getCurrentWeekStart(): string {
   const today = new Date();
-  const dayOfWeek = today.getDay();
+  const dayOfWeek = today.getUTCDay();
 
   let offset = dayOfWeek - 3;
   if (offset < 0) {
     offset += 7;
   }
 
-  const wednesday = new Date(today);
-  wednesday.setDate(today.getDate() - offset);
+  const wednesday = new Date(Date.UTC(
+    today.getUTCFullYear(),
+    today.getUTCMonth(),
+    today.getUTCDate() - offset
+  ));
   return wednesday.toISOString().split('T')[0];
 }
 

--- a/server/src/utils/date.ts
+++ b/server/src/utils/date.ts
@@ -14,7 +14,10 @@ import { logger } from '../utils/logger.js';
 
 export function getCurrentWeekStart(): string {
   const today = new Date();
-  const dayOfWeek = today.getDay(); // 0 = Sunday, 3 = Wednesday
+  // Use UTC to avoid local-timezone edge cases (e.g., midnight CEST
+  // where the local date is ahead of UTC, causing toISOString() to
+  // return the previous day after setDate adjustments).
+  const dayOfWeek = today.getUTCDay(); // 0 = Sunday, 3 = Wednesday
   
   // Calculate offset to previous or current Wednesday
   let offset = dayOfWeek - 3;
@@ -22,8 +25,11 @@ export function getCurrentWeekStart(): string {
     offset += 7;
   }
   
-  const wednesday = new Date(today);
-  wednesday.setDate(today.getDate() - offset);
+  const wednesday = new Date(Date.UTC(
+    today.getUTCFullYear(),
+    today.getUTCMonth(),
+    today.getUTCDate() - offset
+  ));
   return wednesday.toISOString().split('T')[0];
 }
 


### PR DESCRIPTION
Fixes a timezone bug where `getCurrentWeekStart()` returns the wrong Wednesday between midnight and 2 AM CEST.

**Root cause:** The function used `new Date().getDay()` (local time) for calculation but `toISOString()` (UTC) for output. When local time is ahead of UTC (CEST = UTC+2), the `setDate()` adjustment on a local-time Date object lands the UTC timestamp on the previous day.

**Fix:** Use UTC methods consistently: `getUTCDay()`, `getUTCDate()`, `Date.UTC()`.

**Impact:** The API returned `weekStart` one day too early, causing 0 movies to be returned for the current week even when data was present in the database.